### PR TITLE
fix(integration): return NonFinite from iterative and Gaussian integrators

### DIFF
--- a/crates/multicalc/src/numerical_integration/gaussian_integration.rs
+++ b/crates/multicalc/src/numerical_integration/gaussian_integration.rs
@@ -6,6 +6,17 @@ use crate::numerical_integration::integrator::{IntegratorMultiVariable, Integrat
 use crate::numerical_integration::mode::GaussianQuadratureMethod;
 use crate::scalar::Numeric;
 
+/// Returns `sample` unchanged, or [`IntegrateError::NonFinite`] if it is NaN or infinite.
+/// The quadrature rules never check their samples otherwise, so a blow-up in the integrand
+/// would silently propagate into a garbage result. Mirrors the `Rk45` policy in `ode/rk45.rs`.
+fn finite<T: Numeric>(sample: T) -> Result<T, IntegrateError> {
+    if sample.is_finite() {
+        Ok(sample)
+    } else {
+        Err(IntegrateError::NonFinite)
+    }
+}
+
 /// Default quadrature order (number of nodes).
 pub const DEFAULT_QUADRATURE_ORDERS: usize = 4;
 
@@ -112,7 +123,7 @@ impl<T: Numeric> GaussianSingle<T> {
         table: &'static [(f64, f64)],
         func: &F,
         integration_limit: &[[T; 2]; NUM_INTEGRATIONS],
-    ) -> T {
+    ) -> Result<T, IntegrateError> {
         let a = integration_limit[level - 1][0];
         let b = integration_limit[level - 1][1];
         let half = (b - a) * T::HALF;
@@ -121,17 +132,17 @@ impl<T: Numeric> GaussianSingle<T> {
         if level == 1 {
             let mut ans = T::ZERO;
             for &(weight, abscissa) in table {
-                ans += T::from_f64(weight) * func(half * T::from_f64(abscissa) + mid);
+                ans += T::from_f64(weight) * finite(func(half * T::from_f64(abscissa) + mid))?;
             }
-            return half * ans;
+            return Ok(half * ans);
         }
 
-        let inner = self.integrate_legendre(level - 1, table, func, integration_limit);
+        let inner = self.integrate_legendre(level - 1, table, func, integration_limit)?;
         let mut ans = T::ZERO;
         for &(weight, _) in table {
             ans += T::from_f64(weight) * inner;
         }
-        half * ans
+        Ok(half * ans)
     }
 
     /// Gauss-Hermite / Gauss-Laguerre over their fixed domain: nodes are used as-is with no
@@ -142,21 +153,21 @@ impl<T: Numeric> GaussianSingle<T> {
         level: usize,
         table: &'static [(f64, f64)],
         func: &F,
-    ) -> T {
+    ) -> Result<T, IntegrateError> {
         if level == 1 {
             let mut ans = T::ZERO;
             for &(weight, abscissa) in table {
-                ans += T::from_f64(weight) * func(T::from_f64(abscissa));
+                ans += T::from_f64(weight) * finite(func(T::from_f64(abscissa)))?;
             }
-            return ans;
+            return Ok(ans);
         }
 
-        let inner = self.integrate_canonical(level - 1, table, func);
+        let inner = self.integrate_canonical(level - 1, table, func)?;
         let mut ans = T::ZERO;
         for &(weight, _) in table {
             ans += T::from_f64(weight) * inner;
         }
-        ans
+        Ok(ans)
     }
 }
 
@@ -178,8 +189,9 @@ impl<T: Numeric> IntegratorSingleVariable for GaussianSingle<T> {
     ///   method's fixed domain.
     ///
     /// # Errors
-    /// [`IntegrateError::QuadratureOrderOutOfRange`] if the configured order is unsupported, or
-    /// [`IntegrateError::LimitsIllDefined`] if any limit does not match the method's domain.
+    /// [`IntegrateError::QuadratureOrderOutOfRange`] if the configured order is unsupported,
+    /// [`IntegrateError::LimitsIllDefined`] if any limit does not match the method's domain, or
+    /// [`IntegrateError::NonFinite`] if a sampled integrand value is infinite or NaN.
     ///
     /// # Examples
     /// ```
@@ -200,12 +212,12 @@ impl<T: Numeric> IntegratorSingleVariable for GaussianSingle<T> {
         let table = nodes(self.config.integration_method, self.config.order)?;
         self.config.check_limits(integration_limit)?;
 
-        Ok(match self.config.integration_method {
+        match self.config.integration_method {
             GaussianQuadratureMethod::GaussLegendre => {
                 self.integrate_legendre(NUM_INTEGRATIONS, table, func, integration_limit)
             }
             _ => self.integrate_canonical(NUM_INTEGRATIONS, table, func),
-        })
+        }
     }
 }
 
@@ -254,7 +266,7 @@ impl<T: Numeric> GaussianMulti<T> {
         func: &F,
         integration_limits: &[[T; 2]; NUM_INTEGRATIONS],
         point: &[T; NUM_VARS],
-    ) -> T {
+    ) -> Result<T, IntegrateError> {
         let a = integration_limits[level - 1][0];
         let b = integration_limits[level - 1][1];
         let half = (b - a) * T::HALF;
@@ -267,9 +279,9 @@ impl<T: Numeric> GaussianMulti<T> {
         if level == 1 {
             for &(weight, abscissa) in table {
                 current[var] = half * T::from_f64(abscissa) + mid;
-                ans += T::from_f64(weight) * func(&current);
+                ans += T::from_f64(weight) * finite(func(&current))?;
             }
-            return half * ans;
+            return Ok(half * ans);
         }
 
         for &(weight, abscissa) in table {
@@ -282,9 +294,9 @@ impl<T: Numeric> GaussianMulti<T> {
                     func,
                     integration_limits,
                     &current,
-                );
+                )?;
         }
-        half * ans
+        Ok(half * ans)
     }
 
     /// Gauss-Hermite / Gauss-Laguerre partial integration over the fixed domain. The node is
@@ -301,7 +313,7 @@ impl<T: Numeric> GaussianMulti<T> {
         table: &'static [(f64, f64)],
         func: &F,
         point: &[T; NUM_VARS],
-    ) -> T {
+    ) -> Result<T, IntegrateError> {
         let var = idx_to_integrate[level - 1];
 
         let mut current = *point;
@@ -310,17 +322,17 @@ impl<T: Numeric> GaussianMulti<T> {
         if level == 1 {
             for &(weight, abscissa) in table {
                 current[var] = T::from_f64(abscissa);
-                ans += T::from_f64(weight) * func(&current);
+                ans += T::from_f64(weight) * finite(func(&current))?;
             }
-            return ans;
+            return Ok(ans);
         }
 
         for &(weight, abscissa) in table {
             current[var] = T::from_f64(abscissa);
             ans += T::from_f64(weight)
-                * self.integrate_canonical(level - 1, idx_to_integrate, table, func, &current);
+                * self.integrate_canonical(level - 1, idx_to_integrate, table, func, &current)?;
         }
-        ans
+        Ok(ans)
     }
 }
 
@@ -343,8 +355,9 @@ impl<T: Numeric> IntegratorMultiVariable for GaussianMulti<T> {
     ///
     /// # Errors
     /// [`IntegrateError::QuadratureOrderOutOfRange`] if the configured order is unsupported,
-    /// [`IntegrateError::LimitsIllDefined`] if any limit does not match the method's domain, or
-    /// [`IntegrateError::IndexOutOfRange`] if any index is `>= NUM_VARS`.
+    /// [`IntegrateError::LimitsIllDefined`] if any limit does not match the method's domain,
+    /// [`IntegrateError::IndexOutOfRange`] if any index is `>= NUM_VARS`, or
+    /// [`IntegrateError::NonFinite`] if a sampled integrand value is infinite or NaN.
     ///
     /// # Examples
     /// ```
@@ -374,7 +387,7 @@ impl<T: Numeric> IntegratorMultiVariable for GaussianMulti<T> {
             }
         }
 
-        Ok(match self.config.integration_method {
+        match self.config.integration_method {
             GaussianQuadratureMethod::GaussLegendre => self.integrate_legendre(
                 NUM_INTEGRATIONS,
                 idx_to_integrate,
@@ -384,6 +397,6 @@ impl<T: Numeric> IntegratorMultiVariable for GaussianMulti<T> {
                 point,
             ),
             _ => self.integrate_canonical(NUM_INTEGRATIONS, idx_to_integrate, table, func, point),
-        })
+        }
     }
 }

