### PR TITLE
Faster jacobians for large inputs using column solves instead of inidividual solves

### DIFF
--- a/crates/multicalc/benches/calculus.md
+++ b/crates/multicalc/benches/calculus.md
@@ -136,7 +136,8 @@ Gauss-Laguerre, order 5                                          | 4.4 ns      |
 
 Operation                                                        | Median time |
 ---------------------------------------------------------------- | ----------- |
-Jacobian, 2 functions × 3 variables                              | 2.7 ns      |
+Jacobian, 2 functions × 3 variables                              | 10 ns       |
+Jacobian, 6 functions × 6 variables                              | 87 ns       |
 Hessian, 3 variables                                             | 0.15 µs     |
 Curl, 3D                                                         | 6.2 ns      |
 Divergence, 3D                                                   | 0.37 ns     |

--- a/crates/multicalc/benches/calculus.rs
+++ b/crates/multicalc/benches/calculus.rs
@@ -142,6 +142,21 @@ fn jacobian_hessian(crit: &mut Criterion) {
         b.iter(|| jacobian.get(&f, black_box(&point)).unwrap())
     });
 
+    // Larger case: the column-seeded harness runs one pass per input (6) instead of one per
+    // cell (36), so this shows the scaling the 2x3 case is too small to reveal.
+    let big = scalar_fn_vec!(|a: &[f64; 6]| [
+        a[0] * a[1] + a[2],
+        a[1] * a[2] + a[3],
+        a[2] * a[3] + a[4],
+        a[3] * a[4] + a[5],
+        a[4] * a[5] + a[0],
+        a[5] * a[0] + a[1],
+    ]);
+    let big_point = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    crit.bench_function("calculus/jacobian/6_funcs_6_vars", |b| {
+        b.iter(|| jacobian.get(&big, black_box(&big_point)).unwrap())
+    });
+
     let func =
         scalar_fn!(|a: &[f64; 3]| a[1] * a[0].sin() + c(2.0) * a[0] * a[1].exp() + a[2] * a[2]);
     let hessian: Hessian = Hessian::default();

--- a/crates/multicalc/src/numerical_derivative/autodiff.rs
+++ b/crates/multicalc/src/numerical_derivative/autodiff.rs
@@ -8,7 +8,7 @@ use core::marker::PhantomData;
 
 use crate::error::DiffError;
 use crate::numerical_derivative::derivator::{DerivatorMultiVariable, DerivatorSingleVariable};
-use crate::scalar::{Dual, HyperDual, Jet, Numeric, ScalarFn, ScalarFnN};
+use crate::scalar::{Dual, HyperDual, Jet, Numeric, ScalarFn, ScalarFnN, VectorFn};
 
 /// Highest single-variable derivative order an [`AutoDiffSingle`] supports through its [`Jet`].
 const MAX_ORDER: usize = 6;
@@ -155,5 +155,29 @@ impl<T: Numeric> DerivatorMultiVariable for AutoDiffMulti<T> {
             }
             _ => Err(DiffError::OrderUnsupported),
         }
+    }
+
+    /// Computes input `col` on a single [`Dual`] direction and evaluates `func` once, reading the
+    /// derivative of every output from that one pass.
+    /// The whole Jacobian column in O(1) evaluations.
+    fn jacobian_column<
+        F: VectorFn<NUM_VARS, NUM_FUNCS>,
+        const NUM_VARS: usize,
+        const NUM_FUNCS: usize,
+    >(
+        &self,
+        func: &F,
+        col: usize,
+        point: &[T; NUM_VARS],
+    ) -> Result<[T; NUM_FUNCS], DiffError> {
+        if col >= NUM_VARS {
+            return Err(DiffError::IndexOutOfRange);
+        }
+
+        let mut seed: [Dual<T>; NUM_VARS] = core::array::from_fn(|k| Dual::constant(point[k]));
+        seed[col] = Dual::variable(point[col]);
+
+        let outputs = func.eval(&seed);
+        Ok(core::array::from_fn(|m| outputs[m].deriv))
     }
 }

--- a/crates/multicalc/src/numerical_derivative/derivator.rs
+++ b/crates/multicalc/src/numerical_derivative/derivator.rs
@@ -1,5 +1,5 @@
 use crate::error::DiffError;
