### PR TITLE
feature/benchmark_naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Benchmark suites are unified under a single `benchmarks` target: use criterion
+  substring filters (`cargo bench -- linear_algebra`) instead of `--bench <suite>`. 
+  @rtmongold
+
 ## [0.7.0] - 2026-07-06
 
 A feature release adding automatic differentiation, a linear-algebra core, nonlinear

--- a/crates/multicalc/Cargo.toml
+++ b/crates/multicalc/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/multicalc"
 readme = "README.md"
 keywords = ["Math", "Science", "Calculus", "Differentiation", "Integration"]
 categories = ["mathematics", "science", "no-std"]
+autobenches = false
 
 [dependencies]
 libm = "0.2"
@@ -24,19 +25,7 @@ default = []
 alloc = []
 
 [[bench]]
-name = "calculus"
-harness = false
-
-[[bench]]
-name = "linear_algebra"
-harness = false
-
-[[bench]]
-name = "optimization"
-harness = false
-
-[[bench]]
-name = "root_finding"
+name = "benchmarks"
 harness = false
 
 [lints]

--- a/crates/multicalc/benches/README.md
+++ b/crates/multicalc/benches/README.md
@@ -19,7 +19,8 @@ report accuracy (how close the result lands to the known value). The examples in
 
 ```sh
 cargo bench                       # all suites
-cargo bench --bench calculus      # one suite
+cargo bench -- calculus           # one suite (criterion group filter)
+cargo bench -- derivative         # one benchmark family within calculus
 ```
 
 Each suite sets a criterion sample size of 50, a 500 ms warm-up, and a 2 s measurement window.

--- a/crates/multicalc/benches/benchmarks.rs
+++ b/crates/multicalc/benches/benchmarks.rs
@@ -1,0 +1,13 @@
+use criterion::criterion_main;
+
+mod calculus;
+mod linear_algebra;
+mod optimization;
+mod root_finding;
+
+criterion_main!(
+    calculus::calculus_benches,
+    linear_algebra::linear_algebra_benches,
+    optimization::optimization_benches,
+    root_finding::root_finding_benches,
+);

--- a/crates/multicalc/benches/calculus.md
+++ b/crates/multicalc/benches/calculus.md
@@ -1,6 +1,6 @@
 # Calculus benchmarks
 
-Results for the [`calculus`](calculus.rs) suite (`cargo bench --bench calculus`). The accuracy
+Results for the [`calculus`](calculus.rs) suite (`cargo bench -- calculus`). The accuracy
 tables report approximation error against the analytic value; the latency tables report
 wall-clock medians on the machine noted in [README.md](README.md). See that index for how the
 suites fit together and how to run them.

--- a/crates/multicalc/benches/calculus.rs
+++ b/crates/multicalc/benches/calculus.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, black_box, criterion_group};
 
 use multicalc::approximation::linear_approximation::LinearApproximator;
 use multicalc::approximation::quadratic_approximation::QuadraticApproximator;
