### PR TITLE
Correctly link to CONTRIBUTING.md from README

### DIFF
--- a/crates/multicalc/README.md
+++ b/crates/multicalc/README.md
@@ -350,7 +350,7 @@ accuracy figures and measured latency.
 
 ## Contributing
 
-See [CONTRIBUTIONS.md](../../CONTRIBUTIONS.md).
+See [CONTRIBUTIONS.md](../../CONTRIBUTING.md).
 
 ## Acknowledgements
 

--- a/crates/multicalc/README.md
+++ b/crates/multicalc/README.md
@@ -350,7 +350,7 @@ accuracy figures and measured latency.
 
 ## Contributing
 
-See [CONTRIBUTIONS.md](../../CONTRIBUTING.md).
+See [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 ## Acknowledgements
 


### PR DESCRIPTION
## What & why

A small fix to make the README link to CONTRIBUTING.md (rather than CONTRIBUTIONS.md which does not exist)