-use crate::scalar::{Numeric, ScalarFn, ScalarFnN};
+use crate::scalar::{Numeric, ScalarFn, ScalarFnN, VectorFn};
 
 /// Base trait for single-variable differentiation.
 pub trait DerivatorSingleVariable {
@@ -107,4 +107,24 @@ pub trait DerivatorMultiVariable {
     ) -> Result<Self::Scalar, DiffError> {
         self.get(func, idx_to_differentiate, point)
     }
+
+    /// Returns one column of a vector function's Jacobian: the partial derivative of every
+    /// output with respect to input `col`, at `point`.
+    ///
+    /// Implementations compute the whole column at once — forward-mode from a
+    /// single seeded pass, finite difference from two full-vector evaluations.
+    ///
+    /// # Errors
+    /// [`DiffError::IndexOutOfRange`] if `col >= NUM_VARS`, plus whatever error the underlying
+    /// evaluation returns.
+    fn jacobian_column<
+        F: VectorFn<NUM_VARS, NUM_FUNCS>,
+        const NUM_VARS: usize,
+        const NUM_FUNCS: usize,
+    >(
+        &self,
+        func: &F,
+        col: usize,
+        point: &[Self::Scalar; NUM_VARS],
+    ) -> Result<[Self::Scalar; NUM_FUNCS], DiffError>;
 }

--- a/crates/multicalc/src/numerical_derivative/finite_difference.rs
+++ b/crates/multicalc/src/numerical_derivative/finite_difference.rs
@@ -7,7 +7,7 @@
 use crate::error::DiffError;
 use crate::numerical_derivative::derivator::{DerivatorMultiVariable, DerivatorSingleVariable};
 use crate::numerical_derivative::mode::{self, FiniteDifferenceMode};
-use crate::scalar::{Numeric, ScalarFn, ScalarFnN};
+use crate::scalar::{Numeric, ScalarFn, ScalarFnN, VectorFn};
 
 /// Low and high sample offsets (in units of the step size) and the divisor factor
 /// for each finite-difference mode.
@@ -188,5 +188,39 @@ impl<T: Numeric> DerivatorMultiVariable for FiniteDifferenceMulti<T> {
             point,
             self.config.step_size,
         ))
+    }
+
+    /// Evaluates the whole vector function at the low and high
+    /// sample points, reading every output's difference quotient from those two passes,
+    /// getting the whole Jacobian column in two evaluations.
+    fn jacobian_column<
+        F: VectorFn<NUM_VARS, NUM_FUNCS>,
+        const NUM_VARS: usize,
+        const NUM_FUNCS: usize,
+    >(
+        &self,
+        func: &F,
+        col: usize,
+        point: &[T; NUM_VARS],
+    ) -> Result<[T; NUM_FUNCS], DiffError> {
+        self.config.check_step_size()?;
+        if col >= NUM_VARS {
+            return Err(DiffError::IndexOutOfRange);
+        }
+
+        let (lo, hi, denom) = offsets::<T>(self.config.method);
+        let step = self.config.step_size;
+
+        let mut low_point = *point;
+        low_point[col] += lo * step;
+        let mut high_point = *point;
+        high_point[col] += hi * step;
+
+        let low = func.eval(&low_point);
+        let high = func.eval(&high_point);
+
+        Ok(core::array::from_fn(|m| {
+            (high[m] - low[m]) / (denom * step)
+        }))
     }
 }

--- a/crates/multicalc/src/numerical_derivative/jacobian.rs
+++ b/crates/multicalc/src/numerical_derivative/jacobian.rs
@@ -3,7 +3,6 @@ use crate::linear_algebra::Matrix;
 use crate::numerical_derivative::autodiff::AutoDiffMulti;
 use crate::numerical_derivative::derivator::DerivatorMultiVariable;
 use crate::scalar::VectorFn;
