### PR TITLE
docs/fix misspelled examples/ labels in optimization README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `vector!` and `matrix!` macros for building [`Vector`] and [`Matrix`] literals,
   e.g. `vector![1.0, 2.0, 3.0]` and `matrix![[1.0, 2.0], [3.0, 4.0]]`. @rtmongold (#37)
 
+### Fixed
+
+- Fixed misspelled `examples/` link labels in `optimization/README.md`. @rtmongold
+
 ## [0.7.2] - 2026-07-09
 
 ### Added

--- a/crates/multicalc/src/optimization/README.md
+++ b/crates/multicalc/src/optimization/README.md
@@ -32,5 +32,5 @@ theory", and Nocedal & Wright, *Numerical Optimization*, chapters 4 and 10.
 
 ## Runnable examples
 
-- [xamples/curve_fit.rs](../../examples/curve_fit.rs) — Levenberg-Marquardt on an exponential model.
-- [xamples/optimization_solvers.rs](../../examples/optimization_solvers.rs) — Gauss-Newton on a linear residual (when GN is enough vs LM).
+- [examples/curve_fit.rs](../../examples/curve_fit.rs) — Levenberg-Marquardt on an exponential model.
+- [examples/optimization_solvers.rs](../../examples/optimization_solvers.rs) — Gauss-Newton on a linear residual (when GN is enough vs LM).


### PR DESCRIPTION
change from xample/ to example/

