### PR TITLE
fix(linalg): reject near-singular Matrix::inverse via EPSILON-scaled det

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Iterative integrators return `IntegrateError::LimitsIllDefined` instead of `NaN`
   if `classify` fails after validation. @rtmongold (#171)
 - RK45 now handles zero-dimensional states without producing NaN norms. (#159)
+- 2×2/3×3/4×4 `Matrix::inverse` reject near-singular inputs via an
+  `EPSILON`-scaled det check instead of exact `det == 0`. @rtmongold (#181)
 
 ## [0.8.0] - 2026-07-16
 

--- a/crates/multicalc/src/linear_algebra/matrix.rs
+++ b/crates/multicalc/src/linear_algebra/matrix.rs
@@ -156,6 +156,26 @@ impl<const ROWS: usize, const COLS: usize, T: Numeric> Matrix<ROWS, COLS, T> {
     pub fn is_finite(self) -> bool {
         self.data.iter().flatten().all(|x| x.is_finite())
     }
+
+    /// Largest absolute entry; used to scale near-singularity checks.
+    #[inline]
+    #[must_use]
+    fn max_abs(self) -> T {
+        let mut best = T::ZERO;
+        for r in 0..ROWS {
+            for c in 0..COLS {
+                best = best.max(self[(r, c)].abs());
+            }
+        }
+        best
+    }
+
+    /// `true` when `|det|` is at or below `EPSILON * n * scale^n`.
+    #[inline]
+    #[must_use]
+    fn det_near_singular(det: T, scale: T, n: usize) -> bool {
+        det.abs() <= T::EPSILON * T::from_usize(n) * scale.powi(n as i32)
+    }
 }
 
 impl<const N: usize, T: Numeric> Matrix<N, N, T> {
@@ -297,8 +317,8 @@ impl<T: Numeric> Matrix<2, 2, T> {
         self[(0, 0)] * self[(1, 1)] - self[(0, 1)] * self[(1, 0)]
     }
 
-    /// The inverse, or [`LinalgError::Singular`] if the matrix is singular
-    /// (`determinant() == 0`).
+    /// The inverse, or [`LinalgError::Singular`] if the matrix is singular or
+    /// near-singular (`|det|` at or below an `EPSILON`-scaled threshold).
     ///
     /// ```
     /// use multicalc::linear_algebra::Matrix;
@@ -310,7 +330,7 @@ impl<T: Numeric> Matrix<2, 2, T> {
     #[inline]
     pub fn inverse(self) -> Result<Self, LinalgError> {
         let det = self.determinant();
-        if det == T::ZERO {
+        if Self::det_near_singular(det, self.max_abs(), 2) {
             return Err(LinalgError::Singular);
         }
         let inv = T::ONE / det;
@@ -339,8 +359,8 @@ impl<T: Numeric> Matrix<3, 3, T> {
             + m[(0, 2)] * (m[(1, 0)] * m[(2, 1)] - m[(1, 1)] * m[(2, 0)])
     }
 
-    /// The inverse, or [`LinalgError::Singular`] if the matrix is singular
-    /// (`determinant() == 0`).
+    /// The inverse, or [`LinalgError::Singular`] if the matrix is singular or
+    /// near-singular (`|det|` at or below an `EPSILON`-scaled threshold).
     ///
     /// ```
     /// use multicalc::linear_algebra::Matrix;
@@ -350,7 +370,7 @@ impl<T: Numeric> Matrix<3, 3, T> {
     #[inline]
     pub fn inverse(self) -> Result<Self, LinalgError> {
         let det = self.determinant();
-        if det == T::ZERO {
+        if Self::det_near_singular(det, self.max_abs(), 3) {
             return Err(LinalgError::Singular);
         }
         let inv = T::ONE / det;
@@ -422,8 +442,8 @@ impl<T: Numeric> Matrix<4, 4, T> {
         s[0] * c[5] - s[1] * c[4] + s[2] * c[3] + s[3] * c[2] - s[4] * c[1] + s[5] * c[0]
     }
 
-    /// The inverse, or [`LinalgError::Singular`] if the matrix is singular
-    /// (`determinant() == 0`).
+    /// The inverse, or [`LinalgError::Singular`] if the matrix is singular or
+    /// near-singular (`|det|` at or below an `EPSILON`-scaled threshold).
     ///
     /// Built from the adjugate, the transpose of the cofactor matrix, scaled by `1/det`.
     ///
@@ -447,7 +467,7 @@ impl<T: Numeric> Matrix<4, 4, T> {
     pub fn inverse(self) -> Result<Self, LinalgError> {
         let (s, c) = self.row_pair_minors();
         let det = s[0] * c[5] - s[1] * c[4] + s[2] * c[3] + s[3] * c[2] - s[4] * c[1] + s[5] * c[0];
-        if det == T::ZERO {
+        if Self::det_near_singular(det, self.max_abs(), 4) {
             return Err(LinalgError::Singular);
         }
         let inv = T::ONE / det;

--- a/crates/multicalc/src/linear_algebra/test.rs
+++ b/crates/multicalc/src/linear_algebra/test.rs
@@ -351,8 +351,8 @@ fn factorization_work_counts() {
     // apply. The multiply/divide counts below are fixed functions of the size — for a 4x4:
     //   LU:       divisions N(N-1)/2 = 6, multiplications sum_{p<N} p^2 = 14  -> 20
     //   Cholesky: multiplications 10, divisions 6                            -> 16
-    // and the direct inverse is a cofactor expansion. If any of these change, update the
-    // expected counts below.
+    //   Inverse:  cofactor expansion (95) plus EPSILON * n * scale^n (5)     -> 100
+    // If any of these change, update the expected counts below.
     let a =
         Matrix::<4, 4, Counted>::from_fn(|i, j| if i == j { Counted(4.0) } else { Counted(1.0) });
 
@@ -380,7 +380,7 @@ fn factorization_work_counts() {
         let _ = a3.svd().unwrap();
     });
 
-    assert_eq!((lu, cholesky, inverse), (20, 16, 95));
+    assert_eq!((lu, cholesky, inverse), (20, 16, 100));
     // One-sided Jacobi converges in a fixed number of sweeps for this input.
     assert_eq!(svd, 441);
 }

--- a/crates/multicalc/tests/suite/linear_algebra/matrix.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/matrix.rs
@@ -90,6 +90,19 @@ fn matrix_inverse() {
     let singular3 = Matrix::new([[1.0, 2.0, 3.0], [2.0, 4.0, 6.0], [1.0, 1.0, 1.0]]);
     assert_eq!(singular3.determinant(), 0.0);
     assert_eq!(singular3.inverse(), Err(LinalgError::Singular));
+
+    // Near-singular: det is tiny but nonzero under exact compare.
+    let near2 = Matrix::new([[1.0, 1.0], [1.0, 1.0 + f64::EPSILON]]);
+    assert_ne!(near2.determinant(), 0.0);
+    assert_eq!(near2.inverse(), Err(LinalgError::Singular));
+
+    let near3 = Matrix::new([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, f64::EPSILON]]);
+    assert_ne!(near3.determinant(), 0.0);
+    assert_eq!(near3.inverse(), Err(LinalgError::Singular));
+
+    // Tiny but full-rank still inverts (scaled threshold, not absolute eps).
+    let tiny = Matrix::<2, 2>::identity().scale(1e-8);
+    assert!(tiny.inverse().is_ok());
 }
 
 #[test]
@@ -167,6 +180,16 @@ fn matrix_4x4_determinant_and_inverse() {
         [1.0, 2.0, 3.0, 4.0],
     ]);
     assert_identity(af * af.inverse().unwrap(), 1e-5_f32);
+
+    // Near-singular: det is tiny but nonzero under exact compare.
+    let near4 = Matrix::<4, 4>::new([
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [1.0, 1.0, 1.0, f64::EPSILON],
+    ]);
+    assert_ne!(near4.determinant(), 0.0);
+    assert_eq!(near4.inverse(), Err(LinalgError::Singular));
 }
 
 #[test]


### PR DESCRIPTION
Closes #153 

2×2/3×3/4×4 `Matrix::inverse` now treat near-singular matrices as singular using `|det| ≤ EPSILON * n * scale^n` (scale = max abs entry) instead of exact `det == 0`.

Add near-singular coverage for 2×2/3×3/4×4 and a scaled full-rank case that still inverts.

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [ ] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
