### PR TITLE
fix(ode): handle zero-dimensional RK45 states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Iterative integrators return `IntegrateError::LimitsIllDefined` instead of `NaN`
   if `classify` fails after validation. @rtmongold (#171)
+- RK45 now handles zero-dimensional states without producing NaN norms. (#159)
 
 ## [0.8.0] - 2026-07-16
 

--- a/crates/multicalc/src/ode/rk45.rs
+++ b/crates/multicalc/src/ode/rk45.rs
@@ -109,6 +109,9 @@ fn error_norm<const N: usize, T: Numeric>(
     atol: T,
     rtol: T,
 ) -> T {
+    if N == 0 {
+        return T::ZERO;
+    }
     let mut sum = T::ZERO;
     for ((e, a), b) in err.as_array().iter().zip(y0.as_array()).zip(y1.as_array()) {
         let scale = atol + rtol * a.abs().max(b.abs());
@@ -125,6 +128,9 @@ fn scaled_norm<const N: usize, T: Numeric>(
     atol: T,
     rtol: T,
 ) -> T {
+    if N == 0 {
+        return T::ZERO;
+    }
     let mut sum = T::ZERO;
     for (e, a) in v.as_array().iter().zip(y.as_array()) {
         let scale = atol + rtol * a.abs();

--- a/crates/multicalc/src/ode/rk45.rs
+++ b/crates/multicalc/src/ode/rk45.rs
@@ -102,6 +102,7 @@ impl<T: Numeric> Rk45<T> {
 }
 
 /// RMS of `err_i / (atol + rtol * max(|y0_i|, |y1_i|))` over the components.
+/// Returns `T::ZERO` when `N == 0`.
 fn error_norm<const N: usize, T: Numeric>(
     err: &Vector<N, T>,
     y0: &Vector<N, T>,
@@ -122,6 +123,7 @@ fn error_norm<const N: usize, T: Numeric>(
 }
 
 /// RMS of `v_i / (atol + rtol * |y_i|)` — used by the initial-step heuristic.
+/// Returns `T::ZERO` when `N == 0`.
 fn scaled_norm<const N: usize, T: Numeric>(
     v: &Vector<N, T>,
     y: &Vector<N, T>,

--- a/crates/multicalc/tests/suite/ode/rk45.rs
+++ b/crates/multicalc/tests/suite/ode/rk45.rs
@@ -108,6 +108,16 @@ fn zero_span_errors() {
 }
 
 #[test]
+fn zero_dimensional_state_remains_empty() {
+    let empty = Vector::<0, f64>::zeros();
+    let zero = |_t: f64, _y: &Vector<0, f64>| Vector::zeros();
+
+    let result = Rk45::default().solve(&zero, 0.0, &empty, 1.0);
+
+    assert_eq!(result.unwrap(), empty);
+}
+
+#[test]
 fn non_finite_rhs_errors() {
     let f = |_t: f64, _y: &Vector<1, f64>| Vector::new([f64::NAN]);
     let res = Rk45::default().solve(&f, 0.0, &Vector::new([1.0]), 1.0);


### PR DESCRIPTION
Returns zero from RK45's RMS helpers for zero-dimensional states, preventing `0/0` from producing NaN and exhausting the step budget. Adds a public regression test that integrates `Vector<0, f64>` and records the fix in the changelog.

Fixes #159.
