### PR TITLE
fix(integration): bounds-check multi-variable indices

### DIFF
--- a/crates/multicalc/src/error.rs
+++ b/crates/multicalc/src/error.rs
@@ -52,6 +52,8 @@ pub enum IntegrateError {
     },
     /// An integrand or state value was infinite or NaN.
     NonFinite,
+    /// A variable index was `>=` the number of variables in the point.
+    IndexOutOfRange,
 }
 
 /// Errors from the solver modules (root finding, Gauss-Newton, Levenberg-Marquardt).
@@ -204,6 +206,7 @@ impl core::fmt::Display for IntegrateError {
             IntegrateError::NonFinite => {
                 f.write_str("integrand or state contained a non-finite value")
             }
+            IntegrateError::IndexOutOfRange => f.write_str("variable index out of range"),
         }
     }
 }

--- a/crates/multicalc/src/numerical_integration/gaussian_integration.rs
+++ b/crates/multicalc/src/numerical_integration/gaussian_integration.rs
@@ -342,8 +342,9 @@ impl<T: Numeric> IntegratorMultiVariable for GaussianMulti<T> {
     ///   upper limit; a variable held constant holds that constant.
     ///
     /// # Errors
-    /// [`IntegrateError::QuadratureOrderOutOfRange`] if the configured order is unsupported, or
-    /// [`IntegrateError::LimitsIllDefined`] if any limit does not match the method's domain.
+    /// [`IntegrateError::QuadratureOrderOutOfRange`] if the configured order is unsupported,
+    /// [`IntegrateError::LimitsIllDefined`] if any limit does not match the method's domain, or
+    /// [`IntegrateError::IndexOutOfRange`] if any index is `>= NUM_VARS`.
     ///
     /// # Examples
     /// ```
@@ -367,6 +368,11 @@ impl<T: Numeric> IntegratorMultiVariable for GaussianMulti<T> {
     ) -> Result<T, IntegrateError> {
         let table = nodes(self.config.integration_method, self.config.order)?;
         self.config.check_limits(integration_limits)?;
+        for &idx in &idx_to_integrate {
+            if idx >= NUM_VARS {
+                return Err(IntegrateError::IndexOutOfRange);
+            }
+        }
 
         Ok(match self.config.integration_method {
             GaussianQuadratureMethod::GaussLegendre => self.integrate_legendre(

--- a/crates/multicalc/src/numerical_integration/iterative_integration.rs
+++ b/crates/multicalc/src/numerical_integration/iterative_integration.rs
@@ -459,8 +459,9 @@ impl<T: Numeric> IntegratorMultiVariable for IterativeMulti<T> {
     ///   upper limit; a variable held constant holds that constant.
     ///
     /// # Errors
-    /// [`IntegrateError::IterationsZero`] if the configured iteration count is zero, or
-    /// [`IntegrateError::LimitsIllDefined`] if any limit is ill-defined.
+    /// [`IntegrateError::IterationsZero`] if the configured iteration count is zero,
+    /// [`IntegrateError::LimitsIllDefined`] if any limit is ill-defined, or
+    /// [`IntegrateError::IndexOutOfRange`] if any index is `>= NUM_VARS`.
     ///
     /// # Examples
     /// ```
@@ -483,6 +484,11 @@ impl<T: Numeric> IntegratorMultiVariable for IterativeMulti<T> {
         point: &[T; NUM_VARS],
     ) -> Result<T, IntegrateError> {
         self.config.check_for_errors(integration_limits)?;
+        for &idx in &idx_to_integrate {
+            if idx >= NUM_VARS {
+                return Err(IntegrateError::IndexOutOfRange);
+            }
+        }
         self.integrate(
             NUM_INTEGRATIONS,
             idx_to_integrate,

--- a/crates/multicalc/tests/suite/numerical_integration.rs
+++ b/crates/multicalc/tests/suite/numerical_integration.rs
@@ -813,3 +813,25 @@ fn kahan_integration_beats_naive_on_long_sum() {
         "kahan ({kahan_err:e}) should be closer than naive ({naive_err:e})"
     );
 }
+
+#[test]
+fn iterative_multi_rejects_out_of_range_index() {
+    let func = |args: &[f64; 2]| args[0] + args[1];
+    let point = [1.0, 2.0];
+    let integrator = iterative_integration::IterativeMulti::default();
+    let err = integrator
+        .get([2; 1], &func, &[[0.0, 1.0]; 1], &point)
+        .unwrap_err();
+    assert_eq!(err, IntegrateError::IndexOutOfRange);
+}
+
+#[test]
+fn gaussian_multi_rejects_out_of_range_index() {
+    let func = |args: &[f64; 2]| args[0] + args[1];
+    let point = [1.0, 2.0];
+    let integrator = gaussian_integration::GaussianMulti::default();
+    let err = integrator
+        .get([2; 1], &func, &[[0.0, 1.0]; 1], &point)
+        .unwrap_err();
+    assert_eq!(err, IntegrateError::IndexOutOfRange);
+}

--- a/crates/multicalc/tests/suite/utils.rs
+++ b/crates/multicalc/tests/suite/utils.rs
@@ -91,6 +91,10 @@ fn integrate_display_strings() {
         IntegrateError::NonFinite,
         "integrand or state contained a non-finite value"
     ));
+    assert!(renders_as(
+        IntegrateError::IndexOutOfRange,
+        "variable index out of range"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
﻿## Summary
- Add `IntegrateError::IndexOutOfRange` and return it from `IterativeMulti::get` / `GaussianMulti::get` when any integration index is `>= NUM_VARS`.
- Document the error on both `get` methods and cover it with regression + Display tests.

Fixes #149

## Test plan
- [x] `cargo test -p multicalc rejects_out_of_range_index`
- [x] `cargo test -p multicalc integrate_display_strings`
