### PR TITLE
fix(ode): return NonFinite from Rk4 on NaN/Inf

### DIFF
--- a/crates/multicalc/GUIDE.md
+++ b/crates/multicalc/GUIDE.md
@@ -458,7 +458,7 @@ use multicalc::linear_algebra::Vector;
 let f = |_t: f64, y: &Vector<2, f64>| Vector::new([y[1], -y[0]]);
 let y0 = Vector::new([1.0, 0.0]);
 
-let y1 = Rk4::step(&f, 0.0, &y0, 0.1);                                  // one fixed step of size 0.1
+let y1 = Rk4::step(&f, 0.0, &y0, 0.1).unwrap();                          // one fixed step of size 0.1
 
 // Adaptive solve over one full period returns to the start [1, 0].
 let yf = Rk45::default().solve(&f, 0.0, &y0, core::f64::consts::TAU).unwrap();

--- a/crates/multicalc/README.md
+++ b/crates/multicalc/README.md
@@ -194,7 +194,7 @@ use multicalc::linear_algebra::Vector;
 let f = |_t: f64, y: &Vector<2, f64>| Vector::new([y[1], -y[0]]);
 let y0 = Vector::new([1.0, 0.0]);
 
-let step = Rk4::step(&f, 0.0, &y0, 0.1);       // one fixed RK4 step of size 0.1
+let step = Rk4::step(&f, 0.0, &y0, 0.1).unwrap();       // one fixed RK4 step of size 0.1
 // adaptive Dormand-Prince 5(4) over one full period returns to the start [1, 0]
 let yf = Rk45::default().solve(&f, 0.0, &y0, core::f64::consts::TAU).unwrap();
 ```

--- a/crates/multicalc/src/kinematics/unicycle.rs
+++ b/crates/multicalc/src/kinematics/unicycle.rs
@@ -14,7 +14,7 @@ use crate::scalar::Numeric;
 /// use multicalc::linear_algebra::Vector;
 /// use multicalc::ode::Rk4;
 /// let plant = Unicycle::new(BodyTwist::new(1.0_f64, 0.0));
-/// let state = Rk4::step(&plant.field(), 0.0, &Vector::new([0.0, 0.0, 0.0]), 0.1);
+/// let state = Rk4::step(&plant.field(), 0.0, &Vector::new([0.0, 0.0, 0.0]), 0.1).unwrap();
 /// assert!((state[0] - 0.1).abs() < 1e-12);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/multicalc/src/ode/rk4.rs
+++ b/crates/multicalc/src/ode/rk4.rs
@@ -1,5 +1,6 @@
 //! Classic fixed-step fourth-order Runge–Kutta.
 
+use crate::error::IntegrateError;
 use crate::linear_algebra::Vector;
 use crate::scalar::Numeric;
 
@@ -9,29 +10,58 @@ pub struct Rk4;
 impl Rk4 {
     /// Advances the state one step of size `dt` from `(t, y)`.
     ///
+    /// Returns [`IntegrateError::NonFinite`] if the state or any stage derivative
+    /// is non-finite (matching [`Rk45`](crate::ode::Rk45)'s NaN policy).
+    ///
     /// ```
     /// use multicalc::ode::Rk4;
     /// use multicalc::linear_algebra::Vector;
     /// // y' = y, y(0) = 1  ->  y(dt) ≈ e^{dt}
-    /// let y1 = Rk4::step(&|_t, y: &Vector<1, f64>| *y, 0.0, &Vector::new([1.0]), 0.1);
+    /// let y1 = Rk4::step(&|_t, y: &Vector<1, f64>| *y, 0.0, &Vector::new([1.0]), 0.1).unwrap();
     /// assert!((y1[0] - 0.1_f64.exp()).abs() < 1e-6);
     /// ```
-    pub fn step<const N: usize, T, F>(f: &F, t: T, y: &Vector<N, T>, dt: T) -> Vector<N, T>
+    pub fn step<const N: usize, T, F>(
+        f: &F,
+        t: T,
+        y: &Vector<N, T>,
+        dt: T,
+    ) -> Result<Vector<N, T>, IntegrateError>
     where
         T: Numeric,
         F: Fn(T, &Vector<N, T>) -> Vector<N, T>,
     {
+        if !y.is_finite() || !t.is_finite() || !dt.is_finite() {
+            return Err(IntegrateError::NonFinite);
+        }
         let half = T::HALF * dt;
         let k1 = f(t, y);
+        if !k1.is_finite() {
+            return Err(IntegrateError::NonFinite);
+        }
         let k2 = f(t + half, &(*y + k1.scale(half)));
+        if !k2.is_finite() {
+            return Err(IntegrateError::NonFinite);
+        }
         let k3 = f(t + half, &(*y + k2.scale(half)));
+        if !k3.is_finite() {
+            return Err(IntegrateError::NonFinite);
+        }
         let k4 = f(t + dt, &(*y + k3.scale(dt)));
+        if !k4.is_finite() {
+            return Err(IntegrateError::NonFinite);
+        }
         let sixth = dt / T::from_f64(6.0);
-        *y + (k1 + k2.scale(T::TWO) + k3.scale(T::TWO) + k4).scale(sixth)
+        let next = *y + (k1 + k2.scale(T::TWO) + k3.scale(T::TWO) + k4).scale(sixth);
+        if !next.is_finite() {
+            return Err(IntegrateError::NonFinite);
+        }
+        Ok(next)
     }
 
     /// Integrates `steps` fixed steps of size `dt` from `(t0, y0)`, invoking `observer`
     /// with each node (the initial node included) and returning the final state.
