### PR TITLE
docs/autodiff_scalar_examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `vector!` and `matrix!` macros for building [`Vector`] and [`Matrix`] literals,
   e.g. `vector![1.0, 2.0, 3.0]` and `matrix![[1.0, 2.0], [3.0, 4.0]]`. @rtmongold (#37)
+- **Autodiff scalars example.** A runnable walkthrough (`examples/autodiff_scalars.rs`)
+  that uses `Dual` and `HyperDual` directly (no derivator). @rtmongold (#106)
 
 ### Fixed
 

--- a/crates/multicalc/examples/README.md
+++ b/crates/multicalc/examples/README.md
@@ -14,6 +14,7 @@ Several examples also reproduce the published accuracy figures in [`benches/`](.
 | Example | Module(s) | What it shows |
 | --- | --- | --- |
 | [`differentiation`](differentiation.rs) | `numerical_derivative` | Single- and multi-variable finite-difference derivatives (orders 1-3, partials, mixed partials). Reproduces the differentiation accuracy tables in benches/calculus.md. |
+| [`autodiff_scalars`](autodiff_scalars.rs) | `scalar` | Use `Dual` and `HyperDual` directly: evaluate a generic `Numeric` function and read f, f′, f″ from the result fields (no derivator). |
 | [`jacobian_hessian`](jacobian_hessian.rs) | `numerical_derivative::{jacobian, hessian}` | Jacobian of a vector of functions and the Hessian of a scalar function. |
 | [`iterative_integration`](iterative_integration.rs) | `numerical_integration::iterative_integration` | Boole / Simpson / Trapezoidal rules, multi-variable partial integrals, and infinite / semi-infinite limits. Reproduces the iterative-integration accuracy table in benches/calculus.md. |
 | [`gaussian_integration`](gaussian_integration.rs) | `numerical_integration::gaussian_integration` | Gauss-Legendre (finite), Gauss-Hermite and Gauss-Laguerre (infinite), with the bare-integrand convention. Reproduces the Gaussian-quadrature accuracy table in benches/calculus.md. |

--- a/crates/multicalc/examples/autodiff_scalars.rs
+++ b/crates/multicalc/examples/autodiff_scalars.rs
@@ -1,0 +1,55 @@
+//! Using autodiff scalar types directly (`Dual`, `HyperDual`).
+//!
+//! Run with: `cargo run --example autodiff_scalars`
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use multicalc::scalar::{Dual, HyperDual, Numeric};
+
+/// f(x) = x^2 + sin(x) — generic over the scalar, so one definition drives f64,
+/// Dual, and HyperDual on the same code path.
+fn f<T: Numeric>(x: T) -> T {
+    x * x * x.sin()
+}
+
+fn report(label: &str, value: f64, exact: f64) {
+    println!(
+        "  {label:<22} = {value:>13.8}   (exact {exact:>13.8}, |err| {:.0e})",
+        (value - exact).abs()
+    );
+}
+
+fn main() {
+    let x = 1.0_f64;
+    let (s, c) = (x.sin(), x.cos());
+    let (fv, fp, fpp) = (
+        x * x * s,
+        2.0 * x * s + x * x * c,
+        2.0 * s + 4.0 * x * c - x * x * s,
+    );
+
+    println!("f(x) = x^2 sin(x) at x = {x}");
+
+    // (1) Dual: one pass gives f and f'
+    let dual = f(Dual::variable(x));
+    report("f (Dual.value)", dual.value, fv);
+    report("f' (Dual.deriv)", dual.deriv, fp);
+
+    // (2) HyperDual: one pass give f, f', and f''
+    let hyper = f(HyperDual::variable(x));
+    report("f (HyperDual.real)", hyper.real, fv);
+    report("f' (HyperDual.eps1)", hyper.eps1, fp);
+    report("f'' (HyperDual.eps1eps2)", hyper.eps1eps2, fpp);
+
+    // (3) Generic over Numeric: plain f64 and Dual share the same function
+    let plain = f(x);
+    let dual = f(Dual::variable(x));
+
+    println!("\nGeneric over Numeric - same fn, two scalar types:");
+    report("f(1.0)", plain, fv);
+    report("Dual.value", dual.value, fv);
+    report("Dual.deriv", dual.deriv, fp);
+
+    assert!((plain - dual.value).abs() < 1e-12);
+    assert!((dual.deriv - fp).abs() < 1e-12);
+}


### PR DESCRIPTION
Closes #106 

Autodiff scalars example uses `Dual` and `HyperDual` directly (no derivator)

