### PR TITLE
docs(examples): add Gauss-Newton solver walkthrough

### DIFF
--- a/crates/multicalc/examples/README.md
+++ b/crates/multicalc/examples/README.md
@@ -23,3 +23,4 @@ Several examples also reproduce the published accuracy figures in [`benches/`](.
 | [`svd`](svd.rs) | `linear_algebra::svd` | Singular value decomposition and Moore-Penrose pseudo-inverse under a robotics stress test (Kabsch rotation recovery, a redundant-arm pseudo-inverse, a near-singular Jacobian, and an overdetermined fit) with latency + approximation error. Reproduces the SVD / pseudo-inverse accuracy table in benches/linear_algebra.md. |
 | [`root_finding`](root_finding.rs) | `root_finding` | Bracketed bisection, Newton with exact derivatives, damped (backtracking) Newton rescuing a far start, and a square-system Newton solve, each printed against its known root. |
 | [`curve_fit`](curve_fit.rs) | `optimization` | Levenberg-Marquardt fit of `y = a·e^(b·t)` to sensor samples with exact autodiff Jacobians; prints recovered `a`, `b`, and `\|err\|`. |
+- `optimization_solvers` — Gauss-Newton linear residual walkthrough

--- a/crates/multicalc/examples/optimization_solvers.rs
+++ b/crates/multicalc/examples/optimization_solvers.rs
@@ -1,0 +1,47 @@
+//! Gauss-Newton least-squares example (well-conditioned linear residual).
+//!
+//! When to use which solver:
+//! - **Gauss-Newton**: undamped, fast near a well-conditioned solution (this example).
+//! - **Levenberg-Marquardt** (see curve_fit.rs): damped / trust-region style; prefer when
+//!   far from the solution or the Jacobian is poorly conditioned.
+//!
+//! Run: cargo run -p multicalc --example optimization_solvers
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use multicalc::GaussNewton;
+use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+use multicalc::scalar::{Numeric, VectorFn};
+
+// Fit y = a + b*t to points on y = 2t + 1; linear residuals converge in one GN step.
+// Expected: a = 1.0, b = 2.0
+struct LineFit;
+
+impl VectorFn<2, 3> for LineFit {
+    fn eval<S: Numeric>(&self, p: &[S; 2]) -> [S; 3] {
+        // residuals at t = 0,1,2 with y = 1,3,5
+        let (a, b) = (p[0], p[1]);
+        [
+            a + b * S::from_f64(0.0) - S::from_f64(1.0),
+            a + b * S::from_f64(1.0) - S::from_f64(3.0),
+            a + b * S::from_f64(2.0) - S::from_f64(5.0),
+        ]
+    }
+}
+
+fn main() {
+    let report = GaussNewton::<AutoDiffMulti>::default()
+        .minimize(&LineFit, &[0.0, 0.0])
+        .expect("gauss-newton did not converge");
+
+    let (a, b) = (report.solution[0], report.solution[1]);
+    println!("Gauss-Newton fit y = a + b*t");
+    println!("  a = {a:.9}   (expect 1.0)");
+    println!("  b = {b:.9}   (expect 2.0)");
+    println!(
+        "  objective = {:.1e}   ({} evals, {:?})",
+        report.objective_function, report.evaluations, report.termination
+    );
+
+    assert!((a - 1.0).abs() < 1e-9 && (b - 2.0).abs() < 1e-9);
+}

--- a/crates/multicalc/src/optimization/README.md
+++ b/crates/multicalc/src/optimization/README.md
@@ -29,3 +29,8 @@ let report = LevenbergMarquardt::<AutoDiffMulti>::default()
 Credits: the Levenberg-Marquardt driver ports MINPACK's `lmder`/`lmpar` (Moré, Garbow, Hillstrom;
 public domain, netlib), following Moré (1978), "The Levenberg-Marquardt algorithm: Implementation and
 theory", and Nocedal & Wright, *Numerical Optimization*, chapters 4 and 10.
+
+## Runnable examples
+
+- [xamples/curve_fit.rs](../../examples/curve_fit.rs) — Levenberg-Marquardt on an exponential model.
+- [xamples/optimization_solvers.rs](../../examples/optimization_solvers.rs) — Gauss-Newton on a linear residual (when GN is enough vs LM).


### PR DESCRIPTION
## Summary
Adds a runnable Gauss-Newton example (linear residual fit) and links it from the optimization README.

Gauss-Newton is the undamped, fast path when the Jacobian is well conditioned; LM (see curve_fit) remains the robust default with damping/trust-region behavior.

## How to test
```
cargo run -p multicalc --example optimization_solvers
```

Closes #105
