### PR TITLE
Add f32 pseudo-inverse identity tests

### DIFF
--- a/crates/multicalc/tests/linear_algebra/helpers.rs
+++ b/crates/multicalc/tests/linear_algebra/helpers.rs
@@ -96,3 +96,35 @@ pub(crate) fn svd_moore_penrose<const M: usize, const N: usize, T: Numeric>(
     let apa = ap * a;
     assert_close(apa, apa.transpose(), tol);
 }
+
+fn max_abs<const R: usize, const C: usize>(m: Matrix<R, C, f32>) -> f32 {
+    let mut max = 0.0_f32;
+    for r in 0..R {
+        for c in 0..C {
+            max = max.max(m[(r, c)].abs());
+        }
+    }
+    max
+}
+
+fn f32_scaled_tol(scale: f32, dim: usize) -> f32 {
+    512.0 * f32::EPSILON * dim as f32 * scale.max(1.0)
+}
+
+/// Verifies the four Moore-Penrose conditions for an f32 pseudo-inverse with
+/// tolerances scaled by matrix magnitude and dimension.
+pub(crate) fn svd_moore_penrose_f32<const M: usize, const N: usize>(a: Matrix<M, N, f32>) {
+    let ap = a.pseudo_inverse().unwrap();
+
+    let aap_a = a * ap * a;
+    assert_close(aap_a, a, f32_scaled_tol(max_abs(a), M.max(N)));
+
+    let apa_ap = ap * a * ap;
+    assert_close(apa_ap, ap, f32_scaled_tol(max_abs(ap), M.max(N)));
+
+    let aap = a * ap;
+    assert_close(aap, aap.transpose(), f32_scaled_tol(max_abs(aap), M));
+
+    let apa = ap * a;
+    assert_close(apa, apa.transpose(), f32_scaled_tol(max_abs(apa), N));
+}

--- a/crates/multicalc/tests/linear_algebra/svd.rs
+++ b/crates/multicalc/tests/linear_algebra/svd.rs
@@ -1,4 +1,6 @@
-use crate::helpers::{assert_close, assert_identity, svd_moore_penrose, svd_reconstructs};
+use crate::helpers::{
+    assert_close, assert_identity, svd_moore_penrose, svd_moore_penrose_f32, svd_reconstructs,
+};
 use multicalc::linear_algebra::{Matrix, Vector};
 use multicalc::utils::error_codes::CalcError;
 
@@ -102,6 +104,31 @@ fn svd_pseudo_inverse_conditions() {
         }),
         1e-10,
     );
+}
+
+#[test]
+fn svd_f32_pseudo_inverse_conditions() {
+    svd_moore_penrose_f32(Matrix::<3, 3, f32>::new([
+        [4.0, 1.0, 2.0],
+        [1.0, 5.0, 3.0],
+        [2.0, 3.0, 6.0],
+    ]));
+    svd_moore_penrose_f32(Matrix::<4, 2, f32>::new([
+        [1.0, 0.0],
+        [2.0, -1.0],
+        [0.5, 3.0],
+        [-1.0, 2.0],
+    ]));
+    svd_moore_penrose_f32(Matrix::<2, 4, f32>::new([
+        [1.0, 0.0, 2.0, -1.0],
+        [0.0, 1.0, 1.0, 3.0],
+    ]));
+    // The second column is twice the first, and the third is their sum.
+    svd_moore_penrose_f32(Matrix::<3, 3, f32>::new([
+        [1.0, 2.0, 3.0],
+        [2.0, 4.0, 6.0],
+        [3.0, 6.0, 9.0],
+    ]));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add an f32 Moore-Penrose helper with tolerances scaled by matrix magnitude and dimension
- cover square, tall, wide, and rank-deficient pseudo-inverse cases

Closes #104

## Validation
- cargo fmt --check
- cargo test -p multicalc --test linear_algebra
- cargo test
- cargo clippy --all-targets -- -D warnings