### PR TITLE
Add numeric traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Jacobians and Hessians, vector-field operators, and Taylor approximation in a `n
 
 - Pure, safe Rust.
 - `no_std`, with no heap allocation and no panics — it runs on bare-metal and embedded targets.
+- Generic over the scalar type — use `f32` or `f64`, defaulting to `f64`.
 - Transcendental functions come from [`libm`](https://crates.io/crates/libm), so the math works
   without `std`.
 - Every fallible call returns a typed [`CalcError`](./src/utils/error_codes.rs); convenience
@@ -181,14 +182,15 @@ let y = model.predict(&[1.1, 2.1, 3.1]);
 ## Error handling
 
 Where a sensible default exists, a "safe" wrapper (such as `get_single` or `get_double`) returns the
-answer directly. Otherwise the call returns `Result<f64, CalcError>`, so you decide how to handle bad
-input. All variants are listed in [error_codes.rs](./src/utils/error_codes.rs).
+answer directly. Otherwise the call returns `Result<T, CalcError>` for the working scalar `T` (`f64`
+by default), so you decide how to handle bad input. All variants are listed in
+[error_codes.rs](./src/utils/error_codes.rs).
 
 ## Heap allocation
 
 By default everything uses fixed-size stack arrays. Enable the `alloc` feature for `Vec`-based methods
 that handle inputs too large for the stack. This currently covers the Jacobian's `get_on_heap`, which
-returns a `Vec<Vec<f64>>`.
+returns a `Vec<Vec<T>>` of the scalar (`Vec<Vec<f64>>` by default).
 
 ## Examples
 

--- a/src/approximation/linear_approximation.rs
+++ b/src/approximation/linear_approximation.rs
@@ -1,33 +1,34 @@
+use crate::numeric::Numeric;
 use crate::numerical_derivative::derivator::DerivatorMultiVariable;
 use crate::utils::error_codes::CalcError;
 
 /// A first-order (linear) Taylor approximation of a function about a base point:
 /// `f(x) ≈ value + Σ gradient[i] * (x[i] - point[i])`.
 #[derive(Debug, Clone, Copy)]
-pub struct LinearApproximation<const NUM_VARS: usize> {
-    point: [f64; NUM_VARS],
-    value: f64,
-    gradient: [f64; NUM_VARS],
+pub struct LinearApproximation<const NUM_VARS: usize, T = f64> {
+    point: [T; NUM_VARS],
+    value: T,
+    gradient: [T; NUM_VARS],
 }
 
 /// Goodness-of-fit metrics for a [`LinearApproximation`] over a set of sample points.
 #[derive(Debug, Clone, Copy)]
-pub struct LinearApproximationPredictionMetrics {
+pub struct LinearApproximationPredictionMetrics<T = f64> {
     /// Mean absolute error.
-    pub mean_absolute_error: f64,
+    pub mean_absolute_error: T,
     /// Mean squared error.
-    pub mean_squared_error: f64,
+    pub mean_squared_error: T,
     /// Root mean squared error.
-    pub root_mean_squared_error: f64,
+    pub root_mean_squared_error: T,
     /// Coefficient of determination; `NaN` when the truth is constant over the points.
-    pub r_squared: f64,
+    pub r_squared: T,
     /// R² adjusted for the number of predictors; `NaN` when there are too few points.
-    pub adjusted_r_squared: f64,
+    pub adjusted_r_squared: T,
 }
 
-impl<const NUM_VARS: usize> LinearApproximation<NUM_VARS> {
+impl<const NUM_VARS: usize, T: Numeric> LinearApproximation<NUM_VARS, T> {
     /// Evaluates the approximation at `x`.
-    pub fn predict(&self, x: &[f64; NUM_VARS]) -> f64 {
+    pub fn predict(&self, x: &[T; NUM_VARS]) -> T {
         let mut result = self.value;
         for ((&g, &xi), &pi) in self.gradient.iter().zip(x).zip(&self.point) {
             result += g * (xi - pi);
@@ -36,18 +37,18 @@ impl<const NUM_VARS: usize> LinearApproximation<NUM_VARS> {
     }
 
     /// The base point the approximation is centered on.
-    pub fn point(&self) -> &[f64; NUM_VARS] {
+    pub fn point(&self) -> &[T; NUM_VARS] {
         &self.point
     }
 
     /// The gradient at the base point. These are also the coefficients of the expanded
     /// linear form `intercept + Σ coefficients[i] * x[i]`.
-    pub fn coefficients(&self) -> &[f64; NUM_VARS] {
+    pub fn coefficients(&self) -> &[T; NUM_VARS] {
         &self.gradient
     }
 
     /// The intercept of the expanded form `intercept + Σ coefficients[i] * x[i]`.
-    pub fn intercept(&self) -> f64 {
+    pub fn intercept(&self) -> T {
         let mut intercept = self.value;
         for i in 0..NUM_VARS {
             intercept -= self.gradient[i] * self.point[i];
@@ -59,11 +60,11 @@ impl<const NUM_VARS: usize> LinearApproximation<NUM_VARS> {
     ///
     /// `r_squared` is `NaN` when the truth is constant over `points`;
     /// `adjusted_r_squared` is `NaN` when there are too few points.
-    pub fn get_prediction_metrics<O: Fn(&[f64; NUM_VARS]) -> f64, const NUM_POINTS: usize>(
+    pub fn get_prediction_metrics<O: Fn(&[T; NUM_VARS]) -> T, const NUM_POINTS: usize>(
         &self,
-        points: &[[f64; NUM_VARS]; NUM_POINTS],
+        points: &[[T; NUM_VARS]; NUM_POINTS],
         original_function: &O,
-    ) -> LinearApproximationPredictionMetrics {
+    ) -> LinearApproximationPredictionMetrics<T> {
         let (mae, mse, rmse, r_squared, adjusted_r_squared) = crate::approximation::compute_metrics(
             |x| self.predict(x),
             points,
@@ -124,14 +125,14 @@ impl<D: DerivatorMultiVariable> LinearApproximator<D> {
     /// //the approximation is exact at the base point
     /// assert!(f64::abs(function_to_approximate(&point) - result.predict(&point)) < 1e-9);
     /// ```