--- a/crates/multicalc/src/numerical_integration/gaussian_integration.rs
+++ b/crates/multicalc/src/numerical_integration/gaussian_integration.rs
@@ -2,20 +2,11 @@ use core::marker::PhantomData;
 
 use crate::error::IntegrateError;
 use crate::gaussian_tables::nodes;
-use crate::numerical_integration::integrator::{IntegratorMultiVariable, IntegratorSingleVariable};
+use crate::numerical_integration::integrator::{
+    IntegratorMultiVariable, IntegratorSingleVariable, is_finite,
+};
 use crate::numerical_integration::mode::GaussianQuadratureMethod;
 use crate::scalar::Numeric;
-
-/// Returns `sample` unchanged, or [`IntegrateError::NonFinite`] if it is NaN or infinite.
-/// The quadrature rules never check their samples otherwise, so a blow-up in the integrand
-/// would silently propagate into a garbage result. Mirrors the `Rk45` policy in `ode/rk45.rs`.
-fn finite<T: Numeric>(sample: T) -> Result<T, IntegrateError> {
-    if sample.is_finite() {
-        Ok(sample)
-    } else {
-        Err(IntegrateError::NonFinite)
-    }
-}
 
 /// Default quadrature order (number of nodes).
 pub const DEFAULT_QUADRATURE_ORDERS: usize = 4;