+    ///
+    /// Returns [`IntegrateError::NonFinite`] if any accepted state or stage goes non-finite.
     ///
     /// ```
     /// use multicalc::ode::Rk4;
@@ -39,7 +69,7 @@ impl Rk4 {
     /// let mut last = 0.0;
     /// // y' = -y over [0, 1] in 100 steps; endpoint ≈ e^{-1}.
     /// let yf = Rk4::integrate(&|_t, y: &Vector<1, f64>| -*y, 0.0,
-    ///     &Vector::new([1.0]), 0.01, 100, |_t, y| last = y[0]);
+    ///     &Vector::new([1.0]), 0.01, 100, |_t, y| last = y[0]).unwrap();
     /// assert!((yf[0] - (-1.0_f64).exp()).abs() < 1e-6);
     /// assert_eq!(last, yf[0]);
     /// ```
@@ -50,20 +80,57 @@ impl Rk4 {
         dt: T,
         steps: usize,
         mut observer: O,
-    ) -> Vector<N, T>
+    ) -> Result<Vector<N, T>, IntegrateError>
     where
         T: Numeric,
         F: Fn(T, &Vector<N, T>) -> Vector<N, T>,
         O: FnMut(T, &Vector<N, T>),
     {
+        if !y0.is_finite() || !t0.is_finite() || !dt.is_finite() {
+            return Err(IntegrateError::NonFinite);
+        }
         let mut t = t0;
         let mut y = *y0;
         observer(t, &y);
         for _ in 0..steps {
-            y = Self::step(f, t, &y, dt);
+            y = Self::step(f, t, &y, dt)?;
             t += dt;
+            if !t.is_finite() {
+                return Err(IntegrateError::NonFinite);
+            }
             observer(t, &y);
         }
-        y
+        Ok(y)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::linear_algebra::Vector;
+
+    #[test]
+    fn step_rejects_non_finite_rhs() {
+        let res = Rk4::step(
+            &|_t, _y: &Vector<1, f64>| Vector::new([f64::NAN]),
+            0.0,
+            &Vector::new([1.0]),
+            0.1,
+        );
+        assert_eq!(res.unwrap_err(), IntegrateError::NonFinite);
+    }
+
+    #[test]
+    fn integrate_rejects_diverging_blow_up() {
+        // y' = y^2 blows up in finite time from y(0)=1; a large step hits Inf/NaN.
+        let res = Rk4::integrate(
+            &|_t, y: &Vector<1, f64>| Vector::new([y[0] * y[0]]),
+            0.0,
+            &Vector::new([1.0]),
+            1.0,
+            20,
+            |_t, _y| {},
+        );
+        assert_eq!(res.unwrap_err(), IntegrateError::NonFinite);
     }
 }

--- a/crates/multicalc/tests/suite/kinematics/unicycle.rs
+++ b/crates/multicalc/tests/suite/kinematics/unicycle.rs
@@ -22,7 +22,7 @@ fn rk4_to(rate: BodyTwist<f64>, dt: f64, tf: f64) -> Vector<3, f64> {
     let mut y = Vector::new([0.0, 0.0, 0.0]);
     let mut t = 0.0;
     for _ in 0..n {
-        y = Rk4::step(&f, t, &y, dt);
+        y = Rk4::step(&f, t, &y, dt).unwrap();
         t += dt;
     }
     y

--- a/crates/multicalc/tests/suite/ode/rk4.rs
+++ b/crates/multicalc/tests/suite/ode/rk4.rs
@@ -1,4 +1,5 @@
 use multicalc::Dual;
+use multicalc::error::IntegrateError;
 use multicalc::linear_algebra::Vector;
 use multicalc::ode::Rk4;
 
@@ -18,7 +19,8 @@ fn exp_decay_matches_closed_form() {
         1.0 / steps as f64,
         steps,
         |_, _| {},
-    );
+    )
+    .unwrap();
     assert!((yf[0] - (-1.0_f64).exp()).abs() < 1e-9);
 }
 