-    pub fn get<F: Fn(&[f64; NUM_VARS]) -> f64, const NUM_VARS: usize>(
+    pub fn get<F: Fn(&[D::Scalar; NUM_VARS]) -> D::Scalar, const NUM_VARS: usize>(
         &self,
         function: &F,
-        point: &[f64; NUM_VARS],
-    ) -> Result<LinearApproximation<NUM_VARS>, CalcError> {
+        point: &[D::Scalar; NUM_VARS],
+    ) -> Result<LinearApproximation<NUM_VARS, D::Scalar>, CalcError> {
         let value = function(point);
 
-        let mut gradient = [0.0; NUM_VARS];
+        let mut gradient = [<D::Scalar as Numeric>::ZERO; NUM_VARS];
         for (i, slot) in gradient.iter_mut().enumerate() {
             *slot = self.derivator.get_single_partial(function, i, point)?;
         }

--- a/src/approximation/mod.rs
+++ b/src/approximation/mod.rs
@@ -1,3 +1,5 @@
+use crate::numeric::Numeric;
+
 pub mod linear_approximation;
 pub mod quadratic_approximation;
 
@@ -10,50 +12,51 @@ mod test;
 /// number of fitted terms (`p`), used only for the adjusted R². `r_squared` is `NaN` when
 /// the truth is constant over `points` (zero total variance); `adjusted_r_squared` is
 /// `NaN` when there are too few points (`num_points <= num_predictors + 1`).
-pub(crate) fn compute_metrics<P, O, const NUM_VARS: usize, const NUM_POINTS: usize>(
+pub(crate) fn compute_metrics<T, P, O, const NUM_VARS: usize, const NUM_POINTS: usize>(
     predict: P,
-    points: &[[f64; NUM_VARS]; NUM_POINTS],
+    points: &[[T; NUM_VARS]; NUM_POINTS],
     original_function: &O,
     num_predictors: usize,
-) -> (f64, f64, f64, f64, f64)
+) -> (T, T, T, T, T)
 where
-    P: Fn(&[f64; NUM_VARS]) -> f64,
-    O: Fn(&[f64; NUM_VARS]) -> f64,
+    T: Numeric,
+    P: Fn(&[T; NUM_VARS]) -> T,
+    O: Fn(&[T; NUM_VARS]) -> T,
 {
-    let n = NUM_POINTS as f64;
+    let n = T::from_usize(NUM_POINTS);
 
-    let mut mean_y = 0.0;
+    let mut mean_y = T::ZERO;
     for point in points {
         mean_y += original_function(point);
     }
     mean_y /= n;
 
-    let mut sum_abs = 0.0;
-    let mut ss_res = 0.0;
-    let mut ss_tot = 0.0;
+    let mut sum_abs = T::ZERO;
+    let mut ss_res = T::ZERO;
+    let mut ss_tot = T::ZERO;
     for point in points {
         let y = original_function(point);
         let residual = predict(point) - y;
-        sum_abs += libm::fabs(residual);
+        sum_abs += residual.abs();
         ss_res += residual * residual;
         ss_tot += (y - mean_y) * (y - mean_y);
     }
 
     let mae = sum_abs / n;
     let mse = ss_res / n;
-    let rmse = libm::sqrt(mse);
+    let rmse = mse.sqrt();
 
-    let r_squared = if ss_tot == 0.0 {
-        f64::NAN
+    let r_squared = if ss_tot == T::ZERO {
+        T::NAN
     } else {
-        1.0 - ss_res / ss_tot
+        T::ONE - ss_res / ss_tot
     };
 
-    let denominator = n - num_predictors as f64 - 1.0;
-    let adjusted_r_squared = if denominator <= 0.0 {
-        f64::NAN
+    let denominator = n - T::from_usize(num_predictors) - T::ONE;
+    let adjusted_r_squared = if denominator <= T::ZERO {
+        T::NAN
     } else {
-        1.0 - (1.0 - r_squared) * (n - 1.0) / denominator
+        T::ONE - (T::ONE - r_squared) * (n - T::ONE) / denominator
     };
 
     (mae, mse, rmse, r_squared, adjusted_r_squared)

--- a/src/approximation/quadratic_approximation.rs
+++ b/src/approximation/quadratic_approximation.rs
@@ -1,3 +1,4 @@
+use crate::numeric::Numeric;
 use crate::numerical_derivative::derivator::DerivatorMultiVariable;
 use crate::utils::error_codes::CalcError;
 
@@ -5,32 +6,32 @@ use crate::utils::error_codes::CalcError;
 /// `f(x) ≈ value + Σ gradient[i]·dx[i] + ½ Σ_i Σ_j hessian[i][j]·dx[i]·dx[j]`,
 /// where `dx[i] = x[i] - point[i]`.
 #[derive(Debug, Clone, Copy)]
-pub struct QuadraticApproximation<const NUM_VARS: usize> {
-    point: [f64; NUM_VARS],
-    value: f64,
-    gradient: [f64; NUM_VARS],
-    hessian: [[f64; NUM_VARS]; NUM_VARS],
+pub struct QuadraticApproximation<const NUM_VARS: usize, T = f64> {
+    point: [T; NUM_VARS],
+    value: T,
+    gradient: [T; NUM_VARS],
+    hessian: [[T; NUM_VARS]; NUM_VARS],
 }
 
 /// Goodness-of-fit metrics for a [`QuadraticApproximation`] over a set of sample points.
 #[derive(Debug, Clone, Copy)]
-pub struct QuadraticApproximationPredictionMetrics {
+pub struct QuadraticApproximationPredictionMetrics<T = f64> {
     /// Mean absolute error.
-    pub mean_absolute_error: f64,
+    pub mean_absolute_error: T,
     /// Mean squared error.
-    pub mean_squared_error: f64,
+    pub mean_squared_error: T,
     /// Root mean squared error.
-    pub root_mean_squared_error: f64,
+    pub root_mean_squared_error: T,
     /// Coefficient of determination; `NaN` when the truth is constant over the points.
-    pub r_squared: f64,
+    pub r_squared: T,
     /// R² adjusted for the number of predictors; `NaN` when there are too few points.
-    pub adjusted_r_squared: f64,
+    pub adjusted_r_squared: T,
 }
 
-impl<const NUM_VARS: usize> QuadraticApproximation<NUM_VARS> {
+impl<const NUM_VARS: usize, T: Numeric> QuadraticApproximation<NUM_VARS, T> {
     /// Evaluates the approximation at `x`. The `½` keeps the quadratic term correct for
     /// both diagonal and off-diagonal Hessian entries.
-    pub fn predict(&self, x: &[f64; NUM_VARS]) -> f64 {
+    pub fn predict(&self, x: &[T; NUM_VARS]) -> T {
         let mut result = self.value;
         for (((&gi, &xi), &pi), hrow) in self
             .gradient
@@ -42,24 +43,24 @@ impl<const NUM_VARS: usize> QuadraticApproximation<NUM_VARS> {
             let di = xi - pi;
             result += gi * di;
             for ((&hij, &xj), &pj) in hrow.iter().zip(x).zip(&self.point) {
-                result += 0.5 * hij * di * (xj - pj);
+                result += T::HALF * hij * di * (xj - pj);
             }
         }
         result
     }
 
     /// The base point the approximation is centered on.
-    pub fn point(&self) -> &[f64; NUM_VARS] {
+    pub fn point(&self) -> &[T; NUM_VARS] {
         &self.point
     }
 
     /// The gradient at the base point.
-    pub fn gradient(&self) -> &[f64; NUM_VARS] {
+    pub fn gradient(&self) -> &[T; NUM_VARS] {
         &self.gradient
     }
 
     /// The Hessian matrix at the base point.
-    pub fn hessian(&self) -> &[[f64; NUM_VARS]; NUM_VARS] {
+    pub fn hessian(&self) -> &[[T; NUM_VARS]; NUM_VARS] {
         &self.hessian
     }
 
@@ -67,11 +68,11 @@ impl<const NUM_VARS: usize> QuadraticApproximation<NUM_VARS> {
     ///
     /// `r_squared` is `NaN` when the truth is constant over `points`;
     /// `adjusted_r_squared` is `NaN` when there are too few points.
-    pub fn get_prediction_metrics<O: Fn(&[f64; NUM_VARS]) -> f64, const NUM_POINTS: usize>(
+    pub fn get_prediction_metrics<O: Fn(&[T; NUM_VARS]) -> T, const NUM_POINTS: usize>(
         &self,
-        points: &[[f64; NUM_VARS]; NUM_POINTS],
+        points: &[[T; NUM_VARS]; NUM_POINTS],
         original_function: &O,
-    ) -> QuadraticApproximationPredictionMetrics {
+    ) -> QuadraticApproximationPredictionMetrics<T> {
         // p = N gradient terms + N(N+1)/2 distinct (symmetric) Hessian terms
         let num_predictors = NUM_VARS + NUM_VARS * (NUM_VARS + 1) / 2;
 
@@ -135,21 +136,21 @@ impl<D: DerivatorMultiVariable> QuadraticApproximator<D> {
     /// //the approximation is exact at the base point
     /// assert!(f64::abs(function_to_approximate(&point) - result.predict(&point)) < 1e-9);
     /// ```
-    pub fn get<F: Fn(&[f64; NUM_VARS]) -> f64, const NUM_VARS: usize>(
+    pub fn get<F: Fn(&[D::Scalar; NUM_VARS]) -> D::Scalar, const NUM_VARS: usize>(
         &self,
         function: &F,
-        point: &[f64; NUM_VARS],
-    ) -> Result<QuadraticApproximation<NUM_VARS>, CalcError> {
+        point: &[D::Scalar; NUM_VARS],
+    ) -> Result<QuadraticApproximation<NUM_VARS, D::Scalar>, CalcError> {
         let value = function(point);
 
-        let mut gradient = [0.0; NUM_VARS];
+        let mut gradient = [<D::Scalar as Numeric>::ZERO; NUM_VARS];
         for (i, slot) in gradient.iter_mut().enumerate() {
             *slot = self.derivator.get_single_partial(function, i, point)?;
         }
 
         // symmetric fill: compute the upper triangle + diagonal once, mirror the rest.
         // the explicit indices are needed for the mirror write `hessian[col][row]`.
-        let mut hessian = [[f64::NAN; NUM_VARS]; NUM_VARS];
+        let mut hessian = [[<D::Scalar as Numeric>::NAN; NUM_VARS]; NUM_VARS];
         #[allow(clippy::needless_range_loop)]
         for row in 0..NUM_VARS {
             for col in 0..NUM_VARS {

--- a/src/approximation/test.rs
+++ b/src/approximation/test.rs
@@ -1,6 +1,7 @@
 use crate::approximation::linear_approximation::*;
 use crate::approximation::quadratic_approximation::*;
 use crate::numerical_derivative::finite_difference::FiniteDifferenceMulti;
+use crate::numerical_derivative::mode::FiniteDifferenceMode;
 use rand::Rng;
 
 #[test]
@@ -98,4 +99,25 @@ fn test_linear_approximation_exact() {
     assert!(metrics.root_mean_squared_error < 1e-6);
     assert!(f64::abs(metrics.r_squared - 1.0) < 1e-6);
     assert!(f64::abs(metrics.adjusted_r_squared - 1.0) < 1e-6);
+}
+
+#[test]
+fn test_linear_approximation_f32() {
+    //exactly-linear truth 2x + 3y - z + 5; the linear model is exact up to f32 rounding
+    let truth = |args: &[f32; 3]| -> f32 { 2.0 * args[0] + 3.0 * args[1] - args[2] + 5.0 };
+
+    let point = [1.0, 2.0, 3.0];
+
+    //a larger step suits f32; the default 1e-5 cancels badly at single precision
+    let approximator = LinearApproximator::from_derivator(
+        FiniteDifferenceMulti::<f32>::from_parameters(0.01, FiniteDifferenceMode::Central, 10.0),
+    );
+    let result = approximator.get(&truth, &point).unwrap();
+
+    let nearby = [1.05, 2.05, 2.95];
+    let predicted = result.predict(&nearby);
+    assert!(
+        f32::abs(truth(&nearby) - predicted) < 1e-2,
+        "got {predicted}"
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 //! `multicalc` — single- and multi-variable calculus for `no_std` Rust: derivatives,
 //! integrals, Jacobians and Hessians, vector-field operators, and Taylor approximation.
 //!
-//! All math is on `f64`, with transcendentals from [`libm`] so it works without `std`.
+//! Operations are generic over the [`Numeric`] scalar trait — implemented for `f32` and `f64`,
+//! defaulting to `f64` — with transcendentals from [`libm`] so it works without `std`.
 //! Fallible operations return [`utils::error_codes::CalcError`].
 #![no_std]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,12 @@ extern crate alloc;
 /// (`libm::sin`, `libm::exp`, …) without taking their own dependency.
 pub use libm;
 
+/// The scalar trait the calculus modules are generic over (implemented for `f32` and `f64`).
+pub use numeric::Numeric;
+
 pub mod approximation;
 pub mod gaussian_tables;
+pub mod numeric;
 pub mod numerical_derivative;
 pub mod numerical_integration;
 pub mod utils;

--- a/src/numeric.rs
+++ b/src/numeric.rs
@@ -1,0 +1,168 @@
+//! The scalar abstraction the calculus modules are generic over.
+//!
+//! [`Numeric`] wraps the `libm` transcendentals, the float constants, and the numeric
+//! conversions the modules need, so each algorithm is written once and runs at either
+//! precision. It is implemented for `f64` and `f32`.
+
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+/// A floating-point scalar usable by the differentiation, integration, and approximation
+/// modules. Transcendentals come from [`libm`](libm), so the trait works without `std`.
+pub trait Numeric:
+    Copy
+    + Clone
+    + PartialEq
+    + PartialOrd
+    + core::fmt::Debug
+    + Add<Output = Self>
+    + Sub<Output = Self>
+    + Mul<Output = Self>
+    + Div<Output = Self>
+    + Neg<Output = Self>
+    + AddAssign
+    + SubAssign
+    + MulAssign
+    + DivAssign
+{
+    /// The value `0`.
+    const ZERO: Self;
+    /// The value `1`.
+    const ONE: Self;
+    /// The value `2`.
+    const TWO: Self;
+    /// The value `0.5`.
+    const HALF: Self;
+    /// Archimedes' constant, π.
+    const PI: Self;
+    /// The difference between `1` and the next larger representable value.
+    const EPSILON: Self;
+    /// Not a Number.
+    const NAN: Self;
+    /// Positive infinity.
+    const INFINITY: Self;
+    /// Negative infinity.
+    const NEG_INFINITY: Self;
+
+    /// Converts from `f64`, narrowing if necessary. Used for table values and literals.
+    fn from_f64(value: f64) -> Self;
+    /// Converts from `u64`, e.g. an iteration count.
+    fn from_u64(value: u64) -> Self;
+    /// Converts from `usize`, e.g. a point or variable count.
+    fn from_usize(value: usize) -> Self;
+
+    /// Absolute value.
+    fn abs(self) -> Self;
+    /// Square root.
+    fn sqrt(self) -> Self;
+    /// Cosine, with `self` in radians.
+    fn cos(self) -> Self;
+    /// Tangent, with `self` in radians.
+    fn tan(self) -> Self;
+
+    /// Returns `true` if `self` is NaN.
+    fn is_nan(self) -> bool;
+    /// Returns `true` if `self` is neither infinite nor NaN.
+    fn is_finite(self) -> bool;
+}
+
+impl Numeric for f64 {
+    const ZERO: Self = 0.0;
+    const ONE: Self = 1.0;
+    const TWO: Self = 2.0;
+    const HALF: Self = 0.5;
+    const PI: Self = core::f64::consts::PI;
+    const EPSILON: Self = f64::EPSILON;
+    const NAN: Self = f64::NAN;
+    const INFINITY: Self = f64::INFINITY;
+    const NEG_INFINITY: Self = f64::NEG_INFINITY;
+
+    #[inline]
+    fn from_f64(value: f64) -> Self {
+        value
+    }
+    #[inline]
+    fn from_u64(value: u64) -> Self {
+        value as f64
+    }
+    #[inline]
+    fn from_usize(value: usize) -> Self {
+        value as f64
+    }
+
+    #[inline]
+    fn abs(self) -> Self {
+        libm::fabs(self)
+    }
+    #[inline]
+    fn sqrt(self) -> Self {
+        libm::sqrt(self)
+    }
+    #[inline]
+    fn cos(self) -> Self {
+        libm::cos(self)
+    }
+    #[inline]
+    fn tan(self) -> Self {
+        libm::tan(self)
+    }
+
+    #[inline]
+    fn is_nan(self) -> bool {
+        f64::is_nan(self)
+    }
+    #[inline]
+    fn is_finite(self) -> bool {
+        f64::is_finite(self)
+    }
+}
+
+impl Numeric for f32 {
+    const ZERO: Self = 0.0;
+    const ONE: Self = 1.0;
+    const TWO: Self = 2.0;
+    const HALF: Self = 0.5;
+    const PI: Self = core::f32::consts::PI;
+    const EPSILON: Self = f32::EPSILON;
+    const NAN: Self = f32::NAN;
+    const INFINITY: Self = f32::INFINITY;
+    const NEG_INFINITY: Self = f32::NEG_INFINITY;
+
+    #[inline]
+    fn from_f64(value: f64) -> Self {
+        value as f32
+    }
+    #[inline]
+    fn from_u64(value: u64) -> Self {
+        value as f32
+    }
+    #[inline]
+    fn from_usize(value: usize) -> Self {
+        value as f32
+    }
+
+    #[inline]
+    fn abs(self) -> Self {
+        libm::fabsf(self)
+    }
+    #[inline]
+    fn sqrt(self) -> Self {
+        libm::sqrtf(self)
+    }
+    #[inline]
+    fn cos(self) -> Self {
+        libm::cosf(self)
+    }
+    #[inline]
+    fn tan(self) -> Self {
+        libm::tanf(self)
+    }
+
+    #[inline]
+    fn is_nan(self) -> bool {
+        f32::is_nan(self)
+    }
+    #[inline]
+    fn is_finite(self) -> bool {
+        f32::is_finite(self)
+    }
+}

--- a/src/numeric.rs
+++ b/src/numeric.rs
@@ -7,7 +7,7 @@
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 /// A floating-point scalar usable by the differentiation, integration, and approximation
-/// modules. Transcendentals come from [`libm`](libm), so the trait works without `std`.
+/// modules. Transcendentals come from [`libm`], so the trait works without `std`.
 pub trait Numeric:
     Copy
     + Clone

--- a/src/numerical_derivative/derivator.rs
+++ b/src/numerical_derivative/derivator.rs
@@ -1,7 +1,11 @@
+use crate::numeric::Numeric;
 use crate::utils::error_codes::CalcError;
 
 /// Base trait for single-variable numerical differentiation.
 pub trait DerivatorSingleVariable {
+    /// The scalar the derivative is computed in.
+    type Scalar: Numeric;
+
     /// Computes the `order`-th derivative of `func` at `point`.
     ///
     /// # Errors
@@ -21,21 +25,37 @@ pub trait DerivatorSingleVariable {
     /// let val = derivator.get(2, &func, 2.0).unwrap();
     /// assert!(f64::abs(val - 12.0) < 1e-5);
     /// ```
-    fn get<F: Fn(f64) -> f64>(&self, order: usize, func: &F, point: f64) -> Result<f64, CalcError>;
+    fn get<F: Fn(Self::Scalar) -> Self::Scalar>(
+        &self,
+        order: usize,
+        func: &F,
+        point: Self::Scalar,
+    ) -> Result<Self::Scalar, CalcError>;
 
     /// Convenience wrapper for the first derivative.
-    fn get_single<F: Fn(f64) -> f64>(&self, func: &F, point: f64) -> Result<f64, CalcError> {
+    fn get_single<F: Fn(Self::Scalar) -> Self::Scalar>(
+        &self,
+        func: &F,
+        point: Self::Scalar,
+    ) -> Result<Self::Scalar, CalcError> {
         self.get(1, func, point)
     }
 
     /// Convenience wrapper for the second derivative.
-    fn get_double<F: Fn(f64) -> f64>(&self, func: &F, point: f64) -> Result<f64, CalcError> {
+    fn get_double<F: Fn(Self::Scalar) -> Self::Scalar>(
+        &self,
+        func: &F,
+        point: Self::Scalar,
+    ) -> Result<Self::Scalar, CalcError> {
         self.get(2, func, point)
     }
 }
 
 /// Base trait for multi-variable numerical differentiation.
 pub trait DerivatorMultiVariable {
+    /// The scalar the derivative is computed in.
+    type Scalar: Numeric;
+
     /// Computes the partial derivative of `func` at `point`, differentiating once
     /// with respect to each variable index listed in `idx_to_differentiate`. The
     /// derivative order equals the length of that array.
@@ -59,30 +79,40 @@ pub trait DerivatorMultiVariable {
     /// let expected = f64::cos(1.0) - f64::sin(2.0) + f64::exp(3.0);
     /// assert!(f64::abs(val - expected) < 0.001);
     /// ```
-    fn get<F: Fn(&[f64; NUM_VARS]) -> f64, const NUM_VARS: usize, const NUM_ORDER: usize>(
+    fn get<
+        F: Fn(&[Self::Scalar; NUM_VARS]) -> Self::Scalar,
+        const NUM_VARS: usize,
+        const NUM_ORDER: usize,
+    >(
         &self,
         func: &F,
         idx_to_differentiate: &[usize; NUM_ORDER],
-        point: &[f64; NUM_VARS],
-    ) -> Result<f64, CalcError>;
+        point: &[Self::Scalar; NUM_VARS],
+    ) -> Result<Self::Scalar, CalcError>;
 
     /// Convenience wrapper for a single partial derivative.
-    fn get_single_partial<F: Fn(&[f64; NUM_VARS]) -> f64, const NUM_VARS: usize>(
+    fn get_single_partial<
+        F: Fn(&[Self::Scalar; NUM_VARS]) -> Self::Scalar,
+        const NUM_VARS: usize,
+    >(
         &self,
         func: &F,
         idx_to_differentiate: usize,
-        point: &[f64; NUM_VARS],
-    ) -> Result<f64, CalcError> {
+        point: &[Self::Scalar; NUM_VARS],
+    ) -> Result<Self::Scalar, CalcError> {
         self.get(func, &[idx_to_differentiate], point)
     }
 
     /// Convenience wrapper for a second partial derivative.
-    fn get_double_partial<F: Fn(&[f64; NUM_VARS]) -> f64, const NUM_VARS: usize>(
+    fn get_double_partial<
+        F: Fn(&[Self::Scalar; NUM_VARS]) -> Self::Scalar,
+        const NUM_VARS: usize,
+    >(
         &self,
         func: &F,
         idx_to_differentiate: &[usize; 2],
-        point: &[f64; NUM_VARS],
-    ) -> Result<f64, CalcError> {
+        point: &[Self::Scalar; NUM_VARS],
+    ) -> Result<Self::Scalar, CalcError> {
         self.get(func, idx_to_differentiate, point)
     }
 }

--- a/src/numerical_derivative/finite_difference.rs
+++ b/src/numerical_derivative/finite_difference.rs
@@ -4,6 +4,7 @@
 //! error (roughly as the inverse of the step size raised to the order). For third
 //! derivatives and higher, tune `step_size` and `step_size_multiplier` per problem.
 
+use crate::numeric::Numeric;
 use crate::numerical_derivative::derivator::{DerivatorMultiVariable, DerivatorSingleVariable};
 use crate::numerical_derivative::mode::{self, FiniteDifferenceMode};
 use crate::utils::error_codes::CalcError;
@@ -11,40 +12,40 @@ use crate::utils::error_codes::CalcError;
 /// Low and high sample offsets (in units of the step size) and the divisor factor
 /// for each finite-difference mode.
 #[inline]
-fn offsets(method: FiniteDifferenceMode) -> (f64, f64, f64) {
+fn offsets<T: Numeric>(method: FiniteDifferenceMode) -> (T, T, T) {
     match method {
-        FiniteDifferenceMode::Forward => (0.0, 1.0, 1.0),
-        FiniteDifferenceMode::Backward => (-1.0, 0.0, 1.0),
-        FiniteDifferenceMode::Central => (-1.0, 1.0, 2.0),
+        FiniteDifferenceMode::Forward => (T::ZERO, T::ONE, T::ONE),
+        FiniteDifferenceMode::Backward => (-T::ONE, T::ZERO, T::ONE),
+        FiniteDifferenceMode::Central => (-T::ONE, T::ONE, T::TWO),
     }
 }
 
 /// Configuration shared by the single- and multi-variable finite-difference differentiators.
 #[derive(Debug, Clone, Copy)]
-pub struct FiniteDifferenceConfig {
+pub struct FiniteDifferenceConfig<T = f64> {
     /// The finite-difference step size. See [`mode::DEFAULT_STEP_SIZE`].
-    pub step_size: f64,
+    pub step_size: T,
     /// Forward, Backward or Central difference.
     pub method: FiniteDifferenceMode,
     /// Factor the step is scaled by on each recursion level; only matters for third
     /// derivatives and higher. See [`mode::DEFAULT_STEP_SIZE_MULTIPLIER`].
-    pub step_size_multiplier: f64,
+    pub step_size_multiplier: T,
 }
 
-impl Default for FiniteDifferenceConfig {
+impl<T: Numeric> Default for FiniteDifferenceConfig<T> {
     /// Central difference with the default step size and multiplier; best for most cases.
     fn default() -> Self {
         FiniteDifferenceConfig {
-            step_size: mode::DEFAULT_STEP_SIZE,
+            step_size: T::from_f64(mode::DEFAULT_STEP_SIZE),
             method: FiniteDifferenceMode::Central,
-            step_size_multiplier: mode::DEFAULT_STEP_SIZE_MULTIPLIER,
+            step_size_multiplier: T::from_f64(mode::DEFAULT_STEP_SIZE_MULTIPLIER),
         }
     }
 }
 
-impl FiniteDifferenceConfig {
+impl<T: Numeric> FiniteDifferenceConfig<T> {
     /// Builds a config with explicit parameters.
-    pub fn from_parameters(step: f64, method: FiniteDifferenceMode, multiplier: f64) -> Self {
+    pub fn from_parameters(step: T, method: FiniteDifferenceMode, multiplier: T) -> Self {
         FiniteDifferenceConfig {
             step_size: step,
             method,
@@ -54,7 +55,7 @@ impl FiniteDifferenceConfig {
 
     /// Returns [`CalcError::StepSizeZero`] if the step size is zero.
     fn check_step_size(&self) -> Result<(), CalcError> {
-        if self.step_size == 0.0 {
+        if self.step_size == T::ZERO {
             return Err(CalcError::StepSizeZero);
         }
         Ok(())
@@ -62,22 +63,30 @@ impl FiniteDifferenceConfig {
 }
 
 /// Finite-difference differentiator for single-variable functions.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct FiniteDifferenceSingle {
-    pub config: FiniteDifferenceConfig,
+#[derive(Debug, Clone, Copy)]
+pub struct FiniteDifferenceSingle<T = f64> {
+    pub config: FiniteDifferenceConfig<T>,
 }
 
-impl FiniteDifferenceSingle {
+impl<T: Numeric> Default for FiniteDifferenceSingle<T> {
+    fn default() -> Self {
+        FiniteDifferenceSingle {
+            config: FiniteDifferenceConfig::default(),
+        }
+    }
+}
+
+impl<T: Numeric> FiniteDifferenceSingle<T> {
     /// Builds a differentiator with explicit parameters.
-    pub fn from_parameters(step: f64, method: FiniteDifferenceMode, multiplier: f64) -> Self {
+    pub fn from_parameters(step: T, method: FiniteDifferenceMode, multiplier: T) -> Self {
         FiniteDifferenceSingle {
             config: FiniteDifferenceConfig::from_parameters(step, method, multiplier),
         }
     }
 
     #[inline]
-    fn diff<F: Fn(f64) -> f64>(&self, order: usize, func: &F, point: f64, step: f64) -> f64 {
-        let (lo, hi, denom) = offsets(self.config.method);
+    fn diff<F: Fn(T) -> T>(&self, order: usize, func: &F, point: T, step: T) -> T {
+        let (lo, hi, denom) = offsets::<T>(self.config.method);
 
         if order == 1 {
             let low = func(point + lo * step);
@@ -92,8 +101,10 @@ impl FiniteDifferenceSingle {
     }
 }
 
-impl DerivatorSingleVariable for FiniteDifferenceSingle {
-    fn get<F: Fn(f64) -> f64>(&self, order: usize, func: &F, point: f64) -> Result<f64, CalcError> {
+impl<T: Numeric> DerivatorSingleVariable for FiniteDifferenceSingle<T> {
+    type Scalar = T;
+
+    fn get<F: Fn(T) -> T>(&self, order: usize, func: &F, point: T) -> Result<T, CalcError> {
         if order == 0 {
             return Err(CalcError::DerivativeOrderZero);
         }
@@ -103,29 +114,37 @@ impl DerivatorSingleVariable for FiniteDifferenceSingle {
 }
 
 /// Finite-difference differentiator for multi-variable functions.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct FiniteDifferenceMulti {
-    pub config: FiniteDifferenceConfig,
+#[derive(Debug, Clone, Copy)]
+pub struct FiniteDifferenceMulti<T = f64> {
+    pub config: FiniteDifferenceConfig<T>,
 }
 
-impl FiniteDifferenceMulti {
+impl<T: Numeric> Default for FiniteDifferenceMulti<T> {
+    fn default() -> Self {
+        FiniteDifferenceMulti {
+            config: FiniteDifferenceConfig::default(),
+        }
+    }
+}
+
+impl<T: Numeric> FiniteDifferenceMulti<T> {
     /// Builds a differentiator with explicit parameters.
-    pub fn from_parameters(step: f64, method: FiniteDifferenceMode, multiplier: f64) -> Self {
+    pub fn from_parameters(step: T, method: FiniteDifferenceMode, multiplier: T) -> Self {
         FiniteDifferenceMulti {
             config: FiniteDifferenceConfig::from_parameters(step, method, multiplier),
         }
     }
 
     #[inline]
-    fn diff<F: Fn(&[f64; NUM_VARS]) -> f64, const NUM_VARS: usize, const NUM_ORDER: usize>(
+    fn diff<F: Fn(&[T; NUM_VARS]) -> T, const NUM_VARS: usize, const NUM_ORDER: usize>(
         &self,
         order: usize,
         func: &F,
         idx_to_differentiate: &[usize; NUM_ORDER],
-        point: &[f64; NUM_VARS],
-        step: f64,
-    ) -> f64 {
-        let (lo, hi, denom) = offsets(self.config.method);
+        point: &[T; NUM_VARS],
+        step: T,
+    ) -> T {
+        let (lo, hi, denom) = offsets::<T>(self.config.method);
         let var = idx_to_differentiate[order - 1];
 
         let mut low_point = *point;
@@ -144,13 +163,15 @@ impl FiniteDifferenceMulti {
     }
 }
 
-impl DerivatorMultiVariable for FiniteDifferenceMulti {
-    fn get<F: Fn(&[f64; NUM_VARS]) -> f64, const NUM_VARS: usize, const NUM_ORDER: usize>(
+impl<T: Numeric> DerivatorMultiVariable for FiniteDifferenceMulti<T> {
+    type Scalar = T;
+
+    fn get<F: Fn(&[T; NUM_VARS]) -> T, const NUM_VARS: usize, const NUM_ORDER: usize>(
         &self,
         func: &F,
         idx_to_differentiate: &[usize; NUM_ORDER],
-        point: &[f64; NUM_VARS],
-    ) -> Result<f64, CalcError> {
+        point: &[T; NUM_VARS],
+    ) -> Result<T, CalcError> {
         if NUM_ORDER == 0 {
             return Err(CalcError::DerivativeOrderZero);
         }

--- a/src/numerical_derivative/hessian.rs
+++ b/src/numerical_derivative/hessian.rs
@@ -1,3 +1,4 @@
+use crate::numeric::Numeric;
 use crate::numerical_derivative::derivator::DerivatorMultiVariable;
 use crate::utils::error_codes::CalcError;
 
@@ -47,12 +48,12 @@ impl<D: DerivatorMultiVariable> Hessian<D> {
     /// let result = hessian.get(&my_func, &[1.0, 2.0]).unwrap();
     /// assert!(f64::abs(result[0][0] - (-2.0 * f64::sin(1.0))) < 1e-5);
     /// ```
-    pub fn get<F: Fn(&[f64; NUM_VARS]) -> f64, const NUM_VARS: usize>(
+    pub fn get<F: Fn(&[D::Scalar; NUM_VARS]) -> D::Scalar, const NUM_VARS: usize>(
         &self,
         function: &F,
-        vector_of_points: &[f64; NUM_VARS],
-    ) -> Result<[[f64; NUM_VARS]; NUM_VARS], CalcError> {
-        let mut result = [[f64::NAN; NUM_VARS]; NUM_VARS];
+        vector_of_points: &[D::Scalar; NUM_VARS],
+    ) -> Result<[[D::Scalar; NUM_VARS]; NUM_VARS], CalcError> {
+        let mut result = [[<D::Scalar as Numeric>::NAN; NUM_VARS]; NUM_VARS];
 
         // explicit indices are needed for the symmetric mirror write `result[col][row]`
         #[allow(clippy::needless_range_loop)]

--- a/src/numerical_derivative/jacobian.rs
+++ b/src/numerical_derivative/jacobian.rs
@@ -1,3 +1,4 @@
+use crate::numeric::Numeric;
 use crate::numerical_derivative::derivator::DerivatorMultiVariable;
 use crate::utils::error_codes::CalcError;
 
@@ -55,14 +56,14 @@ impl<D: DerivatorMultiVariable> Jacobian<D> {
     /// ```
     pub fn get<const NUM_FUNCS: usize, const NUM_VARS: usize>(
         &self,
-        function_matrix: &[&dyn Fn(&[f64; NUM_VARS]) -> f64; NUM_FUNCS],
-        vector_of_points: &[f64; NUM_VARS],
-    ) -> Result<[[f64; NUM_VARS]; NUM_FUNCS], CalcError> {
+        function_matrix: &[&dyn Fn(&[D::Scalar; NUM_VARS]) -> D::Scalar; NUM_FUNCS],
+        vector_of_points: &[D::Scalar; NUM_VARS],
+    ) -> Result<[[D::Scalar; NUM_VARS]; NUM_FUNCS], CalcError> {
         if function_matrix.is_empty() {
             return Err(CalcError::EmptyFunctionSet);
         }
 
-        let mut result = [[0.0; NUM_VARS]; NUM_FUNCS];
+        let mut result = [[<D::Scalar as Numeric>::ZERO; NUM_VARS]; NUM_FUNCS];
 
         for (func, row) in function_matrix.iter().zip(result.iter_mut()) {
             for (col_index, slot) in row.iter_mut().enumerate() {
@@ -75,7 +76,7 @@ impl<D: DerivatorMultiVariable> Jacobian<D> {
         Ok(result)
     }
 
-    /// Same as [`Jacobian::get`] but returns a heap-allocated `Vec<Vec<f64>>`, which avoids a
+    /// Same as [`Jacobian::get`] but returns a heap-allocated `Vec<Vec<_>>`, which avoids a
     /// stack overflow on large inputs. Requires the `alloc` feature (off by default).
     ///
     /// The result has one row per function and one column per variable, so entry `[m][n]`
@@ -91,17 +92,17 @@ impl<D: DerivatorMultiVariable> Jacobian<D> {
     #[cfg(feature = "alloc")]
     pub fn get_on_heap<const NUM_VARS: usize>(
         &self,
-        function_matrix: &[Box<dyn Fn(&[f64; NUM_VARS]) -> f64>],
-        vector_of_points: &[f64; NUM_VARS],
-    ) -> Result<Vec<Vec<f64>>, CalcError> {
+        function_matrix: &[Box<dyn Fn(&[D::Scalar; NUM_VARS]) -> D::Scalar>],
+        vector_of_points: &[D::Scalar; NUM_VARS],
+    ) -> Result<Vec<Vec<D::Scalar>>, CalcError> {
         if function_matrix.is_empty() {
             return Err(CalcError::EmptyFunctionSet);
         }
 
-        let mut result: Vec<Vec<f64>> = Vec::new();
+        let mut result: Vec<Vec<D::Scalar>> = Vec::new();
 
         for func in function_matrix {
-            let mut cur_row: Vec<f64> = Vec::new();
+            let mut cur_row: Vec<D::Scalar> = Vec::new();
             for col_index in 0..NUM_VARS {
                 cur_row.push(self.derivator.get_single_partial(
                     func,

--- a/src/numerical_derivative/test.rs
+++ b/src/numerical_derivative/test.rs
@@ -448,3 +448,15 @@ fn test_hessian_1() {
         }
     }
 }
+
+#[test]
+fn test_single_derivative_f32() {
+    //x*x at 0.5; central difference is exact for quadratics, leaving only f32 rounding
+    let func = |x: f32| -> f32 { x * x };
+
+    let derivator = FiniteDifferenceSingle::<f32>::default();
+
+    //first derivative is 2x, known to be 1.0 at x = 0.5
+    let val = derivator.get(1, &func, 0.5).unwrap();
+    assert!(f32::abs(val - 1.0) < 1e-2, "got {val}");
+}

--- a/src/numerical_integration/gaussian_integration.rs
+++ b/src/numerical_integration/gaussian_integration.rs
@@ -1,4 +1,7 @@
+use core::marker::PhantomData;
+
 use crate::gaussian_tables::nodes;
+use crate::numeric::Numeric;
 use crate::numerical_integration::integrator::{IntegratorMultiVariable, IntegratorSingleVariable};
 use crate::numerical_integration::mode::GaussianQuadratureMethod;
 use crate::utils::error_codes::CalcError;
@@ -40,9 +43,9 @@ impl GaussianConfig {
     /// Gauss-Laguerre over `[0, +inf)`. The canonical domain is required (not ignored) so a
     /// mismatched limit cannot silently return a wrong result. `NaN` comparisons are false and
     /// are therefore rejected.
-    fn check_limits<const NUM_INTEGRATIONS: usize>(
+    fn check_limits<T: Numeric, const NUM_INTEGRATIONS: usize>(
         &self,
-        integration_limit: &[[f64; 2]; NUM_INTEGRATIONS],
+        integration_limit: &[[T; 2]; NUM_INTEGRATIONS],
     ) -> Result<(), CalcError> {
         for limit in integration_limit {
             let ok = match self.integration_method {
@@ -50,10 +53,10 @@ impl GaussianConfig {
                     limit[0].is_finite() && limit[1].is_finite() && limit[0] < limit[1]
                 }
                 GaussianQuadratureMethod::GaussHermite => {
-                    limit[0] == f64::NEG_INFINITY && limit[1] == f64::INFINITY
+                    limit[0] == T::NEG_INFINITY && limit[1] == T::INFINITY
                 }
                 GaussianQuadratureMethod::GaussLaguerre => {
-                    limit[0] == 0.0 && limit[1] == f64::INFINITY
+                    limit[0] == T::ZERO && limit[1] == T::INFINITY
                 }
             };
 
@@ -67,47 +70,60 @@ impl GaussianConfig {
 }
 
 /// Implements the gaussian quadrature methods for numerical integration for single variable functions
-#[derive(Debug, Clone, Copy, Default)]
-pub struct GaussianSingle {
+#[derive(Debug, Clone, Copy)]
+pub struct GaussianSingle<T = f64> {
     pub config: GaussianConfig,
+    _marker: PhantomData<T>,
 }
 
-impl GaussianSingle {
+impl<T> Default for GaussianSingle<T> {
+    fn default() -> Self {
+        GaussianSingle {
+            config: GaussianConfig::default(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> GaussianSingle<T> {
     /// custom constructor, optimal for fine-tuning for specific cases
     pub fn from_parameters(order: usize, integration_method: GaussianQuadratureMethod) -> Self {
         GaussianSingle {
             config: GaussianConfig::from_parameters(order, integration_method),
+            _marker: PhantomData,
         }
     }
+}
 
+impl<T: Numeric> GaussianSingle<T> {
     /// Gauss-Legendre over a finite `[a, b]`: nodes (defined on `[-1, 1]`) are affine-mapped
     /// by `(b-a)/2 * x + (b+a)/2` and the result scaled by `(b-a)/2`. Inner folds of a
     /// single-variable integral are constant in the outer variable, so the inner result is
-    /// computed once and reused.
-    fn integrate_legendre<F: Fn(f64) -> f64, const NUM_INTEGRATIONS: usize>(
+    /// computed once and reused. Each tabulated `(weight, abscissa)` is converted to `T` in place.
+    fn integrate_legendre<F: Fn(T) -> T, const NUM_INTEGRATIONS: usize>(
         &self,
         level: usize,
         table: &'static [(f64, f64)],
         func: &F,
-        integration_limit: &[[f64; 2]; NUM_INTEGRATIONS],
-    ) -> f64 {
+        integration_limit: &[[T; 2]; NUM_INTEGRATIONS],
+    ) -> T {
         let a = integration_limit[level - 1][0];
         let b = integration_limit[level - 1][1];
-        let half = (b - a) / 2.0;
-        let mid = (b + a) / 2.0;
+        let half = (b - a) * T::HALF;
+        let mid = (b + a) * T::HALF;
 
         if level == 1 {
-            let mut ans = 0.0;
+            let mut ans = T::ZERO;
             for &(weight, abscissa) in table {
-                ans += weight * func(half * abscissa + mid);
+                ans += T::from_f64(weight) * func(half * T::from_f64(abscissa) + mid);
             }
             return half * ans;
         }
 
         let inner = self.integrate_legendre(level - 1, table, func, integration_limit);
-        let mut ans = 0.0;
+        let mut ans = T::ZERO;
         for &(weight, _) in table {
-            ans += weight * inner;
+            ans += T::from_f64(weight) * inner;
         }
         half * ans
     }
@@ -115,30 +131,32 @@ impl GaussianSingle {
     /// Gauss-Hermite / Gauss-Laguerre over their fixed domain: nodes are used as-is with no
     /// affine map and no exponential factor, since the tabulated weights already carry the
     /// `e^{-x^2}` / `e^{-x}` weighting function.
-    fn integrate_canonical<F: Fn(f64) -> f64>(
+    fn integrate_canonical<F: Fn(T) -> T>(
         &self,
         level: usize,
         table: &'static [(f64, f64)],
         func: &F,
-    ) -> f64 {
+    ) -> T {
         if level == 1 {
-            let mut ans = 0.0;
+            let mut ans = T::ZERO;
             for &(weight, abscissa) in table {
-                ans += weight * func(abscissa);
+                ans += T::from_f64(weight) * func(T::from_f64(abscissa));
             }
             return ans;
         }
 
         let inner = self.integrate_canonical(level - 1, table, func);
-        let mut ans = 0.0;
+        let mut ans = T::ZERO;
         for &(weight, _) in table {
-            ans += weight * inner;
+            ans += T::from_f64(weight) * inner;
         }
         ans
     }
 }
 
-impl IntegratorSingleVariable for GaussianSingle {
+impl<T: Numeric> IntegratorSingleVariable for GaussianSingle<T> {
+    type Scalar = T;
+
     /// Integrates `func` by Gaussian quadrature, once for each limit in `integration_limit`
     /// (so the array length sets the number of integrations).
     ///
@@ -168,11 +186,11 @@ impl IntegratorSingleVariable for GaussianSingle {
     /// let val = integrator.get(&my_func, &[[0.0, 2.0]; 1]).unwrap();
     /// assert!(f64::abs(val - 8.0) < 1e-7);
     /// ```
-    fn get<F: Fn(f64) -> f64, const NUM_INTEGRATIONS: usize>(
+    fn get<F: Fn(T) -> T, const NUM_INTEGRATIONS: usize>(
         &self,
         func: &F,
-        integration_limit: &[[f64; 2]; NUM_INTEGRATIONS],
-    ) -> Result<f64, CalcError> {
+        integration_limit: &[[T; 2]; NUM_INTEGRATIONS],
+    ) -> Result<T, CalcError> {
         let table = nodes(self.config.integration_method, self.config.order)?;
         self.config.check_limits(integration_limit)?;
 
@@ -186,24 +204,37 @@ impl IntegratorSingleVariable for GaussianSingle {
 }
 
 /// Implements the gaussian quadrature methods for numerical integration for multi variable functions
-#[derive(Debug, Clone, Copy, Default)]
-pub struct GaussianMulti {
+#[derive(Debug, Clone, Copy)]
+pub struct GaussianMulti<T = f64> {
     pub config: GaussianConfig,
+    _marker: PhantomData<T>,
 }
 
-impl GaussianMulti {
+impl<T> Default for GaussianMulti<T> {
+    fn default() -> Self {
+        GaussianMulti {
+            config: GaussianConfig::default(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> GaussianMulti<T> {
     /// custom constructor, optimal for fine-tuning for specific cases
     pub fn from_parameters(order: usize, integration_method: GaussianQuadratureMethod) -> Self {
         GaussianMulti {
             config: GaussianConfig::from_parameters(order, integration_method),
+            _marker: PhantomData,
         }
     }
+}
 
+impl<T: Numeric> GaussianMulti<T> {
     /// Gauss-Legendre partial integration over a finite `[a, b]`. The affine-mapped node is
     /// written into the integrated variable's slot before recursing; the inner fold depends
     /// on the outer node, so it is recomputed for each one.
     fn integrate_legendre<
-        F: Fn(&[f64; NUM_VARS]) -> f64,
+        F: Fn(&[T; NUM_VARS]) -> T,
         const NUM_VARS: usize,
         const NUM_INTEGRATIONS: usize,
     >(
@@ -212,29 +243,29 @@ impl GaussianMulti {
         idx_to_integrate: [usize; NUM_INTEGRATIONS],
         table: &'static [(f64, f64)],
         func: &F,
-        integration_limits: &[[f64; 2]; NUM_INTEGRATIONS],
-        point: &[f64; NUM_VARS],
-    ) -> f64 {
+        integration_limits: &[[T; 2]; NUM_INTEGRATIONS],
+        point: &[T; NUM_VARS],
+    ) -> T {
         let a = integration_limits[level - 1][0];
         let b = integration_limits[level - 1][1];
-        let half = (b - a) / 2.0;
-        let mid = (b + a) / 2.0;
+        let half = (b - a) * T::HALF;
+        let mid = (b + a) * T::HALF;
         let var = idx_to_integrate[level - 1];
 
         let mut current = *point;
-        let mut ans = 0.0;
+        let mut ans = T::ZERO;
 
         if level == 1 {
             for &(weight, abscissa) in table {
-                current[var] = half * abscissa + mid;
-                ans += weight * func(&current);
+                current[var] = half * T::from_f64(abscissa) + mid;
+                ans += T::from_f64(weight) * func(&current);
             }
             return half * ans;
         }
 
         for &(weight, abscissa) in table {
-            current[var] = half * abscissa + mid;
-            ans += weight
+            current[var] = half * T::from_f64(abscissa) + mid;
+            ans += T::from_f64(weight)
                 * self.integrate_legendre(
                     level - 1,
                     idx_to_integrate,
@@ -251,7 +282,7 @@ impl GaussianMulti {
     /// written into the integrated variable's slot as-is (no map, no exponential factor) and
     /// the recursion stays in the same method.
     fn integrate_canonical<
-        F: Fn(&[f64; NUM_VARS]) -> f64,
+        F: Fn(&[T; NUM_VARS]) -> T,
         const NUM_VARS: usize,
         const NUM_INTEGRATIONS: usize,
     >(
@@ -260,31 +291,33 @@ impl GaussianMulti {
         idx_to_integrate: [usize; NUM_INTEGRATIONS],
         table: &'static [(f64, f64)],
         func: &F,
-        point: &[f64; NUM_VARS],
-    ) -> f64 {
+        point: &[T; NUM_VARS],
+    ) -> T {
         let var = idx_to_integrate[level - 1];
 
         let mut current = *point;
-        let mut ans = 0.0;
+        let mut ans = T::ZERO;
 
         if level == 1 {
             for &(weight, abscissa) in table {
-                current[var] = abscissa;
-                ans += weight * func(&current);
+                current[var] = T::from_f64(abscissa);
+                ans += T::from_f64(weight) * func(&current);
             }
             return ans;
         }
 
         for &(weight, abscissa) in table {
-            current[var] = abscissa;
-            ans += weight
+            current[var] = T::from_f64(abscissa);
+            ans += T::from_f64(weight)
                 * self.integrate_canonical(level - 1, idx_to_integrate, table, func, &current);
         }
         ans
     }
 }
 
-impl IntegratorMultiVariable for GaussianMulti {
+impl<T: Numeric> IntegratorMultiVariable for GaussianMulti<T> {
+    type Scalar = T;
+
     /// Partially integrates `func` by Gaussian quadrature over the variables in
     /// `idx_to_integrate`, once for each limit in `integration_limits` (so the array length
     /// sets the number of integrations).
@@ -316,13 +349,13 @@ impl IntegratorMultiVariable for GaussianMulti {
     /// let val = integrator.get([0; 1], &my_func, &[[0.0, 1.0]; 1], &point).unwrap();
     /// assert!(f64::abs(val - 7.0) < 1e-7);
     /// ```
-    fn get<F: Fn(&[f64; NUM_VARS]) -> f64, const NUM_VARS: usize, const NUM_INTEGRATIONS: usize>(
+    fn get<F: Fn(&[T; NUM_VARS]) -> T, const NUM_VARS: usize, const NUM_INTEGRATIONS: usize>(
         &self,
         idx_to_integrate: [usize; NUM_INTEGRATIONS],
         func: &F,
-        integration_limits: &[[f64; 2]; NUM_INTEGRATIONS],
-        point: &[f64; NUM_VARS],
-    ) -> Result<f64, CalcError> {
+        integration_limits: &[[T; 2]; NUM_INTEGRATIONS],
+        point: &[T; NUM_VARS],
+    ) -> Result<T, CalcError> {
         let table = nodes(self.config.integration_method, self.config.order)?;
         self.config.check_limits(integration_limits)?;
 

--- a/src/numerical_integration/integrator.rs
+++ b/src/numerical_integration/integrator.rs
@@ -1,16 +1,12 @@
+use crate::numeric::Numeric;
 use crate::utils::error_codes::CalcError;
-use core::f64::consts::PI;
-
-/// Smallest inset from an infinite endpoint, keeping the domain transform away from
-/// its singular limit (a larger value trades tail truncation for endpoint stability).
-const EPSILON: f64 = f64::EPSILON;
 
 /// Classification of an integration interval, distinguishing finite domains from the
 /// three infinite/semi-infinite shapes that need a domain transform.
-pub(crate) enum Domain {
-    Finite(f64, f64),
-    LowerToInf(f64),
-    UpperToInf(f64),
+pub(crate) enum Domain<T: Numeric> {
+    Finite(T, T),
+    LowerToInf(T),
+    UpperToInf(T),
     BothInf,
 }
 
@@ -18,88 +14,95 @@ pub(crate) enum Domain {
 ///
 /// Rejects `NaN` limits, equal/reversed finite limits, and infinite limits whose
 /// finite end points the wrong way (e.g. `(a, -inf)` or `(+inf, b)`).
-pub(crate) fn classify(limit: &[f64; 2]) -> Result<Domain, CalcError> {
+pub(crate) fn classify<T: Numeric>(limit: &[T; 2]) -> Result<Domain<T>, CalcError> {
     let (a, b) = (limit[0], limit[1]);
     if a.is_nan() || b.is_nan() {
         return Err(CalcError::IntegrationLimitsIllDefined);
     }
     match (a.is_finite(), b.is_finite()) {
         (true, true) if a < b => Ok(Domain::Finite(a, b)),
-        (true, false) if b > 0.0 => Ok(Domain::LowerToInf(a)), // (a, +inf); rejects (a, -inf)
-        (false, true) if a < 0.0 => Ok(Domain::UpperToInf(b)), // (-inf, b); rejects (+inf, b)
-        (false, false) if a < 0.0 && b > 0.0 => Ok(Domain::BothInf), // (-inf, +inf)
+        (true, false) if b > T::ZERO => Ok(Domain::LowerToInf(a)), // (a, +inf); rejects (a, -inf)
+        (false, true) if a < T::ZERO => Ok(Domain::UpperToInf(b)), // (-inf, b); rejects (+inf, b)
+        (false, false) if a < T::ZERO && b > T::ZERO => Ok(Domain::BothInf), // (-inf, +inf)
         _ => Err(CalcError::IntegrationLimitsIllDefined),
     }
 }
 
 /// Returns the `t`-interval the rule walks for a domain. The finite end of a
 /// semi-infinite domain sits at `t = 0` and is perfectly regular, so it is included;
-/// only an infinite end needs the `EPSILON` inset.
-pub(crate) fn t_bounds(d: &Domain) -> (f64, f64) {
+/// only an infinite end needs the `T::EPSILON` inset that keeps the transform away from
+/// its singular limit.
+pub(crate) fn t_bounds<T: Numeric>(d: &Domain<T>) -> (T, T) {
     match d {
         Domain::Finite(a, b) => (*a, *b),
-        Domain::LowerToInf(_) => (0.0, 1.0 - EPSILON), // finite end t=0, +inf at t=1
-        Domain::UpperToInf(_) => (0.0, 1.0 - EPSILON), // finite end t=0, -inf at t=1
-        Domain::BothInf => (EPSILON, 1.0 - EPSILON),
+        Domain::LowerToInf(_) => (T::ZERO, T::ONE - T::EPSILON), // finite end t=0, +inf at t=1
+        Domain::UpperToInf(_) => (T::ZERO, T::ONE - T::EPSILON), // finite end t=0, -inf at t=1
+        Domain::BothInf => (T::EPSILON, T::ONE - T::EPSILON),
     }
 }
 
 /// Maps a sample `t` to its position `x` and the Jacobian `dx/dt` for a domain.
 /// Finite domains are the identity, so the finite path pays nothing extra.
-pub(crate) fn map_sample(d: &Domain, t: f64) -> (f64, f64) {
+pub(crate) fn map_sample<T: Numeric>(d: &Domain<T>, t: T) -> (T, T) {
     match *d {
-        Domain::Finite(_, _) => (t, 1.0),
+        Domain::Finite(_, _) => (t, T::ONE),
         Domain::LowerToInf(a) => {
-            let q = 1.0 - t;
-            (a + t / q, 1.0 / (q * q))
+            let q = T::ONE - t;
+            (a + t / q, T::ONE / (q * q))
         }
         Domain::UpperToInf(b) => {
-            let q = 1.0 - t;
-            (b - t / q, 1.0 / (q * q))
+            let q = T::ONE - t;
+            (b - t / q, T::ONE / (q * q))
         }
         Domain::BothInf => {
-            let u = PI * (t - 0.5);
-            let c = libm::cos(u);
-            (libm::tan(u), PI / (c * c))
+            let u = T::PI * (t - T::HALF);
+            let c = u.cos();
+            (u.tan(), T::PI / (c * c))
         }
     }
 }
 
 /// Base trait for single variable numerical integration.
 pub trait IntegratorSingleVariable {
+    /// The scalar the integral is computed in.
+    type Scalar: Numeric;
+
     /// Generic n-th integration of a single variable function. The number of
     /// integrations equals the length of `integration_limit`.
     ///
     /// # Errors
     /// [`CalcError::IterationsZero`] if the configured iteration count is zero, or
     /// [`CalcError::IntegrationLimitsIllDefined`] if any limit is ill-defined.
-    fn get<F: Fn(f64) -> f64, const NUM_INTEGRATIONS: usize>(
+    fn get<F: Fn(Self::Scalar) -> Self::Scalar, const NUM_INTEGRATIONS: usize>(
         &self,
         func: &F,
-        integration_limit: &[[f64; 2]; NUM_INTEGRATIONS],
-    ) -> Result<f64, CalcError>;
+        integration_limit: &[[Self::Scalar; 2]; NUM_INTEGRATIONS],
+    ) -> Result<Self::Scalar, CalcError>;
 
     /// Convenience wrapper for a single integral of a single variable function.
-    fn get_single<F: Fn(f64) -> f64>(
+    fn get_single<F: Fn(Self::Scalar) -> Self::Scalar>(
         &self,
         func: &F,
-        integration_limit: &[f64; 2],
-    ) -> Result<f64, CalcError> {
+        integration_limit: &[Self::Scalar; 2],
+    ) -> Result<Self::Scalar, CalcError> {
         self.get(func, &[*integration_limit])
     }
 
     /// Convenience wrapper for a double integral of a single variable function.
-    fn get_double<F: Fn(f64) -> f64>(
+    fn get_double<F: Fn(Self::Scalar) -> Self::Scalar>(
         &self,
         func: &F,
-        integration_limit: &[[f64; 2]; 2],
-    ) -> Result<f64, CalcError> {
+        integration_limit: &[[Self::Scalar; 2]; 2],
+    ) -> Result<Self::Scalar, CalcError> {
         self.get(func, integration_limit)
     }
 }
 
 /// Base trait for multi-variable numerical integration.
 pub trait IntegratorMultiVariable {
+    /// The scalar the integral is computed in.
+    type Scalar: Numeric;
+
     /// Generic n-th partial integration of a multi variable function. The number of
     /// integrations equals the length of `integration_limits`.
     ///
@@ -113,33 +116,43 @@ pub trait IntegratorMultiVariable {
     /// # Errors
     /// [`CalcError::IterationsZero`] if the configured iteration count is zero, or
     /// [`CalcError::IntegrationLimitsIllDefined`] if any limit is ill-defined.
-    fn get<F: Fn(&[f64; NUM_VARS]) -> f64, const NUM_VARS: usize, const NUM_INTEGRATIONS: usize>(
+    fn get<
+        F: Fn(&[Self::Scalar; NUM_VARS]) -> Self::Scalar,
+        const NUM_VARS: usize,
+        const NUM_INTEGRATIONS: usize,
+    >(
         &self,
         idx_to_integrate: [usize; NUM_INTEGRATIONS],
         func: &F,
-        integration_limits: &[[f64; 2]; NUM_INTEGRATIONS],
-        point: &[f64; NUM_VARS],
-    ) -> Result<f64, CalcError>;
+        integration_limits: &[[Self::Scalar; 2]; NUM_INTEGRATIONS],
+        point: &[Self::Scalar; NUM_VARS],
+    ) -> Result<Self::Scalar, CalcError>;
 
     /// Convenience wrapper for a single partial integral of a multi variable function.
-    fn get_single_partial<F: Fn(&[f64; NUM_VARS]) -> f64, const NUM_VARS: usize>(
+    fn get_single_partial<
+        F: Fn(&[Self::Scalar; NUM_VARS]) -> Self::Scalar,
+        const NUM_VARS: usize,
+    >(
         &self,
         func: &F,
         idx_to_integrate: usize,
-        integration_limits: &[f64; 2],
-        point: &[f64; NUM_VARS],
-    ) -> Result<f64, CalcError> {
+        integration_limits: &[Self::Scalar; 2],
+        point: &[Self::Scalar; NUM_VARS],
+    ) -> Result<Self::Scalar, CalcError> {
         self.get([idx_to_integrate], func, &[*integration_limits], point)
     }
 
     /// Convenience wrapper for a double partial integral of a multi variable function.
-    fn get_double_partial<F: Fn(&[f64; NUM_VARS]) -> f64, const NUM_VARS: usize>(
+    fn get_double_partial<
+        F: Fn(&[Self::Scalar; NUM_VARS]) -> Self::Scalar,
+        const NUM_VARS: usize,
+    >(
         &self,
         func: &F,
         idx_to_integrate: [usize; 2],
-        integration_limits: &[[f64; 2]; 2],
-        point: &[f64; NUM_VARS],
-    ) -> Result<f64, CalcError> {
+        integration_limits: &[[Self::Scalar; 2]; 2],
+        point: &[Self::Scalar; NUM_VARS],
+    ) -> Result<Self::Scalar, CalcError> {
         self.get(idx_to_integrate, func, integration_limits, point)
     }
 }

--- a/src/numerical_integration/iterative_integration.rs
+++ b/src/numerical_integration/iterative_integration.rs
@@ -1,3 +1,6 @@
+use core::marker::PhantomData;
+
+use crate::numeric::Numeric;
 use crate::numerical_integration::integrator::*;
 use crate::numerical_integration::mode::IterativeMethod;
 use crate::utils::error_codes::CalcError;
@@ -37,9 +40,9 @@ impl IterativeConfig {
     /// Checks that the iteration count is non-zero and every limit is well-defined.
     /// The iteration count is checked before the limits so a zero count reports
     /// [`CalcError::IterationsZero`] regardless of the limits.
-    fn check_for_errors<const NUM_INTEGRATIONS: usize>(
+    fn check_for_errors<T: Numeric, const NUM_INTEGRATIONS: usize>(
         &self,
-        integration_limit: &[[f64; 2]; NUM_INTEGRATIONS],
+        integration_limit: &[[T; 2]; NUM_INTEGRATIONS],
     ) -> Result<(), CalcError> {
         if self.total_iterations == 0 {
             return Err(CalcError::IterationsZero);
@@ -56,13 +59,13 @@ impl IterativeConfig {
 /// Dispatches to the chosen rule, integrating `g` over `[lo, hi]` with `iterations`
 /// intervals. The caller decides the domain branch before building `g`, so a finite
 /// integral passes `func` straight through with no per-sample transform.
-fn integrate_rule<G: FnMut(f64) -> f64>(
+fn integrate_rule<T: Numeric, G: FnMut(T) -> T>(
     method: IterativeMethod,
     iterations: u64,
-    lo: f64,
-    hi: f64,
+    lo: T,
+    hi: T,
     g: G,
-) -> f64 {
+) -> T {
     match method {
         IterativeMethod::Booles => booles(iterations, lo, hi, g),
         IterativeMethod::Simpsons => simpsons(iterations, lo, hi, g),
@@ -71,102 +74,115 @@ fn integrate_rule<G: FnMut(f64) -> f64>(
 }
 
 /// Boole's composite rule over `[lo, hi]`.
-fn booles<G: FnMut(f64) -> f64>(iterations: u64, lo: f64, hi: f64, mut g: G) -> f64 {
-    let delta = (hi - lo) / iterations as f64;
+fn booles<T: Numeric, G: FnMut(T) -> T>(iterations: u64, lo: T, hi: T, mut g: G) -> T {
+    let delta = (hi - lo) / T::from_u64(iterations);
     let mut point = lo;
 
-    let mut ans = 7.0 * g(point);
-    let mut multiplier = 32.0;
+    let mut ans = T::from_f64(7.0) * g(point);
+    let mut multiplier = T::from_f64(32.0);
 
     for iter in 0..iterations - 1 {
         point += delta;
         ans += multiplier * g(point);
 
         if (iter + 2) % 2 != 0 {
-            multiplier = 32.0;
+            multiplier = T::from_f64(32.0);
         } else if (iter + 2) % 4 == 0 {
-            multiplier = 14.0;
+            multiplier = T::from_f64(14.0);
         } else {
-            multiplier = 12.0;
+            multiplier = T::from_f64(12.0);
         }
     }
 
-    ans += 7.0 * g(hi);
+    ans += T::from_f64(7.0) * g(hi);
 
-    2.0 * delta * ans / 45.0
+    T::TWO * delta * ans / T::from_f64(45.0)
 }
 
 /// Simpson's 3/8 composite rule over `[lo, hi]`.
-fn simpsons<G: FnMut(f64) -> f64>(iterations: u64, lo: f64, hi: f64, mut g: G) -> f64 {
-    let delta = (hi - lo) / iterations as f64;
+fn simpsons<T: Numeric, G: FnMut(T) -> T>(iterations: u64, lo: T, hi: T, mut g: G) -> T {
+    let delta = (hi - lo) / T::from_u64(iterations);
     let mut point = lo;
 
     let mut ans = g(point);
-    let mut multiplier = 3.0;
+    let mut multiplier = T::from_f64(3.0);
 
     for iter in 0..iterations - 1 {
         point += delta;
         ans += multiplier * g(point);
 
         if (iter + 2) % 3 == 0 {
-            multiplier = 2.0;
+            multiplier = T::TWO;
         } else {
-            multiplier = 3.0;
+            multiplier = T::from_f64(3.0);
         }
     }
 
     ans += g(hi);
 
-    3.0 * delta * ans / 8.0
+    T::from_f64(3.0) * delta * ans / T::from_f64(8.0)
 }
 
 /// Trapezoidal composite rule over `[lo, hi]`.
-fn trapezoidal<G: FnMut(f64) -> f64>(iterations: u64, lo: f64, hi: f64, mut g: G) -> f64 {
-    let delta = (hi - lo) / iterations as f64;
+fn trapezoidal<T: Numeric, G: FnMut(T) -> T>(iterations: u64, lo: T, hi: T, mut g: G) -> T {
+    let delta = (hi - lo) / T::from_u64(iterations);
     let mut point = lo;
 
     let mut ans = g(point);
 
     for _ in 0..iterations - 1 {
         point += delta;
-        ans += 2.0 * g(point);
+        ans += T::TWO * g(point);
     }
 
     ans += g(hi);
 
-    0.5 * delta * ans
+    T::HALF * delta * ans
 }
 
 /// Implements the iterative methods for numerical integration for single variable functions
-#[derive(Debug, Clone, Copy, Default)]
-pub struct IterativeSingle {
+#[derive(Debug, Clone, Copy)]
+pub struct IterativeSingle<T = f64> {
     pub config: IterativeConfig,
+    _marker: PhantomData<T>,
 }
 
-impl IterativeSingle {
+impl<T> Default for IterativeSingle<T> {
+    fn default() -> Self {
+        IterativeSingle {
+            config: IterativeConfig::default(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> IterativeSingle<T> {
     /// custom constructor. Optimal for fine-tuning for more complex equations
     pub fn from_parameters(total_iterations: u64, integration_method: IterativeMethod) -> Self {
         IterativeSingle {
             config: IterativeConfig::from_parameters(total_iterations, integration_method),
+            _marker: PhantomData,
         }
     }
+}
 
+impl<T: Numeric> IterativeSingle<T> {
     /// Integrates the `level`-th limit (1-based). Inner folds of a single-variable
     /// integral are constant in the outer variable, so the inner result is computed
     /// once and reused; an infinite outer limit weights it by `dx/dt`. A finite limit
     /// skips the domain transform entirely.
-    fn integrate<F: Fn(f64) -> f64, const NUM_INTEGRATIONS: usize>(
+    fn integrate<F: Fn(T) -> T, const NUM_INTEGRATIONS: usize>(
         &self,
         level: usize,
         func: &F,
-        integration_limit: &[[f64; 2]; NUM_INTEGRATIONS],
-    ) -> f64 {
+        integration_limit: &[[T; 2]; NUM_INTEGRATIONS],
+    ) -> T {
         let method = self.config.integration_method;
         let iterations = self.config.total_iterations;
 
         let domain = match classify(&integration_limit[level - 1]) {
             Ok(d) => d,
-            Err(_) => return f64::NAN, // limits validated in check_for_errors; unreachable
+            Err(_) => return T::NAN, // limits validated in check_for_errors; unreachable
         };
 
         if level == 1 {
@@ -196,7 +212,9 @@ impl IterativeSingle {
     }
 }
 
-impl IntegratorSingleVariable for IterativeSingle {
+impl<T: Numeric> IntegratorSingleVariable for IterativeSingle<T> {
+    type Scalar = T;
+
     /// Integrates `func`, once for each limit in `integration_limit` (so the array length
     /// sets the number of integrations).
     ///
@@ -232,36 +250,49 @@ impl IntegratorSingleVariable for IterativeSingle {
     /// let val = integrator.get(&|x| (-x * x).exp(), &[[f64::NEG_INFINITY, f64::INFINITY]]).unwrap();
     /// assert!(f64::abs(val - std::f64::consts::PI.sqrt()) < 1e-6);
     /// ```
-    fn get<F: Fn(f64) -> f64, const NUM_INTEGRATIONS: usize>(
+    fn get<F: Fn(T) -> T, const NUM_INTEGRATIONS: usize>(
         &self,
         func: &F,
-        integration_limit: &[[f64; 2]; NUM_INTEGRATIONS],
-    ) -> Result<f64, CalcError> {
+        integration_limit: &[[T; 2]; NUM_INTEGRATIONS],
+    ) -> Result<T, CalcError> {
         self.config.check_for_errors(integration_limit)?;
         Ok(self.integrate(NUM_INTEGRATIONS, func, integration_limit))
     }
 }
 
 /// Implements the iterative methods for numerical integration for multi variable functions
-#[derive(Debug, Clone, Copy, Default)]
-pub struct IterativeMulti {
+#[derive(Debug, Clone, Copy)]
+pub struct IterativeMulti<T = f64> {
     pub config: IterativeConfig,
+    _marker: PhantomData<T>,
 }
 
-impl IterativeMulti {
+impl<T> Default for IterativeMulti<T> {
+    fn default() -> Self {
+        IterativeMulti {
+            config: IterativeConfig::default(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> IterativeMulti<T> {
     /// custom constructor, optimal for fine-tuning the integrator for more complex equations
     pub fn from_parameters(total_iterations: u64, integration_method: IterativeMethod) -> Self {
         IterativeMulti {
             config: IterativeConfig::from_parameters(total_iterations, integration_method),
+            _marker: PhantomData,
         }
     }
+}
 
+impl<T: Numeric> IterativeMulti<T> {
     /// Integrates the `level`-th limit (1-based) of a partial integral. The sampled
     /// abscissa is written into the integrated variable's slot before recursing, and
     /// an infinite limit weights the whole inner integral by `dx/dt`. A finite limit
     /// skips the domain transform entirely.
     fn integrate<
-        F: Fn(&[f64; NUM_VARS]) -> f64,
+        F: Fn(&[T; NUM_VARS]) -> T,
         const NUM_VARS: usize,
         const NUM_INTEGRATIONS: usize,
     >(
@@ -269,15 +300,15 @@ impl IterativeMulti {
         level: usize,
         idx_to_integrate: [usize; NUM_INTEGRATIONS],
         func: &F,
-        integration_limits: &[[f64; 2]; NUM_INTEGRATIONS],
-        point: &[f64; NUM_VARS],
-    ) -> f64 {
+        integration_limits: &[[T; 2]; NUM_INTEGRATIONS],
+        point: &[T; NUM_VARS],
+    ) -> T {
         let method = self.config.integration_method;
         let iterations = self.config.total_iterations;
 
         let domain = match classify(&integration_limits[level - 1]) {
             Ok(d) => d,
-            Err(_) => return f64::NAN, // limits validated in check_for_errors; unreachable
+            Err(_) => return T::NAN, // limits validated in check_for_errors; unreachable
         };
         let var = idx_to_integrate[level - 1];
 
@@ -330,7 +361,9 @@ impl IterativeMulti {
     }
 }
 
-impl IntegratorMultiVariable for IterativeMulti {
+impl<T: Numeric> IntegratorMultiVariable for IterativeMulti<T> {
+    type Scalar = T;
+
     /// Partially integrates `func` over the variables in `idx_to_integrate`, once for each
     /// limit in `integration_limits` (so the array length sets the number of integrations).
     ///
@@ -358,13 +391,13 @@ impl IntegratorMultiVariable for IterativeMulti {
     /// let val = integrator.get([0; 1], &func, &[[0.0, 1.0]; 1], &point).unwrap();
     /// assert!(f64::abs(val - 7.0) < 1e-6);
     /// ```
-    fn get<F: Fn(&[f64; NUM_VARS]) -> f64, const NUM_VARS: usize, const NUM_INTEGRATIONS: usize>(
+    fn get<F: Fn(&[T; NUM_VARS]) -> T, const NUM_VARS: usize, const NUM_INTEGRATIONS: usize>(
         &self,
         idx_to_integrate: [usize; NUM_INTEGRATIONS],
         func: &F,
-        integration_limits: &[[f64; 2]; NUM_INTEGRATIONS],
-        point: &[f64; NUM_VARS],
-    ) -> Result<f64, CalcError> {
+        integration_limits: &[[T; 2]; NUM_INTEGRATIONS],
+        point: &[T; NUM_VARS],
+    ) -> Result<T, CalcError> {
         self.config.check_for_errors(integration_limits)?;
         Ok(self.integrate(
             NUM_INTEGRATIONS,

--- a/src/numerical_integration/test.rs
+++ b/src/numerical_integration/test.rs
@@ -517,3 +517,31 @@ fn test_composite_rule_degree_3_polynomial() {
     let val = boole.get_single(&func, &integration_limit).unwrap();
     assert!(f64::abs(val - 4.0) < 1e-9);
 }
+
+#[test]
+fn test_booles_integration_f32() {
+    //2x integrated over [0, 2] is 4
+    let func = |x: f32| -> f32 { 2.0 * x };
+
+    let integrator = iterative_integration::IterativeSingle::<f32>::from_parameters(
+        100,
+        IterativeMethod::Booles,
+    );
+
+    let val = integrator.get_single(&func, &[0.0, 2.0]).unwrap();
+    assert!(f32::abs(val - 4.0) < 1e-3, "got {val}");
+}
+
+#[test]
+fn test_gauss_legendre_integration_f32() {
+    //4x^3 - 3x^2 integrated over [0, 2] is 8
+    let func = |x: f32| -> f32 { 4.0 * x * x * x - 3.0 * x * x };
+
+    let integrator = gaussian_integration::GaussianSingle::<f32>::from_parameters(
+        4,
+        GaussianQuadratureMethod::GaussLegendre,
+    );
+
+    let val = integrator.get_single(&func, &[0.0, 2.0]).unwrap();
+    assert!(f32::abs(val - 8.0) < 1e-2, "got {val}");
+}

--- a/src/vector_field/curl.rs
+++ b/src/vector_field/curl.rs
@@ -1,3 +1,4 @@
+use crate::numeric::Numeric;
 use crate::numerical_derivative::derivator::DerivatorMultiVariable;
 use crate::utils::error_codes::CalcError;
 
@@ -32,10 +33,10 @@ use crate::utils::error_codes::CalcError;
 /// ```
 pub fn get_3d<D: DerivatorMultiVariable, const NUM_VARS: usize>(
     derivator: D,
-    vector_field: &[&dyn Fn(&[f64; NUM_VARS]) -> f64; 3],
-    point: &[f64; NUM_VARS],
-) -> Result<[f64; 3], CalcError> {
-    let mut ans = [0.0; 3];
+    vector_field: &[&dyn Fn(&[D::Scalar; NUM_VARS]) -> D::Scalar; 3],
+    point: &[D::Scalar; NUM_VARS],
+) -> Result<[D::Scalar; 3], CalcError> {
+    let mut ans = [<D::Scalar as Numeric>::ZERO; 3];
 
     ans[0] = derivator.get_single_partial(&vector_field[2], 1, point)?
         - derivator.get_single_partial(&vector_field[1], 2, point)?;
@@ -76,9 +77,9 @@ pub fn get_3d<D: DerivatorMultiVariable, const NUM_VARS: usize>(
 /// ```
 pub fn get_2d<D: DerivatorMultiVariable, const NUM_VARS: usize>(
     derivator: D,
-    vector_field: &[&dyn Fn(&[f64; NUM_VARS]) -> f64; 2],
-    point: &[f64; NUM_VARS],
-) -> Result<f64, CalcError> {
+    vector_field: &[&dyn Fn(&[D::Scalar; NUM_VARS]) -> D::Scalar; 2],
+    point: &[D::Scalar; NUM_VARS],
+) -> Result<D::Scalar, CalcError> {
     Ok(derivator.get_single_partial(&vector_field[1], 0, point)?
         - derivator.get_single_partial(&vector_field[0], 1, point)?)
 }

--- a/src/vector_field/divergence.rs
+++ b/src/vector_field/divergence.rs
@@ -31,9 +31,9 @@ use crate::utils::error_codes::CalcError;
 /// ```
 pub fn get_3d<D: DerivatorMultiVariable, const NUM_VARS: usize>(
     derivator: D,
-    vector_field: &[&dyn Fn(&[f64; NUM_VARS]) -> f64; 3],
-    point: &[f64; NUM_VARS],
-) -> Result<f64, CalcError> {
+    vector_field: &[&dyn Fn(&[D::Scalar; NUM_VARS]) -> D::Scalar; 3],
+    point: &[D::Scalar; NUM_VARS],
+) -> Result<D::Scalar, CalcError> {
     Ok(derivator.get_single_partial(&vector_field[0], 0, point)?
         + derivator.get_single_partial(&vector_field[1], 1, point)?
         + derivator.get_single_partial(&vector_field[2], 2, point)?)
@@ -68,9 +68,9 @@ pub fn get_3d<D: DerivatorMultiVariable, const NUM_VARS: usize>(
 /// ```
 pub fn get_2d<D: DerivatorMultiVariable, const NUM_VARS: usize>(
     derivator: D,
-    vector_field: &[&dyn Fn(&[f64; NUM_VARS]) -> f64; 2],
-    point: &[f64; NUM_VARS],
-) -> Result<f64, CalcError> {
+    vector_field: &[&dyn Fn(&[D::Scalar; NUM_VARS]) -> D::Scalar; 2],
+    point: &[D::Scalar; NUM_VARS],
+) -> Result<D::Scalar, CalcError> {
     Ok(derivator.get_single_partial(&vector_field[0], 0, point)?
         + derivator.get_single_partial(&vector_field[1], 1, point)?)
 }

--- a/src/vector_field/flux_integral.rs
+++ b/src/vector_field/flux_integral.rs
@@ -1,3 +1,4 @@
+use crate::numeric::Numeric;
 use crate::numerical_integration::iterative_integration::DEFAULT_TOTAL_ITERATIONS;
 use crate::utils::error_codes::CalcError;
 
@@ -32,11 +33,11 @@ use crate::vector_field::line_integral;
 /// // the flux integral is 0
 /// assert!(f64::abs(val) < 0.01);
 /// ```
-pub fn get_2d(
-    vector_field: &[&dyn Fn(&[f64; 2]) -> f64; 2],
-    transformations: &[&dyn Fn(f64) -> f64; 2],
-    integration_limit: &[f64; 2],
-) -> Result<f64, CalcError> {
+pub fn get_2d<T: Numeric>(
+    vector_field: &[&dyn Fn(&[T; 2]) -> T; 2],
+    transformations: &[&dyn Fn(T) -> T; 2],
+    integration_limit: &[T; 2],
+) -> Result<T, CalcError> {
     get_2d_custom(
         vector_field,
         transformations,
@@ -51,12 +52,12 @@ pub fn get_2d(
 /// [`CalcError::IterationsZero`] if `total_iterations` is zero, or
 /// [`CalcError::IntegrationLimitsIllDefined`] if the lower limit is not strictly less than the
 /// upper limit.
-pub fn get_2d_custom(
-    vector_field: &[&dyn Fn(&[f64; 2]) -> f64; 2],
-    transformations: &[&dyn Fn(f64) -> f64; 2],
-    integration_limit: &[f64; 2],
+pub fn get_2d_custom<T: Numeric>(
+    vector_field: &[&dyn Fn(&[T; 2]) -> T; 2],
+    transformations: &[&dyn Fn(T) -> T; 2],
+    integration_limit: &[T; 2],
     total_iterations: u64,
-) -> Result<f64, CalcError> {
+) -> Result<T, CalcError> {
     Ok(line_integral::get_partial_2d(
         vector_field,
         transformations,

--- a/src/vector_field/line_integral.rs
+++ b/src/vector_field/line_integral.rs
@@ -1,9 +1,10 @@
+use crate::numeric::Numeric;
 use crate::numerical_integration::iterative_integration::DEFAULT_TOTAL_ITERATIONS;
 use crate::utils::error_codes::CalcError;
 
 /// Builds the curve position [transformations[0](t), ..., transformations[N-1](t)].
-fn curve_point<const N: usize>(transformations: &[&dyn Fn(f64) -> f64; N], t: f64) -> [f64; N] {
-    let mut point = [0.0; N];
+fn curve_point<T: Numeric, const N: usize>(transformations: &[&dyn Fn(T) -> T; N], t: T) -> [T; N] {
+    let mut point = [T::ZERO; N];
     for i in 0..N {
         point[i] = transformations[i](t);
     }
@@ -12,13 +13,13 @@ fn curve_point<const N: usize>(transformations: &[&dyn Fn(f64) -> f64; N], t: f6
 
 /// Trapezoidal integration of the `idx`-th field component along the parametrized curve.
 /// Generic over the dimension `N`, so the 2D and 3D paths share one body.
-fn get_partial<const N: usize>(
-    vector_field: &[&dyn Fn(&[f64; N]) -> f64; N],
-    transformations: &[&dyn Fn(f64) -> f64; N],
-    integration_limit: &[f64; 2],
+fn get_partial<T: Numeric, const N: usize>(
+    vector_field: &[&dyn Fn(&[T; N]) -> T; N],
+    transformations: &[&dyn Fn(T) -> T; N],
+    integration_limit: &[T; 2],
     total_iterations: u64,
     idx: usize,
-) -> Result<f64, CalcError> {
+) -> Result<T, CalcError> {
     if total_iterations == 0 {
         return Err(CalcError::IterationsZero);
     }
@@ -30,9 +31,9 @@ fn get_partial<const N: usize>(
         return Err(CalcError::IntegrationLimitsIllDefined);
     }
 
-    let delta = (integration_limit[1] - integration_limit[0]) / total_iterations as f64;
+    let delta = (integration_limit[1] - integration_limit[0]) / T::from_u64(total_iterations);
     let mut t = integration_limit[0];
-    let mut ans = 0.0;
+    let mut ans = T::ZERO;
 
     //use the trapezoidal rule for line integrals, caching the shared endpoint so each
     //curve point and field value is evaluated once per node rather than twice
@@ -44,7 +45,7 @@ fn get_partial<const N: usize>(
         let right = curve_point(transformations, t + delta);
         let right_value = vector_field[idx](&right);
 
-        ans += (right[idx] - left[idx]) * (left_value + right_value) / 2.0;
+        ans += (right[idx] - left[idx]) * (left_value + right_value) / T::TWO;
 
         t += delta;
         left = right;
@@ -83,11 +84,11 @@ fn get_partial<const N: usize>(
 /// // the line integral is -2*pi
 /// assert!(f64::abs(val + 6.28) < 0.01);
 /// ```
-pub fn get_2d(
-    vector_field: &[&dyn Fn(&[f64; 2]) -> f64; 2],
-    transformations: &[&dyn Fn(f64) -> f64; 2],
-    integration_limit: &[f64; 2],
-) -> Result<f64, CalcError> {
+pub fn get_2d<T: Numeric>(
+    vector_field: &[&dyn Fn(&[T; 2]) -> T; 2],
+    transformations: &[&dyn Fn(T) -> T; 2],
+    integration_limit: &[T; 2],
+) -> Result<T, CalcError> {
     get_2d_custom(
         vector_field,
         transformations,
@@ -102,12 +103,12 @@ pub fn get_2d(
 /// [`CalcError::IterationsZero`] if `total_iterations` is zero, or
 /// [`CalcError::IntegrationLimitsIllDefined`] if the lower limit is not strictly less than the
 /// upper limit.
-pub fn get_2d_custom(
-    vector_field: &[&dyn Fn(&[f64; 2]) -> f64; 2],
-    transformations: &[&dyn Fn(f64) -> f64; 2],
-    integration_limit: &[f64; 2],
+pub fn get_2d_custom<T: Numeric>(
+    vector_field: &[&dyn Fn(&[T; 2]) -> T; 2],
+    transformations: &[&dyn Fn(T) -> T; 2],
+    integration_limit: &[T; 2],
     total_iterations: u64,
-) -> Result<f64, CalcError> {
+) -> Result<T, CalcError> {
     Ok(get_partial_2d(
         vector_field,
         transformations,
@@ -130,13 +131,13 @@ pub fn get_2d_custom(
 /// [`CalcError::IterationsZero`] if `total_iterations` is zero, or
 /// [`CalcError::IntegrationLimitsIllDefined`] if the lower limit is not strictly less than the
 /// upper limit.
-pub fn get_partial_2d(
-    vector_field: &[&dyn Fn(&[f64; 2]) -> f64; 2],
-    transformations: &[&dyn Fn(f64) -> f64; 2],
-    integration_limit: &[f64; 2],
+pub fn get_partial_2d<T: Numeric>(
+    vector_field: &[&dyn Fn(&[T; 2]) -> T; 2],
+    transformations: &[&dyn Fn(T) -> T; 2],
+    integration_limit: &[T; 2],
     total_iterations: u64,
     idx: usize,
-) -> Result<f64, CalcError> {
+) -> Result<T, CalcError> {
     get_partial(
         vector_field,
         transformations,
@@ -152,11 +153,11 @@ pub fn get_partial_2d(
 /// # Errors
 /// [`CalcError::IntegrationLimitsIllDefined`] if the lower limit is not strictly less than the
 /// upper limit.
-pub fn get_3d(
-    vector_field: &[&dyn Fn(&[f64; 3]) -> f64; 3],
-    transformations: &[&dyn Fn(f64) -> f64; 3],
-    integration_limit: &[f64; 2],
-) -> Result<f64, CalcError> {
+pub fn get_3d<T: Numeric>(
+    vector_field: &[&dyn Fn(&[T; 3]) -> T; 3],
+    transformations: &[&dyn Fn(T) -> T; 3],
+    integration_limit: &[T; 2],
+) -> Result<T, CalcError> {
     get_3d_custom(
         vector_field,
         transformations,
@@ -171,12 +172,12 @@ pub fn get_3d(
 /// [`CalcError::IterationsZero`] if `total_iterations` is zero, or
 /// [`CalcError::IntegrationLimitsIllDefined`] if the lower limit is not strictly less than the
 /// upper limit.
-pub fn get_3d_custom(
-    vector_field: &[&dyn Fn(&[f64; 3]) -> f64; 3],
-    transformations: &[&dyn Fn(f64) -> f64; 3],
-    integration_limit: &[f64; 2],
+pub fn get_3d_custom<T: Numeric>(
+    vector_field: &[&dyn Fn(&[T; 3]) -> T; 3],
+    transformations: &[&dyn Fn(T) -> T; 3],
+    integration_limit: &[T; 2],
     total_iterations: u64,
-) -> Result<f64, CalcError> {
+) -> Result<T, CalcError> {
     Ok(get_partial_3d(
         vector_field,
         transformations,
@@ -205,13 +206,13 @@ pub fn get_3d_custom(
 /// [`CalcError::IterationsZero`] if `total_iterations` is zero, or
 /// [`CalcError::IntegrationLimitsIllDefined`] if the lower limit is not strictly less than the
 /// upper limit.
-pub fn get_partial_3d(
-    vector_field: &[&dyn Fn(&[f64; 3]) -> f64; 3],
-    transformations: &[&dyn Fn(f64) -> f64; 3],
-    integration_limit: &[f64; 2],
+pub fn get_partial_3d<T: Numeric>(
+    vector_field: &[&dyn Fn(&[T; 3]) -> T; 3],
+    transformations: &[&dyn Fn(T) -> T; 3],
+    integration_limit: &[T; 2],
     total_iterations: u64,
     idx: usize,
-) -> Result<f64, CalcError> {
+) -> Result<T, CalcError> {
     get_partial(
         vector_field,
         transformations,

--- a/src/vector_field/test.rs
+++ b/src/vector_field/test.rs
@@ -1,4 +1,5 @@
 use crate::numerical_derivative::finite_difference::FiniteDifferenceMulti;
+use crate::numerical_derivative::mode::FiniteDifferenceMode;
 
 use crate::vector_field::curl;
 use crate::vector_field::divergence;
@@ -265,4 +266,22 @@ fn test_line_integral_negative_limits() {
     .unwrap();
 
     assert!(f64::abs(val - (-3.0)) < 1e-9);
+}
+
+#[test]
+fn test_divergence_3d_f32() {
+    //field (y, -x, 2z); divergence is 0 + 0 + 2 = 2
+    let vf_x = |args: &[f32; 3]| -> f32 { args[1] };
+    let vf_y = |args: &[f32; 3]| -> f32 { -args[0] };
+    let vf_z = |args: &[f32; 3]| -> f32 { 2.0 * args[2] };
+
+    let vector_field_matrix: [&dyn Fn(&[f32; 3]) -> f32; 3] = [&vf_x, &vf_y, &vf_z];
+    let point = [0.0, 1.0, 3.0];
+
+    //a larger step suits f32; the default 1e-5 cancels badly at single precision
+    let derivator =
+        FiniteDifferenceMulti::<f32>::from_parameters(0.01, FiniteDifferenceMode::Central, 10.0);
+
+    let val = divergence::get_3d(derivator, &vector_field_matrix, &point).unwrap();
+    assert!(f32::abs(val - 2.0) < 1e-2, "got {val}");
 }


### PR DESCRIPTION
Made the differentiation, integration, approximation, and vector-field modules generic over a new Numeric trait (in src/numeric.rs) that wraps the libm float ops, so the crate now works with both f32 and f64 while defaulting to f64.

Addresses https://github.com/kmolan/multicalc-rust/issues/9