@@ -132,7 +123,7 @@ impl<T: Numeric> GaussianSingle<T> {
         if level == 1 {
             let mut ans = T::ZERO;
             for &(weight, abscissa) in table {
-                ans += T::from_f64(weight) * finite(func(half * T::from_f64(abscissa) + mid))?;
+                ans += T::from_f64(weight) * is_finite(func(half * T::from_f64(abscissa) + mid))?;
             }
             return Ok(half * ans);
         }
@@ -157,7 +148,7 @@ impl<T: Numeric> GaussianSingle<T> {
         if level == 1 {
             let mut ans = T::ZERO;
             for &(weight, abscissa) in table {
-                ans += T::from_f64(weight) * finite(func(T::from_f64(abscissa)))?;
+                ans += T::from_f64(weight) * is_finite(func(T::from_f64(abscissa)))?;
             }
             return Ok(ans);
         }
@@ -279,7 +270,7 @@ impl<T: Numeric> GaussianMulti<T> {
         if level == 1 {
             for &(weight, abscissa) in table {
                 current[var] = half * T::from_f64(abscissa) + mid;
-                ans += T::from_f64(weight) * finite(func(&current))?;
+                ans += T::from_f64(weight) * is_finite(func(&current))?;
             }
             return Ok(half * ans);
         }
@@ -322,7 +313,7 @@ impl<T: Numeric> GaussianMulti<T> {
         if level == 1 {
             for &(weight, abscissa) in table {
                 current[var] = T::from_f64(abscissa);
-                ans += T::from_f64(weight) * finite(func(&current))?;
+                ans += T::from_f64(weight) * is_finite(func(&current))?;
             }
             return Ok(ans);
         }

--- a/crates/multicalc/src/numerical_integration/integrator.rs
+++ b/crates/multicalc/src/numerical_integration/integrator.rs
@@ -28,6 +28,18 @@ pub(crate) fn classify<T: Numeric>(limit: &[T; 2]) -> Result<Domain<T>, Integrat
     }
 }
 
+/// Returns `sample` unchanged, or [`IntegrateError::NonFinite`] if it is NaN or infinite.
+/// The quadrature and iterative rules never check their samples otherwise, so a blow-up in
+/// the integrand would silently propagate into a garbage result. Mirrors the `Rk45` policy
+/// in `ode/rk45.rs`.
+pub(crate) fn is_finite<T: Numeric>(sample: T) -> Result<T, IntegrateError> {
+    if sample.is_finite() {
+        Ok(sample)
+    } else {
+        Err(IntegrateError::NonFinite)
+    }
+}
+
 /// Returns the `t`-interval the rule walks for a domain. The finite end of a
 /// semi-infinite domain sits at `t = 0` and is perfectly regular, so it is included;
 /// only an infinite end needs the `T::EPSILON` inset that keeps the transform away from

--- a/crates/multicalc/src/numerical_integration/iterative_integration.rs
+++ b/crates/multicalc/src/numerical_integration/iterative_integration.rs
@@ -61,6 +61,17 @@ impl IterativeConfig {
     }
 }
 
+/// Returns `sample` unchanged, or [`IntegrateError::NonFinite`] if it is NaN or infinite.
+/// The iterative rules never check their samples otherwise, so a blow-up in the integrand
+/// would silently propagate into a garbage result. Mirrors the `Rk45` policy in `ode/rk45.rs`.
+fn finite<T: Numeric>(sample: T) -> Result<T, IntegrateError> {
+    if sample.is_finite() {
+        Ok(sample)
+    } else {
+        Err(IntegrateError::NonFinite)
+    }
+}
+
 /// Dispatches to the chosen rule, integrating `g` over `[lo, hi]` with `iterations`
 /// intervals. The caller decides the domain branch before building `g`, so a finite
 /// integral passes `func` straight through with no per-sample transform.
@@ -222,7 +233,7 @@ impl<T: Numeric> IterativeSingle<T> {
         if level == 1 {
             return match domain {
                 Domain::Finite(a, b) => {
-                    integrate_rule(method, iterations, a, b, |x| Ok(func(x)), summation)
+                    integrate_rule(method, iterations, a, b, |x| finite(func(x)), summation)
                 }
                 _ => {
                     let (lo, hi) = t_bounds(&domain);
@@ -233,7 +244,7 @@ impl<T: Numeric> IterativeSingle<T> {
                         hi,
                         |t| {
                             let (x, jacobian) = map_sample(&domain, t);
-                            Ok(func(x) * jacobian)
+                            finite(func(x) * jacobian)
                         },
                         summation,
                     )
@@ -244,7 +255,7 @@ impl<T: Numeric> IterativeSingle<T> {
         let inner = self.integrate(level - 1, func, integration_limit)?;
         match domain {
             Domain::Finite(a, b) => {
-                integrate_rule(method, iterations, a, b, |_| Ok(inner), summation)
+                integrate_rule(method, iterations, a, b, |_| finite(inner), summation)
             }
             _ => {
                 let (lo, hi) = t_bounds(&domain);
@@ -255,7 +266,7 @@ impl<T: Numeric> IterativeSingle<T> {
                     hi,
                     |t| {
                         let (_, jacobian) = map_sample(&domain, t);
-                        Ok(inner * jacobian)
+                        finite(inner * jacobian)
                     },
                     summation,
                 )
@@ -279,8 +290,9 @@ impl<T: Numeric> IntegratorSingleVariable for IterativeSingle<T> {
     /// * `integration_limit` - the `[lower, upper]` limit for each level of integration.
     ///
     /// # Errors
-    /// [`IntegrateError::IterationsZero`] if the configured iteration count is zero, or
-    /// [`IntegrateError::LimitsIllDefined`] if any limit is ill-defined.
+    /// [`IntegrateError::IterationsZero`] if the configured iteration count is zero,
+    /// [`IntegrateError::LimitsIllDefined`] if any limit is ill-defined, or
+    /// [`IntegrateError::NonFinite`] if a sampled integrand value is infinite or NaN.
     ///
     /// # Examples
     /// ```
@@ -378,7 +390,7 @@ impl<T: Numeric> IterativeMulti<T> {
                     b,
                     |x| {
                         current[var] = x;
-                        Ok(func(&current))
+                        finite(func(&current))
                     },
                     summation,
                 ),
@@ -392,7 +404,7 @@ impl<T: Numeric> IterativeMulti<T> {
                         |t| {
                             let (x, jacobian) = map_sample(&domain, t);
                             current[var] = x;
-                            Ok(func(&current) * jacobian)
+                            finite(func(&current) * jacobian)
                         },
                         summation,
                     )
@@ -436,7 +448,7 @@ impl<T: Numeric> IterativeMulti<T> {
                             integration_limits,
                             &current,
                         )?;
-                        Ok(inner * jacobian)
+                        finite(inner * jacobian)
                     },
                     summation,
                 )
@@ -460,8 +472,9 @@ impl<T: Numeric> IntegratorMultiVariable for IterativeMulti<T> {
     ///
     /// # Errors
     /// [`IntegrateError::IterationsZero`] if the configured iteration count is zero,
-    /// [`IntegrateError::LimitsIllDefined`] if any limit is ill-defined, or
-    /// [`IntegrateError::IndexOutOfRange`] if any index is `>= NUM_VARS`.
+    /// [`IntegrateError::LimitsIllDefined`] if any limit is ill-defined,
+    /// [`IntegrateError::IndexOutOfRange`] if any index is `>= NUM_VARS`, or
+    /// [`IntegrateError::NonFinite`] if a sampled integrand value is infinite or NaN.
     ///
     /// # Examples
     /// ```

--- a/crates/multicalc/src/numerical_integration/iterative_integration.rs
+++ b/crates/multicalc/src/numerical_integration/iterative_integration.rs
@@ -61,17 +61,6 @@ impl IterativeConfig {
     }
 }
 
-/// Returns `sample` unchanged, or [`IntegrateError::NonFinite`] if it is NaN or infinite.
-/// The iterative rules never check their samples otherwise, so a blow-up in the integrand
-/// would silently propagate into a garbage result. Mirrors the `Rk45` policy in `ode/rk45.rs`.
-fn finite<T: Numeric>(sample: T) -> Result<T, IntegrateError> {
-    if sample.is_finite() {
-        Ok(sample)
-    } else {
-        Err(IntegrateError::NonFinite)
-    }
-}
-
 /// Dispatches to the chosen rule, integrating `g` over `[lo, hi]` with `iterations`
 /// intervals. The caller decides the domain branch before building `g`, so a finite
 /// integral passes `func` straight through with no per-sample transform.
@@ -233,7 +222,7 @@ impl<T: Numeric> IterativeSingle<T> {
         if level == 1 {
             return match domain {
                 Domain::Finite(a, b) => {
-                    integrate_rule(method, iterations, a, b, |x| finite(func(x)), summation)
+                    integrate_rule(method, iterations, a, b, |x| is_finite(func(x)), summation)
                 }
                 _ => {
                     let (lo, hi) = t_bounds(&domain);
@@ -244,7 +233,7 @@ impl<T: Numeric> IterativeSingle<T> {
                         hi,
                         |t| {
                             let (x, jacobian) = map_sample(&domain, t);
-                            finite(func(x) * jacobian)
+                            is_finite(func(x) * jacobian)
                         },
                         summation,
                     )
@@ -255,7 +244,7 @@ impl<T: Numeric> IterativeSingle<T> {
         let inner = self.integrate(level - 1, func, integration_limit)?;
         match domain {
             Domain::Finite(a, b) => {
-                integrate_rule(method, iterations, a, b, |_| finite(inner), summation)
+                integrate_rule(method, iterations, a, b, |_| is_finite(inner), summation)
             }
             _ => {
                 let (lo, hi) = t_bounds(&domain);
@@ -266,7 +255,7 @@ impl<T: Numeric> IterativeSingle<T> {
                     hi,
                     |t| {
                         let (_, jacobian) = map_sample(&domain, t);
-                        finite(inner * jacobian)
+                        is_finite(inner * jacobian)
                     },
                     summation,
                 )
@@ -390,7 +379,7 @@ impl<T: Numeric> IterativeMulti<T> {
                     b,
                     |x| {
                         current[var] = x;
-                        finite(func(&current))
+                        is_finite(func(&current))
                     },
                     summation,
                 ),
@@ -404,7 +393,7 @@ impl<T: Numeric> IterativeMulti<T> {
                         |t| {
                             let (x, jacobian) = map_sample(&domain, t);
                             current[var] = x;
-                            finite(func(&current) * jacobian)
+                            is_finite(func(&current) * jacobian)
                         },
                         summation,
                     )
@@ -448,7 +437,7 @@ impl<T: Numeric> IterativeMulti<T> {
                             integration_limits,
                             &current,
                         )?;
-                        finite(inner * jacobian)
+                        is_finite(inner * jacobian)
                     },
                     summation,
                 )

--- a/crates/multicalc/tests/suite/numerical_integration.rs
+++ b/crates/multicalc/tests/suite/numerical_integration.rs
@@ -373,6 +373,32 @@ fn test_error_checking_4() {
 }
 
 #[test]
+fn test_error_checking_5() {
+    //integrand returns NaN, which the iterative rule must surface instead of a garbage number
+    let func = |_args: f64| -> f64 { f64::NAN };
+
+    let integration_limit = [0.0, 1.0];
+
+    let integrator = iterative_integration::IterativeSingle::default();
+    let result = integrator.get_single(&func, &integration_limit);
+    assert!(result.is_err());
+    assert!(result.unwrap_err() == IntegrateError::NonFinite);
+}
+
+#[test]
+fn test_error_checking_6() {
+    //integrand blows up to infinity, which Gauss-Legendre must surface as an error
+    let func = |_args: f64| -> f64 { f64::INFINITY };
+
+    let integration_limit = [0.0, 2.0];
+
+    let integrator = gaussian_integration::GaussianSingle::default();
+    let result = integrator.get_single(&func, &integration_limit);
+    assert!(result.is_err());
+    assert!(result.unwrap_err() == IntegrateError::NonFinite);
+}
+
+#[test]
 fn test_gauss_hermite_single() {
     //integrand is x*x; weights carry the e^{-x*x} kernel
     //∫_{-∞}^∞ x² e^{-x²} dx = √π / 2


### PR DESCRIPTION
## What & why

The iterative and Gaussian integrators never checked their integrand samples, so a `NaN` or `Inf` from the integrand silently produced a garbage number instead of an error. `Rk45` already returns `IntegrateError::NonFinite` in this situation, so this follows that example: each sampled value is checked and `NonFinite` is returned on a non-finite result. Closes https://github.com/kmolan/multicalc-rust/issues/154

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)