@@ -35,7 +37,8 @@ fn harmonic_matches_closed_form() {
         tf / steps as f64,
         steps,
         |_, _| {},
-    );
+    )
+    .unwrap();
     assert!((yf[0] - tf.cos()).abs() < 1e-7);
     assert!((yf[1] - (-tf.sin())).abs() < 1e-7);
 }
@@ -52,7 +55,8 @@ fn fourth_order_convergence() {
             1.0 / steps as f64,
             steps,
             |_, _| {},
-        );
+        )
+        .unwrap();
         (yf[0] - exact).abs()
     };
     let ratio = err(50) / err(100);
@@ -76,7 +80,8 @@ fn ad_through_rk4_matches_fd() {
         dt,
         steps,
         |_, _| {},
-    );
+    )
+    .unwrap();
     let ad = yf[0].deriv;
     assert!((ad - (-tf).exp()).abs() < 1e-6);
 
@@ -88,7 +93,8 @@ fn ad_through_rk4_matches_fd() {
             tf / steps as f64,
             steps,
             |_, _| {},
-        )[0]
+        )
+        .unwrap()[0]
     };
     let h = 1e-6;
     let fd = (run(a + h) - run(a - h)) / (2.0 * h);
@@ -108,7 +114,19 @@ fn f32_energy_round_trip() {
         tf / steps as f32,
         steps,
         |_, _| {},
-    );
+    )
+    .unwrap();
     let energy = yf[0] * yf[0] + yf[1] * yf[1];
     assert!((energy - 1.0).abs() < 1e-3);
+}
+
+#[test]
+fn non_finite_rhs_returns_error() {
+    let res = Rk4::step(
+        &|_t, _y: &Vector<1, f64>| Vector::new([f64::NAN]),
+        0.0,
+        &Vector::new([1.0]),
+        0.1,
+    );
+    assert_eq!(res.unwrap_err(), IntegrateError::NonFinite);
 }

--- a/demos/examples/basics/ode.rs
+++ b/demos/examples/basics/ode.rs
@@ -34,7 +34,8 @@ fn harmonic_oscillator() {
     let yf = Rk4::integrate(&f, 0.0, &y0, dt, steps, |t, y| {
         let e = exact(t);
         max_err = max_err.max((y[0] - e[0]).abs()).max((y[1] - e[1]).abs());
-    });
+    })
+    .unwrap();
     println!("Harmonic oscillator y'' = -y");
     println!("  RK4  {steps} steps over [0, 2*pi]");
     println!(
@@ -85,7 +86,8 @@ where
     let mut max = 0.0_f64;
     let _ = Rk4::integrate(f, 0.0, y0, dt, steps, |_, y| {
         max = max.max((inv(y) - q0).abs());
-    });
+    })
+    .unwrap();
     max
 }
 

--- a/tools/embedded-smoke/src/checks.rs
+++ b/tools/embedded-smoke/src/checks.rs
@@ -187,7 +187,8 @@ pub fn ode_identity() {
         dt,
         steps,
         |_, _| {},
-    );
+    )
+    .expect("rk4 integrate");
     assert_close!("ode_rk4_x", black_box(yf[0]), 1.0, 1e-4, 0.0);
     assert_close!("ode_rk4_v", black_box(yf[1]), 0.0, 1e-4, 0.0);
 

--- a/tools/qa/benches/latency.rs
+++ b/tools/qa/benches/latency.rs
@@ -151,7 +151,7 @@ fn bench_rk4_integrate(c: &mut Criterion) {
     let steps = 2000usize;
     let dt = core::f64::consts::TAU / steps as f64;
     c.bench_function("rk4_integrate", |b| {
-        b.iter(|| Rk4::integrate(&f, 0.0, black_box(&y0), dt, steps, |_t, _y| {}))
+        b.iter(|| Rk4::integrate(&f, 0.0, black_box(&y0), dt, steps, |_t, _y| {}).unwrap())
     });
 }
 


### PR DESCRIPTION
## Summary
- `Rk4::step` / `Rk4::integrate` now return `Result<_, IntegrateError>`.
- Non-finite state, time, step size, or stage derivatives yield `IntegrateError::NonFinite` (same policy as `Rk45`).
- Call sites, docs, and tests updated; added regression coverage for a diverging blow-up.

## Test plan
- [x] `cargo test -p multicalc --lib ode::rk4`
- [x] `cargo test -p multicalc --test suite ode::rk4`

Fixes #158

**Note:** small breaking change to the `Rk4` return types.