### PR TITLE
docs/examples-optimization-solvers-index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   e.g. `vector![1.0, 2.0, 3.0]` and `matrix![[1.0, 2.0], [3.0, 4.0]]`. @rtmongold (#37)
 - **Autodiff scalars example.** A runnable walkthrough (`examples/autodiff_scalars.rs`)
   that uses `Dual` and `HyperDual` directly (no derivator). @rtmongold (#106)
+- Fixed `examples/README.md` table entry for `optimization_solvers` (was an orphan 
+  bullet). @rtmongold (#117)
 
 ### Fixed
 

--- a/crates/multicalc/examples/README.md
+++ b/crates/multicalc/examples/README.md
@@ -24,4 +24,4 @@ Several examples also reproduce the published accuracy figures in [`benches/`](.
 | [`svd`](svd.rs) | `linear_algebra::svd` | Singular value decomposition and Moore-Penrose pseudo-inverse under a robotics stress test (Kabsch rotation recovery, a redundant-arm pseudo-inverse, a near-singular Jacobian, and an overdetermined fit) with latency + approximation error. Reproduces the SVD / pseudo-inverse accuracy table in benches/linear_algebra.md. |
 | [`root_finding`](root_finding.rs) | `root_finding` | Bracketed bisection, Newton with exact derivatives, damped (backtracking) Newton rescuing a far start, and a square-system Newton solve, each printed against its known root. |
 | [`curve_fit`](curve_fit.rs) | `optimization` | Levenberg-Marquardt fit of `y = a·e^(b·t)` to sensor samples with exact autodiff Jacobians; prints recovered `a`, `b`, and `\|err\|`. |
-- `optimization_solvers` — Gauss-Newton linear residual walkthrough
+| [`optimization_solvers`](optimization_solvers.rs) | `optimization` | Gauss-Newton on a well-conditioned linear residual (`y = a + b·t`); when GN is enough vs LM (`curve_fit`). |


### PR DESCRIPTION
Closes #117 and #116

fix `optimization_solvers` was orphan bullet.