-use crate::scalar::function::Component;
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -68,12 +67,12 @@ impl<D: DerivatorMultiVariable> Jacobian<D> {
 
         let mut result: Matrix<NUM_FUNCS, NUM_VARS, D::Scalar> = Matrix::zeros();
 
-        for m in 0..NUM_FUNCS {
-            let component = Component::new(function, m);
-            for n in 0..NUM_VARS {
-                result[(m, n)] =
-                    self.derivator
-                        .get_single_partial(&component, n, vector_of_points)?;
+        for n in 0..NUM_VARS {
+            let column = self
+                .derivator
+                .jacobian_column(function, n, vector_of_points)?;
+            for (m, &value) in column.iter().enumerate() {
+                result[(m, n)] = value;
             }
         }
 
@@ -107,19 +106,18 @@ impl<D: DerivatorMultiVariable> Jacobian<D> {
             return Err(DiffError::EmptyFunctionSet);
         }
 
-        let mut result: Vec<Vec<D::Scalar>> = Vec::new();
+        let mut result: Vec<Vec<D::Scalar>> = Vec::with_capacity(NUM_FUNCS);
+        for _ in 0..NUM_FUNCS {
+            result.push(Vec::with_capacity(NUM_VARS));
+        }
 
-        for m in 0..NUM_FUNCS {
-            let component = Component::new(function, m);
-            let mut cur_row: Vec<D::Scalar> = Vec::new();
-            for col_index in 0..NUM_VARS {
-                cur_row.push(self.derivator.get_single_partial(
-                    &component,
-                    col_index,
-                    vector_of_points,
-                )?);
+        for n in 0..NUM_VARS {
+            let column = self
+                .derivator
+                .jacobian_column(function, n, vector_of_points)?;
+            for (m, &value) in column.iter().enumerate() {
+                result[m].push(value);
             }
-            result.push(cur_row);
         }
 
         Ok(result)

--- a/crates/multicalc/tests/numerical_derivative.rs
+++ b/crates/multicalc/tests/numerical_derivative.rs
@@ -11,6 +11,7 @@ use multicalc::scalar::{Numeric, ScalarFn, ScalarFnN, VectorFn, c};
 use multicalc::{scalar_fn, scalar_fn_vec};
 use proptest::prelude::*;
 use proptest::test_runner::{RngAlgorithm, TestRng, TestRunner};
+use std::cell::Cell;
 
 // ----- autodiff (the default backend): exact derivatives -----
 
@@ -184,6 +185,88 @@ fn ad_jacobian_empty_error() {
     let jacobian: Jacobian = Jacobian::default();
     let result = jacobian.get(&EmptyVectorFn, &[1.0, 2.0, 3.0]);
     assert_eq!(result.unwrap_err(), DiffError::EmptyFunctionSet);
+}
+
+// ----- column-seeded Jacobian -----
+
+// A VectorFn that counts how many times it is evaluated, to prove the column-seeded harness
+// runs one pass per input column (N) rather than one per matrix cell (M*N).
+struct CountingVectorFn {
+    calls: Cell<usize>,
+}
+
+impl VectorFn<3, 2> for CountingVectorFn {
+    fn eval<S: Numeric>(&self, p: &[S; 3]) -> [S; 2] {
+        self.calls.set(self.calls.get() + 1);
+        // (x*y*z, x^2 + y^2)
+        [p[0] * p[1] * p[2], p[0] * p[0] + p[1] * p[1]]
+    }
+}
+
+#[test]
+fn ad_jacobian_is_column_seeded() {
+    let f = CountingVectorFn {
+        calls: Cell::new(0),
+    };
+    let jacobian: Jacobian = Jacobian::default();
+    let result = jacobian.get(&f, &[1.0, 2.0, 3.0]).unwrap();
+
+    // values are unchanged from the old harness
+    let expected = [[6.0, 3.0, 2.0], [2.0, 4.0, 0.0]];
+    for i in 0..2 {
+        for j in 0..3 {
+            assert!(f64::abs(result[i][j] - expected[i][j]) < 1e-12);
+        }
+    }
+
+    // one evaluation per input column (3), not per cell (2*3 = 6)
+    assert_eq!(f.calls.get(), 3);
+}
+
+#[test]
+fn ad_jacobian_column_reads_all_outputs() {
+    // one seeded pass on input 0 gives d/dx of both outputs: [y*z, 2x] = [6, 2]
+    let f = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
+    let d = AutoDiffMulti::default();
+    let column = d.jacobian_column(&f, 0, &[1.0, 2.0, 3.0]).unwrap();
+    assert!(f64::abs(column[0] - 6.0) < 1e-12);
+    assert!(f64::abs(column[1] - 2.0) < 1e-12);
+}
+
+#[test]
+fn ad_jacobian_column_index_out_of_range() {
+    let f = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
+    let d = AutoDiffMulti::default();
+    let result = d.jacobian_column(&f, 5, &[1.0, 2.0, 3.0]);
+    assert_eq!(result.unwrap_err(), DiffError::IndexOutOfRange);
+}
+
+#[test]
+fn fd_jacobian_column_matches() {
+    // the finite-difference implementation produces the right matrix, matching the analytic
+    // values to finite-difference tolerance (unchanged from the per-Component path it replaces)
+    let f = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
+    let jacobian = Jacobian::from_derivator(FiniteDifferenceMulti::default());
+    let result = jacobian.get(&f, &[1.0, 2.0, 3.0]).unwrap();
+
+    let expected = [[6.0, 3.0, 2.0], [2.0, 4.0, 0.0]];
+    for i in 0..2 {
+        for j in 0..3 {
+            assert!(f64::abs(result[i][j] - expected[i][j]) < 1e-5);
+        }
+    }
+}
+
+#[test]
+fn fd_jacobian_is_column_seeded() {
+    // central difference evaluates the full function twice per input column (2*3 = 6), not twice
+    // per matrix cell (2*M*N = 12)
+    let f = CountingVectorFn {
+        calls: Cell::new(0),
+    };
+    let jacobian = Jacobian::from_derivator(FiniteDifferenceMulti::default());
+    let _ = jacobian.get(&f, &[1.0, 2.0, 3.0]).unwrap();
+    assert_eq!(f.calls.get(), 6);
 }
 
 // ----- finite differences: kept as a sparse fallback for the engine and the cases autodiff


### PR DESCRIPTION
## What & why

Current jacobian solves per cell, but we can do much better by solving per column. Thus increasing the solve speed from O(MxN) to O(M).

## Checklist
- [ ] CHANGELOG.md updated under `## [Unreleased]` (required for behavior-facing changes)
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