@@ -23,13 +23,13 @@ fn differentiation(crit: &mut Criterion) {
     let cube = scalar_fn!(|x| x * x * x);
     let derivator: AutoDiffSingle = AutoDiffSingle::default();
 
-    crit.bench_function("derivative/single_order_1", |b| {
+    crit.bench_function("calculus/derivative/single_order_1", |b| {
         b.iter(|| derivator.get(black_box(1), &cube, black_box(2.0)).unwrap())
     });
-    crit.bench_function("derivative/single_order_2", |b| {
+    crit.bench_function("calculus/derivative/single_order_2", |b| {
         b.iter(|| derivator.get(black_box(2), &cube, black_box(2.0)).unwrap())
     });
-    crit.bench_function("derivative/single_order_3", |b| {
+    crit.bench_function("calculus/derivative/single_order_3", |b| {
         b.iter(|| derivator.get(black_box(3), &cube, black_box(2.0)).unwrap())
     });
 
@@ -39,21 +39,21 @@ fn differentiation(crit: &mut Criterion) {
         scalar_fn!(|a: &[f64; 3]| a[1] * a[0].sin() + a[0] * a[1].cos() + a[0] * a[1] * a[2].exp());
     let point = [1.0, 2.0, 3.0];
 
-    crit.bench_function("derivative/multi_single_partial", |b| {
+    crit.bench_function("calculus/derivative/multi_single_partial", |b| {
         b.iter(|| {
             multi
                 .get_single_partial(&func, black_box(0), black_box(&point))
                 .unwrap()
         })
     });
-    crit.bench_function("derivative/multi_mixed_partial_2", |b| {
+    crit.bench_function("calculus/derivative/multi_mixed_partial_2", |b| {
         b.iter(|| {
             multi
                 .get(&func, black_box(&[0usize, 1]), black_box(&point))
                 .unwrap()
         })
     });
-    crit.bench_function("derivative/multi_mixed_partial_3", |b| {
+    crit.bench_function("calculus/derivative/multi_mixed_partial_3", |b| {
         b.iter(|| {
             multi
                 .get(&func, black_box(&[0usize, 1, 2]), black_box(&point))
@@ -71,13 +71,13 @@ fn iterative_integration(crit: &mut Criterion) {
     let trapezoidal = IterativeSingle::from_parameters(120, IterativeMethod::Trapezoidal);
 
     let finite = [0.0, 2.0];
-    crit.bench_function("iterative/boole_single", |b| {
+    crit.bench_function("calculus/iterative/boole_single", |b| {
         b.iter(|| boole.get_single(&poly, black_box(&finite)).unwrap())
     });
-    crit.bench_function("iterative/simpson_single", |b| {
+    crit.bench_function("calculus/iterative/simpson_single", |b| {
         b.iter(|| simpson.get_single(&poly, black_box(&finite)).unwrap())
     });
-    crit.bench_function("iterative/trapezoidal_single", |b| {
+    crit.bench_function("calculus/iterative/trapezoidal_single", |b| {
         b.iter(|| trapezoidal.get_single(&poly, black_box(&finite)).unwrap())
     });
 
@@ -85,15 +85,15 @@ fn iterative_integration(crit: &mut Criterion) {
     // be paid only on the infinite domain (the finite fast path)
     let finite_decay = [-5.0, 5.0];
     let infinite = [f64::NEG_INFINITY, f64::INFINITY];
-    crit.bench_function("iterative/boole_decay_finite", |b| {
+    crit.bench_function("calculus/iterative/boole_decay_finite", |b| {
         b.iter(|| boole.get_single(&decay, black_box(&finite_decay)).unwrap())
     });
-    crit.bench_function("iterative/boole_decay_infinite", |b| {
+    crit.bench_function("calculus/iterative/boole_decay_infinite", |b| {
         b.iter(|| boole.get_single(&decay, black_box(&infinite)).unwrap())
     });
 
     let double = [[0.0, 1.0], [0.0, 1.0]];
-    crit.bench_function("iterative/boole_double_fold", |b| {
+    crit.bench_function("calculus/iterative/boole_double_fold", |b| {
         b.iter(|| boole.get(&poly, black_box(&double)).unwrap())
     });
 }
@@ -105,16 +105,16 @@ fn gaussian_integration(crit: &mut Criterion) {
     let legendre_4 = GaussianSingle::from_parameters(4, GaussianQuadratureMethod::GaussLegendre);
     let legendre_16 = GaussianSingle::from_parameters(16, GaussianQuadratureMethod::GaussLegendre);
     let finite = [0.0, 2.0];
-    crit.bench_function("gaussian/legendre_order_4", |b| {
+    crit.bench_function("calculus/gaussian/legendre_order_4", |b| {
         b.iter(|| legendre_4.get_single(&poly, black_box(&finite)).unwrap())
     });
-    crit.bench_function("gaussian/legendre_order_16", |b| {
+    crit.bench_function("calculus/gaussian/legendre_order_16", |b| {
         b.iter(|| legendre_16.get_single(&poly, black_box(&finite)).unwrap())
     });
 
     let hermite = GaussianSingle::from_parameters(5, GaussianQuadratureMethod::GaussHermite);
     let hermite_limit = [f64::NEG_INFINITY, f64::INFINITY];
-    crit.bench_function("gaussian/hermite_order_5", |b| {
+    crit.bench_function("calculus/gaussian/hermite_order_5", |b| {
         b.iter(|| {
             hermite
                 .get_single(&square, black_box(&hermite_limit))
@@ -124,7 +124,7 @@ fn gaussian_integration(crit: &mut Criterion) {
 
     let laguerre = GaussianSingle::from_parameters(5, GaussianQuadratureMethod::GaussLaguerre);
     let laguerre_limit = [0.0, f64::INFINITY];
-    crit.bench_function("gaussian/laguerre_order_5", |b| {
+    crit.bench_function("calculus/gaussian/laguerre_order_5", |b| {
         b.iter(|| {
             laguerre
                 .get_single(&square, black_box(&laguerre_limit))
@@ -138,14 +138,14 @@ fn jacobian_hessian(crit: &mut Criterion) {
     let point = [1.0, 2.0, 3.0];
 
     let jacobian: Jacobian = Jacobian::default();
-    crit.bench_function("jacobian/2_funcs_3_vars", |b| {
+    crit.bench_function("calculus/jacobian/2_funcs_3_vars", |b| {
         b.iter(|| jacobian.get(&f, black_box(&point)).unwrap())
     });
 
     let func =
         scalar_fn!(|a: &[f64; 3]| a[1] * a[0].sin() + c(2.0) * a[0] * a[1].exp() + a[2] * a[2]);
     let hessian: Hessian = Hessian::default();
-    crit.bench_function("hessian/3_vars", |b| {
+    crit.bench_function("calculus/hessian/3_vars", |b| {
         b.iter(|| hessian.get(&func, black_box(&point)).unwrap())
     });
 }
@@ -154,10 +154,10 @@ fn vector_field(crit: &mut Criterion) {
     let field = scalar_fn_vec!(|a: &[f64; 3]| [a[1], -a[0], c(2.0) * a[2]]);
     let point = [1.0, 2.0, 3.0];
 
-    crit.bench_function("vector_field/curl_3d", |b| {
+    crit.bench_function("calculus/vector_field/curl_3d", |b| {
         b.iter(|| curl::get_3d(AutoDiffMulti::default(), &field, black_box(&point)).unwrap())
     });
-    crit.bench_function("vector_field/divergence_3d", |b| {
+    crit.bench_function("calculus/vector_field/divergence_3d", |b| {
         b.iter(|| divergence::get_3d(AutoDiffMulti::default(), &field, black_box(&point)).unwrap())
     });
 
@@ -167,7 +167,7 @@ fn vector_field(crit: &mut Criterion) {
     let transforms: [&dyn Fn(f64) -> f64; 2] = [&(|t: f64| t.cos()), &(|t: f64| t.sin())];
     let limit = [0.0, std::f64::consts::TAU];
 
-    crit.bench_function("vector_field/line_integral_2d", |b| {
+    crit.bench_function("calculus/vector_field/line_integral_2d", |b| {
         b.iter(|| {
             line_integral::get_2d(
                 black_box(&line_field),
@@ -177,7 +177,7 @@ fn vector_field(crit: &mut Criterion) {
             .unwrap()
         })
     });
-    crit.bench_function("vector_field/flux_integral_2d", |b| {
+    crit.bench_function("calculus/vector_field/flux_integral_2d", |b| {
         b.iter(|| {
             flux_integral::get_2d(
                 black_box(&line_field),
@@ -194,26 +194,26 @@ fn approximation(crit: &mut Criterion) {
     let point = [1.0, 2.0, 3.0];
 
     let linear = LinearApproximator::<AutoDiffMulti>::default();
-    crit.bench_function("approximation/linear_build", |b| {
+    crit.bench_function("calculus/approximation/linear_build", |b| {
         b.iter(|| linear.get(&func, black_box(&point)).unwrap())
     });
     let linear_result = linear.get(&func, &point).unwrap();
-    crit.bench_function("approximation/linear_predict", |b| {
+    crit.bench_function("calculus/approximation/linear_predict", |b| {
         b.iter(|| linear_result.predict(black_box(&point)))
     });
 
     let quadratic = QuadraticApproximator::<AutoDiffMulti>::default();
-    crit.bench_function("approximation/quadratic_build", |b| {
+    crit.bench_function("calculus/approximation/quadratic_build", |b| {
         b.iter(|| quadratic.get(&func, black_box(&point)).unwrap())
     });
     let quadratic_result = quadratic.get(&func, &point).unwrap();
-    crit.bench_function("approximation/quadratic_predict", |b| {
+    crit.bench_function("calculus/approximation/quadratic_predict", |b| {
         b.iter(|| quadratic_result.predict(black_box(&point)))
     });
 }
 
 criterion_group! {
-    name = benches;
+    name = calculus_benches;
     config = Criterion::default()
         .sample_size(50)
         .warm_up_time(Duration::from_millis(500))
@@ -226,4 +226,3 @@ criterion_group! {
         vector_field,
         approximation
 }
-criterion_main!(benches);

--- a/crates/multicalc/benches/linear_algebra.md
+++ b/crates/multicalc/benches/linear_algebra.md
@@ -1,7 +1,7 @@
 # Linear algebra benchmarks
 
 Results for the [`linear_algebra`](linear_algebra.rs) suite
-(`cargo bench --bench linear_algebra`). The accuracy tables report approximation error
+(`cargo bench -- linear_algebra`). The accuracy tables report approximation error
 (reconstruction, solve residual, identity, and Moore–Penrose conditions); the latency tables
 report wall-clock medians on the machine noted in [README.md](README.md).
 

--- a/crates/multicalc/benches/linear_algebra.rs
+++ b/crates/multicalc/benches/linear_algebra.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, black_box, criterion_group};
 
 use multicalc::linear_algebra::{Matrix, PivotedQr, Vector};
 
@@ -13,21 +13,25 @@ fn vector(crit: &mut Criterion) {
     let p: Vector<2> = Vector::new([1.0, 2.0]);
     let q: Vector<2> = Vector::new([3.0, 4.0]);
 
-    crit.bench_function("vector/dot_3", |b| {
+    crit.bench_function("linear_algebra/vector/dot_3", |b| {
         b.iter(|| black_box(u).dot(black_box(v)))
     });
-    crit.bench_function("vector/cross_3", |b| {
+    crit.bench_function("linear_algebra/vector/cross_3", |b| {
         b.iter(|| black_box(u).cross(black_box(v)))
     });
-    crit.bench_function("vector/cross_2d", |b| {
+    crit.bench_function("linear_algebra/vector/cross_2d", |b| {
         b.iter(|| black_box(p).cross(black_box(q)))
     });
-    crit.bench_function("vector/scalar_triple_3", |b| {
+    crit.bench_function("linear_algebra/vector/scalar_triple_3", |b| {
         b.iter(|| black_box(u).scalar_triple(black_box(v), black_box(w)))
     });
-    crit.bench_function("vector/norm_3", |b| b.iter(|| black_box(u).norm()));
-    crit.bench_function("vector/add_3", |b| b.iter(|| black_box(u) + black_box(v)));
-    crit.bench_function("vector/scale_3", |b| {
+    crit.bench_function("linear_algebra/vector/norm_3", |b| {
+        b.iter(|| black_box(u).norm())
+    });
+    crit.bench_function("linear_algebra/vector/add_3", |b| {
+        b.iter(|| black_box(u) + black_box(v))
+    });
+    crit.bench_function("linear_algebra/vector/scale_3", |b| {
         b.iter(|| black_box(u) * black_box(2.0))
     });
 }
@@ -45,26 +49,28 @@ fn matrix(crit: &mut Criterion) {
     ]);
     let v: Vector<3> = Vector::new([1.0, 2.0, 3.0]);
 
-    crit.bench_function("matrix/matmul_3x3", |b| {
+    crit.bench_function("linear_algebra/matrix/matmul_3x3", |b| {
         b.iter(|| black_box(a) * black_box(b3))
     });
-    crit.bench_function("matrix/matmul_4x4", |b| {
+    crit.bench_function("linear_algebra/matrix/matmul_4x4", |b| {
         b.iter(|| black_box(a4) * black_box(b4))
     });
-    crit.bench_function("matrix/mat_vec_3x3", |b| {
+    crit.bench_function("linear_algebra/matrix/mat_vec_3x3", |b| {
         b.iter(|| black_box(a) * black_box(v))
     });
-    crit.bench_function("matrix/transpose_3x3", |b| {
+    crit.bench_function("linear_algebra/matrix/transpose_3x3", |b| {
         b.iter(|| black_box(a).transpose())
     });
-    crit.bench_function("matrix/add_3x3", |b| {
+    crit.bench_function("linear_algebra/matrix/add_3x3", |b| {
         b.iter(|| black_box(a) + black_box(b3))
     });
-    crit.bench_function("matrix/determinant_3x3", |b| {
+    crit.bench_function("linear_algebra/matrix/determinant_3x3", |b| {
         b.iter(|| black_box(a).determinant())
     });
-    crit.bench_function("matrix/inverse_3x3", |b| b.iter(|| black_box(a).inverse()));
-    crit.bench_function("matrix/inverse_4x4", |b| {
+    crit.bench_function("linear_algebra/matrix/inverse_3x3", |b| {
+        b.iter(|| black_box(a).inverse())
+    });
+    crit.bench_function("linear_algebra/matrix/inverse_4x4", |b| {
         b.iter(|| black_box(inv4).inverse())
     });
 }
@@ -81,13 +87,13 @@ fn lu(crit: &mut Criterion) {
     });
     let b8: Vector<8> = Vector::from_fn(|i| (i + 1) as f64);
 
-    crit.bench_function("lu/decompose_4x4", |b| {
+    crit.bench_function("linear_algebra/lu/decompose_4x4", |b| {
         b.iter(|| black_box(a4).lu().unwrap())
     });
-    crit.bench_function("lu/decompose_8x8", |b| {
+    crit.bench_function("linear_algebra/lu/decompose_8x8", |b| {
         b.iter(|| black_box(a8).lu().unwrap())
     });
-    crit.bench_function("lu/decompose_solve_8x8", |b| {
+    crit.bench_function("linear_algebra/lu/decompose_solve_8x8", |b| {
         b.iter(|| black_box(a8).lu().unwrap().solve(black_box(b8)))
     });
 }
@@ -98,13 +104,13 @@ fn cholesky(crit: &mut Criterion) {
     let a8: Matrix<8, 8> = Matrix::from_fn(|i, j| if i == j { 9.0 } else { 1.0 });
     let b8: Vector<8> = Vector::from_fn(|i| (i + 1) as f64);
 
-    crit.bench_function("cholesky/decompose_4x4", |b| {
+    crit.bench_function("linear_algebra/cholesky/decompose_4x4", |b| {
         b.iter(|| black_box(a4).cholesky().unwrap())
     });
-    crit.bench_function("cholesky/decompose_8x8", |b| {
+    crit.bench_function("linear_algebra/cholesky/decompose_8x8", |b| {
         b.iter(|| black_box(a8).cholesky().unwrap())
     });
-    crit.bench_function("cholesky/decompose_solve_8x8", |b| {
+    crit.bench_function("linear_algebra/cholesky/decompose_solve_8x8", |b| {
         b.iter(|| black_box(a8).cholesky().unwrap().solve(black_box(b8)))
     });
 }
@@ -117,7 +123,7 @@ fn qr(crit: &mut Criterion) {
         (0..j).fold(1.0, |acc, _| acc * t)
     });
     let vb = vandermonde * Vector::new([0.5, -1.2, 2.0, 0.3, -0.8, 1.1, -0.4]);
-    crit.bench_function("qr/vandermonde_20x7_solve", |b| {
+    crit.bench_function("linear_algebra/qr/vandermonde_20x7_solve", |b| {
         b.iter(|| {
             PivotedQr::decompose(black_box(vandermonde))
                 .unwrap()
@@ -128,7 +134,7 @@ fn qr(crit: &mut Criterion) {
 
     // Factorization of the famously ill-conditioned 8x8 Hilbert matrix.
     let hilbert = Matrix::<8, 8>::from_fn(|i, j| 1.0 / ((i + j + 1) as f64));
-    crit.bench_function("qr/hilbert_8x8_decompose", |b| {
+    crit.bench_function("linear_algebra/qr/hilbert_8x8_decompose", |b| {
         b.iter(|| PivotedQr::decompose(black_box(hilbert)).unwrap())
     });
 
@@ -139,7 +145,7 @@ fn qr(crit: &mut Criterion) {
         (0..j).fold(1.0, |acc, _| acc * t)
     });
     let rb = design * Vector::new([0.4, 1.0, -0.6, 0.9, -1.3, 0.5, 0.7, -0.2]);
-    crit.bench_function("qr/ridge_15x8_damped_solve", |b| {
+    crit.bench_function("linear_algebra/qr/ridge_15x8_damped_solve", |b| {
         b.iter(|| {
             PivotedQr::decompose(black_box(design))
                 .unwrap()
@@ -172,16 +178,16 @@ fn svd(crit: &mut Criterion) {
         (0..j).fold(1.0, |acc, _| acc * t)
     });
 
-    crit.bench_function("svd/decompose_3x3", |b| {
+    crit.bench_function("linear_algebra/svd/decompose_3x3", |b| {
         b.iter(|| black_box(a3).svd().unwrap())
     });
-    crit.bench_function("svd/decompose_6x6", |b| {
+    crit.bench_function("linear_algebra/svd/decompose_6x6", |b| {
         b.iter(|| black_box(a6).svd().unwrap())
     });
-    crit.bench_function("svd/decompose_8x8", |b| {
+    crit.bench_function("linear_algebra/svd/decompose_8x8", |b| {
         b.iter(|| black_box(a8).svd().unwrap())
     });
-    crit.bench_function("svd/decompose_12x6", |b| {
+    crit.bench_function("linear_algebra/svd/decompose_12x6", |b| {
         b.iter(|| black_box(tall).svd().unwrap())
     });
 
@@ -201,20 +207,19 @@ fn svd(crit: &mut Criterion) {
         }
     });
 
-    crit.bench_function("svd/pseudo_inverse_6x6", |b| {
+    crit.bench_function("linear_algebra/svd/pseudo_inverse_6x6", |b| {
         b.iter(|| black_box(j6).pseudo_inverse().unwrap())
     });
-    crit.bench_function("svd/pseudo_inverse_6x7", |b| {
+    crit.bench_function("linear_algebra/svd/pseudo_inverse_6x7", |b| {
         b.iter(|| black_box(j67).pseudo_inverse().unwrap())
     });
 }
 
 criterion_group! {
-    name = benches;
+    name = linear_algebra_benches;
     config = Criterion::default()
         .sample_size(50)
         .warm_up_time(Duration::from_millis(500))
         .measurement_time(Duration::from_secs(2));
     targets = vector, matrix, qr, lu, cholesky, svd
 }
-criterion_main!(benches);

--- a/crates/multicalc/benches/optimization.md
+++ b/crates/multicalc/benches/optimization.md
@@ -1,6 +1,6 @@
 # Optimization benchmarks
 
-Results for the [`optimization`](optimization.rs) suite (`cargo bench --bench optimization`).
+Results for the [`optimization`](optimization.rs) suite (`cargo bench -- optimization`).
 The accuracy table reports how close each solver lands to the known solution; the latency table
 reports wall-clock medians on the machine noted in [README.md](README.md).
 

--- a/crates/multicalc/benches/optimization.rs
+++ b/crates/multicalc/benches/optimization.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, black_box, criterion_group};
 
 use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
 use multicalc::optimization::{GaussNewton, LevenbergMarquardt};
@@ -70,7 +70,7 @@ impl VectorFn<3, 40> for CircleFit {
 
 fn levenberg_marquardt(crit: &mut Criterion) {
     let rosenbrock = scalar_fn_vec!(|v: &[f64; 2]| [c(10.0) * (v[1] - v[0] * v[0]), c(1.0) - v[0]]);
-    crit.bench_function("lm/rosenbrock", |b| {
+    crit.bench_function("optimization/lm/rosenbrock", |b| {
         b.iter(|| {
             LevenbergMarquardt::<AutoDiffMulti>::default()
                 .minimize(black_box(&rosenbrock), black_box(&[-1.2, 1.0]))
@@ -84,7 +84,7 @@ fn levenberg_marquardt(crit: &mut Criterion) {
         c(-50.0) + v[0] * v[1].exp(),
         c(-25.0) + v[0] * (c(2.0) * v[1]).exp(),
     ]);
-    crit.bench_function("lm/exponential_decay", |b| {
+    crit.bench_function("optimization/lm/exponential_decay", |b| {
         b.iter(|| {
             LevenbergMarquardt::<AutoDiffMulti>::default()
                 .minimize(black_box(&decay), black_box(&[80.0, -0.3]))
@@ -100,7 +100,7 @@ fn levenberg_marquardt(crit: &mut Criterion) {
     let start = [
         1.15, 0.55, 2.05, 0.2, 0.6, 0.18, 5.08, 1.2, 1.45, 0.72, 8.42, -0.65,
     ];
-    crit.bench_function("lm/damped_sinusoids_12p", |b| {
+    crit.bench_function("optimization/lm/damped_sinusoids_12p", |b| {
         b.iter(|| {
             LevenbergMarquardt::<AutoDiffMulti>::default()
                 .minimize(black_box(&sinusoids), black_box(&start))
@@ -109,7 +109,7 @@ fn levenberg_marquardt(crit: &mut Criterion) {
     });
 
     // 6-variable MGH trigonometric function to its global minimum.
-    crit.bench_function("lm/trigonometric_6v", |b| {
+    crit.bench_function("optimization/lm/trigonometric_6v", |b| {
         b.iter(|| {
             LevenbergMarquardt::<AutoDiffMulti>::default()
                 .minimize(black_box(&Trigonometric::<6>), black_box(&[1.0 / 6.0; 6]))
@@ -125,7 +125,7 @@ fn gauss_newton(crit: &mut Criterion) {
         c(-3.0) + v[0] + v[1],
         c(-5.0) + c(2.0) * v[0] + v[1],
     ]);
-    crit.bench_function("gn/linear_least_squares", |b| {
+    crit.bench_function("optimization/gn/linear_least_squares", |b| {
         b.iter(|| {
             GaussNewton::<AutoDiffMulti>::default()
                 .minimize(black_box(&linear), black_box(&[0.0, 0.0]))
@@ -134,7 +134,7 @@ fn gauss_newton(crit: &mut Criterion) {
     });
 
     let rosenbrock = scalar_fn_vec!(|v: &[f64; 2]| [c(10.0) * (v[1] - v[0] * v[0]), c(1.0) - v[0]]);
-    crit.bench_function("gn/rosenbrock", |b| {
+    crit.bench_function("optimization/gn/rosenbrock", |b| {
         b.iter(|| {
             GaussNewton::<AutoDiffMulti>::default()
                 .minimize(black_box(&rosenbrock), black_box(&[0.9, 0.9]))
@@ -147,7 +147,7 @@ fn gauss_newton(crit: &mut Criterion) {
     let px = core::array::from_fn(|i| 2.0 + 3.0 * angle(i).cos());
     let py = core::array::from_fn(|i| -1.0 + 3.0 * angle(i).sin());
     let circle = CircleFit { px, py };
-    crit.bench_function("gn/circle_fit_3p", |b| {
+    crit.bench_function("optimization/gn/circle_fit_3p", |b| {
         b.iter(|| {
             GaussNewton::<AutoDiffMulti>::default()
                 .minimize(black_box(&circle), black_box(&[2.4, -0.6, 3.5]))
@@ -157,11 +157,10 @@ fn gauss_newton(crit: &mut Criterion) {
 }
 
 criterion_group! {
-    name = benches;
+    name = optimization_benches;
     config = Criterion::default()
         .sample_size(50)
         .warm_up_time(Duration::from_millis(500))
         .measurement_time(Duration::from_secs(2));
     targets = levenberg_marquardt, gauss_newton
 }
-criterion_main!(benches);

--- a/crates/multicalc/benches/root_finding.md
+++ b/crates/multicalc/benches/root_finding.md
@@ -1,6 +1,6 @@
 # Root-finding benchmarks
 
-Results for the [`root_finding`](root_finding.rs) suite (`cargo bench --bench root_finding`).
+Results for the [`root_finding`](root_finding.rs) suite (`cargo bench -- root_finding`).
 The accuracy tables report how close each solver lands to the known root; the latency table
 reports wall-clock medians on the machine noted in [README.md](README.md).
 

--- a/crates/multicalc/benches/root_finding.rs
+++ b/crates/multicalc/benches/root_finding.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, black_box, criterion_group};
 
 use multicalc::numerical_derivative::autodiff::{AutoDiffMulti, AutoDiffSingle};
 use multicalc::numerical_derivative::finite_difference::FiniteDifferenceSingle;
@@ -67,7 +67,7 @@ impl VectorFn<2, 2> for TwoLinkArm {
 fn bisection(crit: &mut Criterion) {
     // Wien's displacement law on [1, 10].
     let wien = scalar_fn!(|x| c(-5.0) + x + c(5.0) * (-x).exp());
-    crit.bench_function("bisection/wien", |b| {
+    crit.bench_function("root_finding/bisection/wien", |b| {
         b.iter(|| {
             Bisection::default()
                 .solve(black_box(&wien), black_box(1.0_f64), black_box(10.0))
@@ -79,7 +79,7 @@ fn bisection(crit: &mut Criterion) {
     let e = 0.8_f64;
     let m = 1.0 - e * 1.0_f64.sin();
     let kepler = Kepler { e, m };
-    crit.bench_function("bisection/kepler", |b| {
+    crit.bench_function("root_finding/bisection/kepler", |b| {
         b.iter(|| {
             Bisection::default()
                 .solve(
@@ -94,7 +94,7 @@ fn bisection(crit: &mut Criterion) {
 
 fn newton(crit: &mut Criterion) {
     let wien = scalar_fn!(|x| c(-5.0) + x + c(5.0) * (-x).exp());
-    crit.bench_function("newton/wien", |b| {
+    crit.bench_function("root_finding/newton/wien", |b| {
         b.iter(|| {
             Newton::<AutoDiffSingle>::default()
                 .solve(black_box(&wien), black_box(5.0_f64))
@@ -105,7 +105,7 @@ fn newton(crit: &mut Criterion) {
     let e = 0.8_f64;
     let m = 1.0 - e * 1.0_f64.sin();
     let kepler = Kepler { e, m };
-    crit.bench_function("newton/kepler", |b| {
+    crit.bench_function("root_finding/newton/kepler", |b| {
         b.iter(|| {
             Newton::<AutoDiffSingle>::default()
                 .solve(black_box(&kepler), black_box(m))
@@ -117,7 +117,7 @@ fn newton(crit: &mut Criterion) {
         reynolds: 1.0e5,
         rel_roughness: 1.0e-4,
     };
-    crit.bench_function("newton/colebrook", |b| {
+    crit.bench_function("root_finding/newton/colebrook", |b| {
         b.iter(|| {
             Newton::<AutoDiffSingle>::default()
                 .solve(black_box(&colebrook), black_box(0.02_f64))
@@ -126,7 +126,7 @@ fn newton(crit: &mut Criterion) {
     });
 
     // Finite-difference derivative in place of exact autodiff, on the Wien root.
-    crit.bench_function("newton_fd/wien", |b| {
+    crit.bench_function("root_finding/newton_fd/wien", |b| {
         b.iter(|| {
             Newton::from_derivator(FiniteDifferenceSingle::<f64>::default())
                 .solve(black_box(&wien), black_box(5.0_f64))
@@ -139,7 +139,7 @@ fn damped_newton(crit: &mut Criterion) {
     // f(x) = x / sqrt(1 + x²), root at 0. Plain Newton diverges from x0 = 2; the
     // backtracking line search halves the step until |f| decreases.
     let sigmoid = scalar_fn!(|x| x / (c(1.0) + x * x).sqrt());
-    crit.bench_function("damped_newton/sigmoid", |b| {
+    crit.bench_function("root_finding/damped_newton/sigmoid", |b| {
         b.iter(|| {
             Newton::<AutoDiffSingle>::default()
                 .with_backtracking(true)
@@ -156,7 +156,7 @@ fn newton_system(crit: &mut Criterion) {
     let px = l1 * t1.cos() + l2 * (t1 + t2).cos();
     let py = l1 * t1.sin() + l2 * (t1 + t2).sin();
     let arm = TwoLinkArm { l1, l2, px, py };
-    crit.bench_function("newton_system/two_link_ik", |b| {
+    crit.bench_function("root_finding/newton_system/two_link_ik", |b| {
         b.iter(|| {
             NewtonSystem::<AutoDiffMulti>::default()
                 .solve(black_box(&arm), black_box(&[0.4_f64, 0.9]))
@@ -169,7 +169,7 @@ fn newton_system(crit: &mut Criterion) {
         scalar_fn_vec!(
             |v: &[f64; 2]| [c(-4.0) + v[0] * v[0] + v[1] * v[1], c(-1.0) + v[0] * v[1],]
         );
-    crit.bench_function("newton_system/circle_intersection", |b| {
+    crit.bench_function("root_finding/newton_system/circle_intersection", |b| {
         b.iter(|| {
             NewtonSystem::<AutoDiffMulti>::default()
                 .solve(black_box(&circle), black_box(&[1.5_f64, 0.8]))
@@ -183,7 +183,7 @@ fn newton_system(crit: &mut Criterion) {
         v[1] - c(1.25) * v[0] * v[0],
         v[2] - c(5.0) * v[0] * v[1],
     ]);
-    crit.bench_function("newton_system/equilibrium_3x3", |b| {
+    crit.bench_function("root_finding/newton_system/equilibrium_3x3", |b| {
         b.iter(|| {
             NewtonSystem::<AutoDiffMulti>::default()
                 .solve(black_box(&equilibrium), black_box(&[0.5_f64, 0.25, 0.25]))
@@ -193,11 +193,10 @@ fn newton_system(crit: &mut Criterion) {
 }
 
 criterion_group! {
-    name = benches;
+    name = root_finding_benches;
     config = Criterion::default()
         .sample_size(50)
         .warm_up_time(Duration::from_millis(500))
         .measurement_time(Duration::from_secs(2));
     targets = bisection, newton, damped_newton, newton_system
 }
-criterion_main!(benches);


### PR DESCRIPTION
Closes #87 

Replace per-suite bench targets with one `benchmarks` entry point and prefix all criterion names (`calculus/…`, `linear_algebra/…`, etc.) so suites can be filtered with `cargo bench -- <suite>`.