### PR TITLE
feat(linalg): dual Matrix/Vector access (Index + get/try_*)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Const-evaluable solver constructors, AutoDiff `new()`, and Gaussian quadrature node
   tables / `nodes`. @rtmongold (#168)
+- Add `Matrix::try_row` / `try_column` (`Option`, OOB -> `None`). @rtmongold (#185)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Const-evaluable solver constructors, AutoDiff `new()`, and Gaussian quadrature node
   tables / `nodes`. @rtmongold (#168)
-- Add `Matrix::try_row` / `try_column` (`Option`, OOB -> `None`). @rtmongold (#185)
+- Add `Vector`/`Matrix` `get` / `get_mut`, `Matrix::try_row` / `try_column`, and
+  `Matrix::as_mut_slice_rows`. @rtmongold (#185)
 
 ### Fixed
 
@@ -20,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RK45 now handles zero-dimensional states without producing NaN norms. (#159)
 - 2×2/3×3/4×4 `Matrix::inverse` reject near-singular inputs via an
   `EPSILON`-scaled det check instead of exact `det == 0`. @rtmongold (#181)
+
+### Changed
+
+- Keep panicking `Index` / `IndexMut` as the ergonomic Matrix/Vector access path.
+  Remove panicking `row` / `column` (use `try_row` / `try_column`). @rtmongold (#185)
 
 ## [0.8.0] - 2026-07-16
 

--- a/crates/multicalc/GUIDE.md
+++ b/crates/multicalc/GUIDE.md
@@ -251,7 +251,10 @@ Errors: the underlying derivatives return [`DiffError`](#error-handling). Full d
 ## Linear algebra
 
 Fixed-size, stack-allocated `Matrix` and `Vector`. Dimensions are const generics, so a shape
-mismatch is a compile error, nothing is heap-allocated, and the math never panics.
+mismatch is a compile error and nothing is heap-allocated. Indexing (`v[i]`, `m[(r, c)]`) is
+the ergonomic path and panics on out-of-range like `Vec`. Use `get` / `get_mut` /
+`try_row` / `try_column` when you want `Option` instead of a panic (panicking `row` /
+`column` were removed).
 
 - `Matrix::lu` → `Lu`: partial-pivoting Doolittle LU; `solve`, `determinant`, `inverse`.
 - `Matrix::cholesky` → `Cholesky`: faster path for symmetric positive-definite matrices.
@@ -513,18 +516,20 @@ let dt = 0.1;
 // Zero-order hold of the double integrator: F = [[1, dt], [0, 1]], G = [[dt^2/2], [dt]].
 let a = Matrix::<2, 2>::new([[0.0, 1.0], [0.0, 0.0]]);
 let b = Matrix::<2, 1>::new([[0.0], [1.0]]);
-let (f, g) = zoh::<2, 1, 3, f64>(a, b, dt).unwrap();      // f[(0, 1)] = dt, g[(1, 0)] = dt
+let (f, g) = zoh::<2, 1, 3, f64>(a, b, dt).unwrap();      // f[(0, 1)] == dt, g[(1, 0)] == dt
 
 // Van Loan process-noise discretization of continuous white noise on velocity.
 let qc = Matrix::<2, 2>::new([[0.0, 0.0], [0.0, 1.0]]);
-let (_f, qd) = van_loan::<2, 4, f64>(a, qc, dt).unwrap(); // qd[(1, 1)] = dt, symmetric
+let (_f, qd) = van_loan::<2, 4, f64>(a, qc, dt).unwrap(); // qd[(1, 1)] == dt, symmetric
 
 // Discrete white-noise model.
-let q = q_discrete_white_noise::<2, f64>(dt, 2.0);        // q[(1, 1)] = 2*dt^2
+let q = q_discrete_white_noise::<2, f64>(dt, 2.0);        // q[(1, 1)] == 2*dt^2
 
 // d/dx expm(x·M) at x = 0 equals M, recovered by one Dual through expm.
 let m = Matrix::<2, 2>::new([[0.2, 0.5], [-0.1, 0.3]]);
-let ad = Matrix::<2, 2, Dual<f64>>::from_fn(|i, j| Dual::new(0.0, m[(i, j)]))
+let ad = Matrix::<2, 2, Dual<f64>>::from_fn(|i, j| {
+  Dual::new(0.0, m[(i, j)])
+})
     .expm()
     .unwrap();
 // ad[(0, 1)].deriv == m[(0, 1)]

--- a/crates/multicalc/src/kinematics/differential_drive.rs
+++ b/crates/multicalc/src/kinematics/differential_drive.rs
@@ -148,21 +148,20 @@ impl<T: Numeric> BodyTwist<T> {
     /// Projects an se(2) tangent onto the motions a differential drive can produce, discarding the
     /// lateral component.
     ///
-    /// Lossy: `BodyTwist::project_tangent(xi).to_tangent()` equals `xi` only when `xi[1]` is
-    /// zero. [`tangent_slip`](Self::tangent_slip) reports what is discarded.
+    /// Lossy: `BodyTwist::project_tangent(xi).to_tangent()` equals `xi` only when the
+    /// lateral is zero. `tangent_slip` reports what is discarded.
     #[inline]
     pub fn project_tangent(xi: Vector<3, T>) -> Self {
-        BodyTwist {
-            linear: xi[0],
-            angular: xi[2],
-        }
+        let [linear, _, angular] = *xi.as_array();
+        BodyTwist { linear, angular }
     }
 
     /// The lateral component of `xi`, which [`project_tangent`](Self::project_tangent) discards.
     /// Zero for any motion a differential drive can produce.
     #[inline]
     pub fn tangent_slip(xi: Vector<3, T>) -> T {
-        xi[1]
+        let [_, lateral, _] = *xi.as_array();
+        lateral
     }
 
     /// The arc traced over `dt` by holding this twist constant.

--- a/crates/multicalc/src/kinematics/odometry.rs
+++ b/crates/multicalc/src/kinematics/odometry.rs
@@ -44,6 +44,7 @@ impl VectorFn<5, 3> for OdometryStep {
         let pose = SE2::from_parts(SO2::exp(p[2]), Vector::new([p[0], p[1]]));
         let next = pose * SE2::exp(Vector::new([p[3], S::ZERO, p[4]]));
         let t = next.translation();
-        [t[0], t[1], next.rotation().log()]
+        let [tx, ty] = *t.as_array();
+        [tx, ty, next.rotation().log()]
     }
 }

--- a/crates/multicalc/src/linear_algebra/cholesky.rs
+++ b/crates/multicalc/src/linear_algebra/cholesky.rs
@@ -140,7 +140,8 @@ impl<const N: usize, T: Numeric> Cholesky<N, T> {
     pub fn solve_matrix<const K: usize>(&self, b: Matrix<N, K, T>) -> Matrix<N, K, T> {
         let mut result = Matrix::zeros();
         for c in 0..K {
-            let x = self.solve(b.column(c));
+            let col = Vector::from_fn(|r| b[(r, c)]);
+            let x = self.solve(col);
             for r in 0..N {
                 result[(r, c)] = x[r];
             }

--- a/crates/multicalc/src/linear_algebra/expm.rs
+++ b/crates/multicalc/src/linear_algebra/expm.rs
@@ -65,12 +65,8 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
         for _ in 0..s {
             result = result * result;
         }
-        for i in 0..N {
-            for j in 0..N {
-                if !result[(i, j)].is_finite() {
-                    return Err(LinalgError::NonFinite);
-                }
-            }
+        if !result.is_finite() {
+            return Err(LinalgError::NonFinite);
         }
         Ok(result)
     }

--- a/crates/multicalc/src/linear_algebra/lu.rs
+++ b/crates/multicalc/src/linear_algebra/lu.rs
@@ -65,11 +65,7 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
                 return Err(LinalgError::Singular);
             }
             if p != k {
-                for c in 0..N {
-                    let tmp = a[(k, c)];
-                    a[(k, c)] = a[(p, c)];
-                    a[(p, c)] = tmp;
-                }
+                a.as_mut_slice_rows().swap(k, p);
                 perm.swap(k, p);
                 sign = -sign;
             }
@@ -78,8 +74,8 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
                 let factor = a[(i, k)] / a[(k, k)];
                 a[(i, k)] = factor;
                 for j in (k + 1)..N {
-                    let term = factor * a[(k, j)];
-                    a[(i, j)] -= term;
+                    let akj = a[(k, j)];
+                    a[(i, j)] -= factor * akj;
                 }
             }
         }
@@ -202,7 +198,8 @@ impl<const N: usize, T: Numeric> Lu<N, T> {
     pub fn solve_matrix<const K: usize>(&self, b: Matrix<N, K, T>) -> Matrix<N, K, T> {
         let mut result = Matrix::zeros();
         for c in 0..K {
-            let x = self.solve(b.column(c));
+            let col = Vector::from_fn(|r| b[(r, c)]);
+            let x = self.solve(col);
             for r in 0..N {
                 result[(r, c)] = x[r];
             }

--- a/crates/multicalc/src/linear_algebra/matrix.rs
+++ b/crates/multicalc/src/linear_algebra/matrix.rs
@@ -83,6 +83,20 @@ impl<const ROWS: usize, const COLS: usize, T: Copy> Matrix<ROWS, COLS, T> {
         (slice.len() == ROWS * COLS).then(|| Self::from_fn(|r, c| slice[r * COLS + c]))
     }
 
+    /// Copies row `r`, or `None` if `r >= ROWS`.
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::{Matrix, Vector};
+    /// let m = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
+    /// assert_eq!(m.try_row(1), Some(Vector::new([3.0, 4.0])));
+    /// assert_eq!(m.try_row(2), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn try_row(&self, r: usize) -> Option<Vector<COLS, T>> {
+        self.data.get(r).copied().map(Vector::new)
+    }
+
     /// Copies row `r` into a vector. Panics if `r >= ROWS`.
     ///
     /// ```
@@ -93,6 +107,25 @@ impl<const ROWS: usize, const COLS: usize, T: Copy> Matrix<ROWS, COLS, T> {
     #[inline]
     pub fn row(&self, r: usize) -> Vector<COLS, T> {
         Vector::new(self.data[r])
+    }
+
+    /// Copies column `c`, or `None` if `c >= COLS`.
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::{Matrix, Vector};
+    /// let m = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
+    /// assert_eq!(m.try_column(1), Some(Vector::new([2.0, 4.0])));
+    /// assert_eq!(m.try_column(2), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn try_column(&self, c: usize) -> Option<Vector<ROWS, T>> {
+        let &probe = self.data.first().and_then(|row| row.get(c))?;
+        let mut data = [probe; ROWS];
+        for (dst, row) in data.iter_mut().zip(&self.data) {
+            *dst = *row.get(c)?;
+        }
+        Some(Vector::new(data))
     }
 
     /// Copies column `c` into a vector. Panics if `c >= COLS`.

--- a/crates/multicalc/src/linear_algebra/matrix.rs
+++ b/crates/multicalc/src/linear_algebra/matrix.rs
@@ -14,6 +14,7 @@ use crate::scalar::Numeric;
 /// let b = Matrix::new([[5.0, 6.0], [7.0, 8.0]]);
 ///
 /// assert_eq!(a[(0, 1)], 2.0);
+/// assert_eq!(a.get(0, 1), Some(&2.0));
 /// assert_eq!((a + b).into_array(), [[6.0, 8.0], [10.0, 12.0]]);
 /// assert_eq!((b - a).into_array(), [[4.0, 4.0], [4.0, 4.0]]);
 /// assert_eq!((-a).into_array(), [[-1.0, -2.0], [-3.0, -4.0]]);
@@ -49,6 +50,21 @@ impl<const ROWS: usize, const COLS: usize, T> Matrix<ROWS, COLS, T> {
         }
     }
 
+    // Crate-internal panic path (also used by Index). Public: prefer `[]`; use `get` when fallible.
+    #[inline]
+    #[track_caller]
+    pub(crate) fn at(&self, row: usize, col: usize) -> &T {
+        #[allow(clippy::indexing_slicing)]
+        &self.data[row][col]
+    }
+
+    #[inline]
+    #[track_caller]
+    pub(crate) fn at_mut(&mut self, row: usize, col: usize) -> &mut T {
+        #[allow(clippy::indexing_slicing)]
+        &mut self.data[row][col]
+    }
+
     /// Borrows the rows.
     ///
     /// ```
@@ -59,6 +75,48 @@ impl<const ROWS: usize, const COLS: usize, T> Matrix<ROWS, COLS, T> {
     #[must_use]
     pub const fn as_slice_rows(&self) -> &[[T; COLS]; ROWS] {
         &self.data
+    }
+
+    /// Borrows the rows mutably.
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::Matrix;
+    /// let mut m = Matrix::new([[1.0, 2.0]]);
+    /// m.as_mut_slice_rows()[0][1] = 9.0;
+    /// assert_eq!(m[(0, 1)], 9.0);
+    /// ```
+    #[inline]
+    pub fn as_mut_slice_rows(&mut self) -> &mut [[T; COLS]; ROWS] {
+        &mut self.data
+    }
+
+    /// Returns a reference to entry `(row, col)`, or `None` if out of range.
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::Matrix;
+    /// let m = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
+    /// assert_eq!(m.get(1, 0), Some(&3.0));
+    /// assert_eq!(m.get(2, 0), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn get(&self, row: usize, col: usize) -> Option<&T> {
+        self.data.get(row).and_then(|r| r.get(col))
+    }
+
+    /// Returns a mutable reference to entry `(row, col)`, or `None` if out of range.
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::Matrix;
+    /// let mut m = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
+    /// if let Some(x) = m.get_mut(0, 1) {
+    ///     *x = 7.0;
+    /// }
+    /// assert_eq!(m.get(0, 1), Some(&7.0));
+    /// ```
+    #[inline]
+    pub fn get_mut(&mut self, row: usize, col: usize) -> Option<&mut T> {
+        self.data.get_mut(row).and_then(|r| r.get_mut(col))
     }
 
     /// Consumes the matrix, returning its rows.
@@ -80,6 +138,8 @@ impl<const ROWS: usize, const COLS: usize, T: Copy> Matrix<ROWS, COLS, T> {
     #[inline]
     #[must_use]
     pub fn try_from_row_slice(slice: &[T]) -> Option<Self> {
+        // In-bounds by construction: `r < ROWS`, `c < COLS`, and the length was just checked.
+        #[allow(clippy::indexing_slicing)]
         (slice.len() == ROWS * COLS).then(|| Self::from_fn(|r, c| slice[r * COLS + c]))
     }
 
@@ -97,18 +157,6 @@ impl<const ROWS: usize, const COLS: usize, T: Copy> Matrix<ROWS, COLS, T> {
         self.data.get(r).copied().map(Vector::new)
     }
 
-    /// Copies row `r` into a vector. Panics if `r >= ROWS`.
-    ///
-    /// ```
-    /// use multicalc::linear_algebra::{Matrix, Vector};
-    /// let m = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
-    /// assert_eq!(m.row(1), Vector::new([3.0, 4.0]));
-    /// ```
-    #[inline]
-    pub fn row(&self, r: usize) -> Vector<COLS, T> {
-        Vector::new(self.data[r])
-    }
-
     /// Copies column `c`, or `None` if `c >= COLS`.
     ///
     /// ```
@@ -116,28 +164,14 @@ impl<const ROWS: usize, const COLS: usize, T: Copy> Matrix<ROWS, COLS, T> {
     /// let m = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
     /// assert_eq!(m.try_column(1), Some(Vector::new([2.0, 4.0])));
     /// assert_eq!(m.try_column(2), None);
+    /// let empty: Matrix<0, 3> = Matrix::zeros();
+    /// assert_eq!(empty.try_column(0), Some(Vector::<0>::zeros()));
+    /// assert_eq!(empty.try_column(3), None);
     /// ```
     #[inline]
     #[must_use]
     pub fn try_column(&self, c: usize) -> Option<Vector<ROWS, T>> {
-        let &probe = self.data.first().and_then(|row| row.get(c))?;
-        let mut data = [probe; ROWS];
-        for (dst, row) in data.iter_mut().zip(&self.data) {
-            *dst = *row.get(c)?;
-        }
-        Some(Vector::new(data))
-    }
-
-    /// Copies column `c` into a vector. Panics if `c >= COLS`.
-    ///
-    /// ```
-    /// use multicalc::linear_algebra::{Matrix, Vector};
-    /// let m = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
-    /// assert_eq!(m.column(0), Vector::new([1.0, 3.0]));
-    /// ```
-    #[inline]
-    pub fn column(&self, c: usize) -> Vector<ROWS, T> {
-        Vector::from_fn(|r| self.data[r][c])
+        (c < COLS).then(|| Vector::from_fn(|r| self.data[r][c]))
     }
 }
 
@@ -195,9 +229,9 @@ impl<const ROWS: usize, const COLS: usize, T: Numeric> Matrix<ROWS, COLS, T> {
     #[must_use]
     fn max_abs(self) -> T {
         let mut best = T::ZERO;
-        for r in 0..ROWS {
-            for c in 0..COLS {
-                best = best.max(self[(r, c)].abs());
+        for row in &self.data {
+            for x in row {
+                best = best.max(x.abs());
             }
         }
         best
@@ -239,7 +273,7 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
     pub fn determinant(self) -> T {
         match N {
             0 => T::ONE,
-            1 => self[(0, 0)],
+            1 => self.data[0][0],
             2 => self.determinant_2x2(),
             3 => self.determinant_3x3(),
             4 => self.determinant_4x4(),
@@ -259,7 +293,7 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
     /// ```
     /// use multicalc::linear_algebra::Matrix;
     /// let m: Matrix<2, 2> = Matrix::new([[4.0, 7.0], [2.0, 6.0]]);
-    /// let p = m * m.inverse().unwrap();
+    /// let p = (m * m.inverse().unwrap());
     /// assert!((p[(0, 0)] - 1.0).abs() < 1e-12 && (p[(1, 1)] - 1.0).abs() < 1e-12);
     /// assert!(Matrix::<2, 2>::new([[1.0, 2.0], [2.0, 4.0]]).inverse().is_err());
     /// ```
@@ -277,17 +311,17 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
 
     #[inline]
     fn inverse_1x1(mut self) -> Result<Self, LinalgError> {
-        let value = self[(0, 0)];
+        let value = self.data[0][0];
         if Self::det_near_singular(value, value.abs(), 1) {
             return Err(LinalgError::Singular);
         }
-        self[(0, 0)] = T::ONE / value;
+        self.data[0][0] = T::ONE / value;
         Ok(self)
     }
 
     #[inline]
     fn determinant_2x2(self) -> T {
-        self[(0, 0)] * self[(1, 1)] - self[(0, 1)] * self[(1, 0)]
+        self.data[0][0] * self.data[1][1] - self.data[0][1] * self.data[1][0]
     }
 
     #[inline]
@@ -297,20 +331,20 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
             return Err(LinalgError::Singular);
         }
         let scale = T::ONE / determinant;
-        let m = self;
-        self[(0, 0)] = m[(1, 1)] * scale;
-        self[(0, 1)] = -m[(0, 1)] * scale;
-        self[(1, 0)] = -m[(1, 0)] * scale;
-        self[(1, 1)] = m[(0, 0)] * scale;
+        let m = self.data;
+        self.data[0][0] = m[1][1] * scale;
+        self.data[0][1] = -m[0][1] * scale;
+        self.data[1][0] = -m[1][0] * scale;
+        self.data[1][1] = m[0][0] * scale;
         Ok(self)
     }
 
     #[inline]
     fn determinant_3x3(self) -> T {
-        let m = self;
-        m[(0, 0)] * (m[(1, 1)] * m[(2, 2)] - m[(1, 2)] * m[(2, 1)])
-            - m[(0, 1)] * (m[(1, 0)] * m[(2, 2)] - m[(1, 2)] * m[(2, 0)])
-            + m[(0, 2)] * (m[(1, 0)] * m[(2, 1)] - m[(1, 1)] * m[(2, 0)])
+        let m = self.data;
+        m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+            - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+            + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0])
     }
 
     #[inline]
@@ -320,27 +354,27 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
             return Err(LinalgError::Singular);
         }
         let scale = T::ONE / determinant;
-        let m = self;
+        let m = self.data;
         let adjugate = [
             [
-                m[(1, 1)] * m[(2, 2)] - m[(1, 2)] * m[(2, 1)],
-                m[(0, 2)] * m[(2, 1)] - m[(0, 1)] * m[(2, 2)],
-                m[(0, 1)] * m[(1, 2)] - m[(0, 2)] * m[(1, 1)],
+                m[1][1] * m[2][2] - m[1][2] * m[2][1],
+                m[0][2] * m[2][1] - m[0][1] * m[2][2],
+                m[0][1] * m[1][2] - m[0][2] * m[1][1],
             ],
             [
-                m[(1, 2)] * m[(2, 0)] - m[(1, 0)] * m[(2, 2)],
-                m[(0, 0)] * m[(2, 2)] - m[(0, 2)] * m[(2, 0)],
-                m[(0, 2)] * m[(1, 0)] - m[(0, 0)] * m[(1, 2)],
+                m[1][2] * m[2][0] - m[1][0] * m[2][2],
+                m[0][0] * m[2][2] - m[0][2] * m[2][0],
+                m[0][2] * m[1][0] - m[0][0] * m[1][2],
             ],
             [
-                m[(1, 0)] * m[(2, 1)] - m[(1, 1)] * m[(2, 0)],
-                m[(0, 1)] * m[(2, 0)] - m[(0, 0)] * m[(2, 1)],
-                m[(0, 0)] * m[(1, 1)] - m[(0, 1)] * m[(1, 0)],
+                m[1][0] * m[2][1] - m[1][1] * m[2][0],
+                m[0][1] * m[2][0] - m[0][0] * m[2][1],
+                m[0][0] * m[1][1] - m[0][1] * m[1][0],
             ],
         ];
         for (row, entries) in adjugate.iter().enumerate() {
             for (column, &entry) in entries.iter().enumerate() {
-                self[(row, column)] = entry * scale;
+                self.data[row][column] = entry * scale;
             }
         }
         Ok(self)
@@ -351,22 +385,22 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
     /// adjugate are built from these, so they are computed once and shared.
     #[inline]
     fn row_pair_minors(self) -> ([T; 6], [T; 6]) {
-        let m = self;
+        let m = self.data;
         let top = [
-            m[(0, 0)] * m[(1, 1)] - m[(0, 1)] * m[(1, 0)],
-            m[(0, 0)] * m[(1, 2)] - m[(0, 2)] * m[(1, 0)],
-            m[(0, 0)] * m[(1, 3)] - m[(0, 3)] * m[(1, 0)],
-            m[(0, 1)] * m[(1, 2)] - m[(0, 2)] * m[(1, 1)],
-            m[(0, 1)] * m[(1, 3)] - m[(0, 3)] * m[(1, 1)],
-            m[(0, 2)] * m[(1, 3)] - m[(0, 3)] * m[(1, 2)],
+            m[0][0] * m[1][1] - m[0][1] * m[1][0],
+            m[0][0] * m[1][2] - m[0][2] * m[1][0],
+            m[0][0] * m[1][3] - m[0][3] * m[1][0],
+            m[0][1] * m[1][2] - m[0][2] * m[1][1],
+            m[0][1] * m[1][3] - m[0][3] * m[1][1],
+            m[0][2] * m[1][3] - m[0][3] * m[1][2],
         ];
         let bottom = [
-            m[(2, 0)] * m[(3, 1)] - m[(2, 1)] * m[(3, 0)],
-            m[(2, 0)] * m[(3, 2)] - m[(2, 2)] * m[(3, 0)],
-            m[(2, 0)] * m[(3, 3)] - m[(2, 3)] * m[(3, 0)],
-            m[(2, 1)] * m[(3, 2)] - m[(2, 2)] * m[(3, 1)],
-            m[(2, 1)] * m[(3, 3)] - m[(2, 3)] * m[(3, 1)],
-            m[(2, 2)] * m[(3, 3)] - m[(2, 3)] * m[(3, 2)],
+            m[2][0] * m[3][1] - m[2][1] * m[3][0],
+            m[2][0] * m[3][2] - m[2][2] * m[3][0],
+            m[2][0] * m[3][3] - m[2][3] * m[3][0],
+            m[2][1] * m[3][2] - m[2][2] * m[3][1],
+            m[2][1] * m[3][3] - m[2][3] * m[3][1],
+            m[2][2] * m[3][3] - m[2][3] * m[3][2],
         ];
         (top, bottom)
     }
@@ -390,36 +424,36 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
             return Err(LinalgError::Singular);
         }
         let scale = T::ONE / determinant;
-        let m = self;
+        let m = self.data;
         let adjugate = [
             [
-                m[(1, 1)] * bottom[5] - m[(1, 2)] * bottom[4] + m[(1, 3)] * bottom[3],
-                -m[(0, 1)] * bottom[5] + m[(0, 2)] * bottom[4] - m[(0, 3)] * bottom[3],
-                m[(3, 1)] * top[5] - m[(3, 2)] * top[4] + m[(3, 3)] * top[3],
-                -m[(2, 1)] * top[5] + m[(2, 2)] * top[4] - m[(2, 3)] * top[3],
+                m[1][1] * bottom[5] - m[1][2] * bottom[4] + m[1][3] * bottom[3],
+                -m[0][1] * bottom[5] + m[0][2] * bottom[4] - m[0][3] * bottom[3],
+                m[3][1] * top[5] - m[3][2] * top[4] + m[3][3] * top[3],
+                -m[2][1] * top[5] + m[2][2] * top[4] - m[2][3] * top[3],
             ],
             [
-                -m[(1, 0)] * bottom[5] + m[(1, 2)] * bottom[2] - m[(1, 3)] * bottom[1],
-                m[(0, 0)] * bottom[5] - m[(0, 2)] * bottom[2] + m[(0, 3)] * bottom[1],
-                -m[(3, 0)] * top[5] + m[(3, 2)] * top[2] - m[(3, 3)] * top[1],
-                m[(2, 0)] * top[5] - m[(2, 2)] * top[2] + m[(2, 3)] * top[1],
+                -m[1][0] * bottom[5] + m[1][2] * bottom[2] - m[1][3] * bottom[1],
+                m[0][0] * bottom[5] - m[0][2] * bottom[2] + m[0][3] * bottom[1],
+                -m[3][0] * top[5] + m[3][2] * top[2] - m[3][3] * top[1],
+                m[2][0] * top[5] - m[2][2] * top[2] + m[2][3] * top[1],
             ],
             [
-                m[(1, 0)] * bottom[4] - m[(1, 1)] * bottom[2] + m[(1, 3)] * bottom[0],
-                -m[(0, 0)] * bottom[4] + m[(0, 1)] * bottom[2] - m[(0, 3)] * bottom[0],
-                m[(3, 0)] * top[4] - m[(3, 1)] * top[2] + m[(3, 3)] * top[0],
-                -m[(2, 0)] * top[4] + m[(2, 1)] * top[2] - m[(2, 3)] * top[0],
+                m[1][0] * bottom[4] - m[1][1] * bottom[2] + m[1][3] * bottom[0],
+                -m[0][0] * bottom[4] + m[0][1] * bottom[2] - m[0][3] * bottom[0],
+                m[3][0] * top[4] - m[3][1] * top[2] + m[3][3] * top[0],
+                -m[2][0] * top[4] + m[2][1] * top[2] - m[2][3] * top[0],
             ],
             [
-                -m[(1, 0)] * bottom[3] + m[(1, 1)] * bottom[1] - m[(1, 2)] * bottom[0],
-                m[(0, 0)] * bottom[3] - m[(0, 1)] * bottom[1] + m[(0, 2)] * bottom[0],
-                -m[(3, 0)] * top[3] + m[(3, 1)] * top[1] - m[(3, 2)] * top[0],
-                m[(2, 0)] * top[3] - m[(2, 1)] * top[1] + m[(2, 2)] * top[0],
+                -m[1][0] * bottom[3] + m[1][1] * bottom[1] - m[1][2] * bottom[0],
+                m[0][0] * bottom[3] - m[0][1] * bottom[1] + m[0][2] * bottom[0],
+                -m[3][0] * top[3] + m[3][1] * top[1] - m[3][2] * top[0],
+                m[2][0] * top[3] - m[2][1] * top[1] + m[2][2] * top[0],
             ],
         ];
         for (row, entries) in adjugate.iter().enumerate() {
             for (column, &entry) in entries.iter().enumerate() {
-                self[(row, column)] = entry * scale;
+                self.data[row][column] = entry * scale;
             }
         }
         Ok(self)
@@ -442,16 +476,20 @@ impl<const ROWS: usize, const COLS: usize, T> From<[[T; COLS]; ROWS]> for Matrix
 impl<const ROWS: usize, const COLS: usize, T> Index<(usize, usize)> for Matrix<ROWS, COLS, T> {
     type Output = T;
 
+    /// Panics if `(row, col)` is out of range. Use [`Self::get`] when the index may be invalid.
     #[inline]
+    #[track_caller]
     fn index(&self, (row, col): (usize, usize)) -> &T {
-        &self.data[row][col]
+        self.at(row, col)
     }
 }
 
 impl<const ROWS: usize, const COLS: usize, T> IndexMut<(usize, usize)> for Matrix<ROWS, COLS, T> {
+    /// Panics if `(row, col)` is out of range. Use [`Self::get_mut`] when the index may be invalid.
     #[inline]
+    #[track_caller]
     fn index_mut(&mut self, (row, col): (usize, usize)) -> &mut T {
-        &mut self.data[row][col]
+        self.at_mut(row, col)
     }
 }
 
@@ -459,8 +497,9 @@ impl<const ROWS: usize, const COLS: usize, T: Numeric> Add for Matrix<ROWS, COLS
     type Output = Self;
 
     #[inline]
-    fn add(self, rhs: Self) -> Self {
-        Matrix::from_fn(|r, c| self[(r, c)] + rhs[(r, c)])
+    fn add(mut self, rhs: Self) -> Self {
+        self += rhs;
+        self
     }
 }
 
@@ -479,8 +518,9 @@ impl<const ROWS: usize, const COLS: usize, T: Numeric> Sub for Matrix<ROWS, COLS
     type Output = Self;
 
     #[inline]
-    fn sub(self, rhs: Self) -> Self {
-        Matrix::from_fn(|r, c| self[(r, c)] - rhs[(r, c)])
+    fn sub(mut self, rhs: Self) -> Self {
+        self -= rhs;
+        self
     }
 }
 
@@ -499,8 +539,13 @@ impl<const ROWS: usize, const COLS: usize, T: Numeric> Neg for Matrix<ROWS, COLS
     type Output = Self;
 
     #[inline]
-    fn neg(self) -> Self {
-        Matrix::from_fn(|r, c| -self[(r, c)])
+    fn neg(mut self) -> Self {
+        for row in &mut self.data {
+            for x in row.iter_mut() {
+                *x = -*x;
+            }
+        }
+        self
     }
 }
 
@@ -537,7 +582,13 @@ impl<const ROWS: usize, const COLS: usize, T: Numeric> Mul<Vector<COLS, T>>
 
     #[inline]
     fn mul(self, rhs: Vector<COLS, T>) -> Vector<ROWS, T> {
-        Vector::from_fn(|r| self.row(r).dot(rhs))
+        Vector::from_fn(|r| {
+            let mut acc = T::ZERO;
+            for c in 0..COLS {
+                acc += self[(r, c)] * rhs[c];
+            }
+            acc
+        })
     }
 }
 

--- a/crates/multicalc/src/linear_algebra/mod.rs
+++ b/crates/multicalc/src/linear_algebra/mod.rs
@@ -1,14 +1,8 @@
 //! Fixed-size, stack-allocated linear algebra.
 //!
 //! - [`Vector`] / [`Matrix`] — const-generic, array-backed (row-major), no allocation; shape
-//!   mismatches are compile errors and the math never panics (only out-of-range indexing does).
-//! - [`Cholesky`] / [`Lu`] / [`PivotedQr`] / [`Svd`] — factorizations and the solves built on them.
-//!
-//! ```compile_fail
-//! use multicalc::linear_algebra::Vector;
-//! // adding a 2-vector to a 3-vector does not compile
-//! let _ = Vector::new([1.0, 2.0]) + Vector::new([1.0, 2.0, 3.0]);
-//! ```
+//!   mismatches are compile errors. `Index` (`v[i]`, `m[(r, c)]`) is the ergonomic path
+//!   (panics on OOB); `get` / `get_mut` / `try_row` / `try_column` return `Option`.
 
 pub mod cholesky;
 pub mod expm;

--- a/crates/multicalc/src/linear_algebra/qr.rs
+++ b/crates/multicalc/src/linear_algebra/qr.rs
@@ -116,6 +116,7 @@ impl<const M: usize, const N: usize, T: Numeric> PivotedQr<M, N, T> {
     /// assert!((x[0] - 1.0).abs() < 1e-12);
     /// assert!((x[1] - 2.0).abs() < 1e-12);
     /// ```
+    #[allow(clippy::indexing_slicing)]
     pub fn decompose(a: Matrix<M, N, T>) -> Result<Self, LinalgError> {
         if M < N {
             return Err(LinalgError::Underdetermined);
@@ -153,10 +154,8 @@ impl<const M: usize, const N: usize, T: Numeric> PivotedQr<M, N, T> {
                 }
             }
             if kmax != j {
-                for i in 0..M {
-                    let tmp = qr[(i, j)];
-                    qr[(i, j)] = qr[(i, kmax)];
-                    qr[(i, kmax)] = tmp;
+                for row in qr.as_mut_slice_rows() {
+                    row.swap(j, kmax)
                 }
                 r_diag[kmax] = r_diag[j];
                 reference_norm[kmax] = reference_norm[j];
@@ -222,7 +221,8 @@ impl<const M: usize, const N: usize, T: Numeric> PivotedQr<M, N, T> {
         })
     }
 
-    /// The `N`-by-`N` upper-triangular factor `R`.
+    /// The `N`-by-`N` upper-triangular factor `R`
+    #[allow(clippy::indexing_slicing)]
     pub fn r(&self) -> Matrix<N, N, T> {
         Matrix::from_fn(|row, col| {
             if row == col {
@@ -281,6 +281,7 @@ impl<const M: usize, const N: usize, T: Numeric> PivotedQr<M, N, T> {
     /// assert!((x[1] - 1.0).abs() < 1e-12);
     /// assert!((x[2] - 1.0).abs() < 1e-12);
     /// ```
+    #[allow(clippy::indexing_slicing)]
     pub fn solve_least_squares(&self, b: Vector<M, T>) -> Result<Vector<N, T>, LinalgError> {
         // Apply the reflectors to b, leaving Qᵀb in the first N entries.
         let mut qtb = b;
@@ -381,6 +382,7 @@ pub struct DampedLeastSquares<const N: usize, T = f64> {
 impl<const N: usize, T: Numeric> DampedLeastSquares<N, T> {
     /// Solves `(AᵀA + D²) x = Aᵀb` for the diagonal `D` given by `diag`, returning the solution
     /// and the Cholesky-like factor `S` of `AᵀA + D²`.
+    #[allow(clippy::indexing_slicing)]
     pub fn solve_with_diagonal(&self, diag: &[T; N]) -> (Vector<N, T>, CholeskyFactor<N, T>) {
         // Working matrix: upper triangle is R, lower triangle mirrors it as scratch.
         let mut s = self.r;
@@ -426,8 +428,9 @@ impl<const N: usize, T: Numeric> DampedLeastSquares<N, T> {
                     };
 
                     s[(k, k)] = cos * s[(k, k)] + sin * s_diag[k];
-                    let temp = cos * wa[k] + sin * qtbpj;
-                    qtbpj = -sin * wa[k] + cos * qtbpj;
+                    let wak = wa[k];
+                    let temp = cos * wak + sin * qtbpj;
+                    qtbpj = -sin * wak + cos * qtbpj;
                     wa[k] = temp;
 
                     for i in (k + 1)..N {
@@ -437,7 +440,6 @@ impl<const N: usize, T: Numeric> DampedLeastSquares<N, T> {
                     }
                 }
             }
-            // Store the S diagonal and restore R's.
             s_diag[j] = s[(j, j)];
             s[(j, j)] = saved_diag[j];
         }
@@ -477,6 +479,7 @@ impl<const N: usize, T: Numeric> DampedLeastSquares<N, T> {
 
     /// The largest scaled gradient component `|Aᵀb|ⱼ / (b_norm · ‖columnⱼ‖)`, used by the
     /// gradient convergence test. Returns zero when `b_norm` is zero.
+    #[allow(clippy::indexing_slicing)]
     #[must_use]
     pub fn max_a_t_b_scaled(&self, b_norm: T) -> T {
         if b_norm == T::ZERO {
@@ -497,6 +500,7 @@ impl<const N: usize, T: Numeric> DampedLeastSquares<N, T> {
     }
 
     /// The norm `‖A x‖`, computed as `‖R P x‖` since `Q` has orthonormal columns.
+    #[allow(clippy::indexing_slicing)]
     #[must_use]
     pub fn a_x_norm(&self, x: &Vector<N, T>) -> T {
         let mut w = [T::ZERO; N];
@@ -536,6 +540,7 @@ pub struct CholeskyFactor<const N: usize, T = f64> {
 
 impl<const N: usize, T: Numeric> CholeskyFactor<N, T> {
     /// Forward-solves `Sᵀ w = rhs`, with `rhs` and the result in the factor's internal order.
+    #[allow(clippy::indexing_slicing)]
     #[must_use]
     pub fn solve(&self, mut rhs: [T; N]) -> [T; N] {
         for j in 0..N {

--- a/crates/multicalc/src/linear_algebra/svd.rs
+++ b/crates/multicalc/src/linear_algebra/svd.rs
@@ -72,12 +72,8 @@ impl<const M: usize, const N: usize, T: Numeric> Matrix<M, N, T> {
         if M < N {
             return Err(LinalgError::Underdetermined);
         }
-        for r in 0..M {
-            for c in 0..N {
-                if !self[(r, c)].is_finite() {
-                    return Err(LinalgError::NonFinite);
-                }
-            }
+        if !self.is_finite() {
+            return Err(LinalgError::NonFinite);
         }
 
         let mut u = self;
@@ -89,8 +85,8 @@ impl<const M: usize, const N: usize, T: Numeric> Matrix<M, N, T> {
             let mut off_max = T::ZERO;
             for p in 0..N {
                 for q in (p + 1)..N {
-                    let cp = u.column(p);
-                    let cq = u.column(q);
+                    let cp = Vector::<M, T>::from_fn(|r| u[(r, p)]);
+                    let cq = Vector::<M, T>::from_fn(|r| u[(r, q)]);
                     let alpha = cp.norm_squared();
                     let beta = cq.norm_squared();
                     let gamma = cp.dot(cq);
@@ -133,7 +129,7 @@ impl<const M: usize, const N: usize, T: Numeric> Matrix<M, N, T> {
         // The column norms are the singular values; normalize U's columns by them.
         let mut singular_values = Vector::<N, T>::zeros();
         for k in 0..N {
-            let sigma = u.column(k).norm();
+            let sigma = Vector::<M, T>::from_fn(|r| u[(r, k)]).norm();
             singular_values[k] = sigma;
             if sigma > T::ZERO {
                 for i in 0..M {
@@ -335,7 +331,8 @@ impl<const M: usize, const N: usize, T: Numeric> Svd<M, N, T> {
         for k in 0..N {
             let sigma = self.singular_values[k];
             if sigma > tol {
-                z[k] = self.u.column(k).dot(b) / sigma;
+                let uk = Vector::<M, T>::from_fn(|r| self.u[(r, k)]);
+                z[k] = uk.dot(b) / sigma;
             }
         }
         self.v * z

--- a/crates/multicalc/src/linear_algebra/vector.rs
+++ b/crates/multicalc/src/linear_algebra/vector.rs
@@ -12,6 +12,7 @@ use crate::scalar::Numeric;
 /// let b = Vector::from([4.0, 5.0, 6.0]);
 ///
 /// assert_eq!(a[0], 1.0);
+/// assert_eq!(a.get(0), Some(&1.0));
 /// assert_eq!(a + b, Vector::new([5.0, 7.0, 9.0]));
 /// assert_eq!(b - a, Vector::new([3.0, 3.0, 3.0]));
 /// assert_eq!(-a, Vector::new([-1.0, -2.0, -3.0]));
@@ -81,6 +82,50 @@ impl<const N: usize, T> Vector<N, T> {
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         &mut self.data
+    }
+
+    // Crate-internal panic path (also used by Index). Public: prefer `[]`; use `get` when fallible.
+    #[inline]
+    #[track_caller]
+    pub(crate) fn at(&self, i: usize) -> &T {
+        #[allow(clippy::indexing_slicing)]
+        &self.data[i]
+    }
+
+    #[inline]
+    #[track_caller]
+    pub(crate) fn at_mut(&mut self, i: usize) -> &mut T {
+        #[allow(clippy::indexing_slicing)]
+        &mut self.data[i]
+    }
+
+    /// Returns a reference to component `i`, or `None` if `i >= N`.
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::Vector;
+    /// let v = Vector::new([1.0, 2.0]);
+    /// assert_eq!(v.get(0), Some(&1.0));
+    /// assert_eq!(v.get(2), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn get(&self, i: usize) -> Option<&T> {
+        self.data.get(i)
+    }
+
+    /// Returns a mutable reference to component `i`, or `None` if `i >= N`.
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::Vector;
+    /// let mut v = Vector::new([1.0, 2.0]);
+    /// if let Some(x) = v.get_mut(1) {
+    ///     *x = 9.0;
+    /// }
+    /// assert_eq!(v.get(1), Some(&9.0));
+    /// ```
+    #[inline]
+    pub fn get_mut(&mut self, i: usize) -> Option<&mut T> {
+        self.data.get_mut(i)
     }
 
     /// Consumes the vector, returning its components.
@@ -195,16 +240,20 @@ impl<const N: usize, T> From<[T; N]> for Vector<N, T> {
 impl<const N: usize, T> Index<usize> for Vector<N, T> {
     type Output = T;
 
+    /// Panics if `index >= N`. Use [`Self::get`] when the index may be invalid.
     #[inline]
+    #[track_caller]
     fn index(&self, index: usize) -> &T {
-        &self.data[index]
+        self.at(index)
     }
 }
 
 impl<const N: usize, T> IndexMut<usize> for Vector<N, T> {
+    /// Panics if `index >= N`. Use [`Self::get_mut`] when the index may be invalid.
     #[inline]
+    #[track_caller]
     fn index_mut(&mut self, index: usize) -> &mut T {
-        &mut self.data[index]
+        self.at_mut(index)
     }
 }
 
@@ -308,6 +357,8 @@ impl<T: Numeric> Vector<2, T> {
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> T {
-        self[0] * rhs[1] - self[1] * rhs[0]
+        let [a0, a1] = self.data;
+        let [b0, b1] = rhs.data;
+        a0 * b1 - a1 * b0
     }
 }

--- a/crates/multicalc/src/numerical_derivative/hessian.rs
+++ b/crates/multicalc/src/numerical_derivative/hessian.rs
@@ -76,17 +76,17 @@ impl<D: DerivatorMultiVariable> Hessian<D> {
         let mut result: Matrix<NUM_VARS, NUM_VARS, D::Scalar> =
             Matrix::from_fn(|_, _| <D::Scalar as Numeric>::NAN);
 
-        // explicit indices drive the symmetric mirror write `result[(col, row)]`
         for row_index in 0..NUM_VARS {
             for col_index in 0..NUM_VARS {
                 if result[(row_index, col_index)].is_nan() {
-                    result[(row_index, col_index)] = self.derivator.get_double_partial(
+                    let value = self.derivator.get_double_partial(
                         function,
                         &[row_index, col_index],
                         vector_of_points,
                     )?;
+                    result[(row_index, col_index)] = value;
                     // a Hessian is symmetric, so mirror instead of recomputing
-                    result[(col_index, row_index)] = result[(row_index, col_index)];
+                    result[(col_index, row_index)] = value;
                 }
             }
         }

--- a/crates/multicalc/src/optimization/gauss_newton.rs
+++ b/crates/multicalc/src/optimization/gauss_newton.rs
@@ -160,10 +160,11 @@ impl<D: DerivatorMultiVariable> GaussNewton<D> {
 
             // Gradient convergence: max over columns of |(Jᵀr)_c| / (fnorm · ‖columnₙ‖).
             let gradient = j.transpose() * Vector::new(residuals);
+            let ga = *gradient.as_array();
             let mut gnorm = zero;
             for (c, &column_norm) in qr.column_norms.iter().enumerate() {
                 if column_norm != zero {
-                    gnorm = max(gnorm, (gradient[c] / (fnorm * column_norm)).abs());
+                    gnorm = max(gnorm, (ga[c] / (fnorm * column_norm)).abs());
                 }
             }
             if gnorm <= self.gtol {
@@ -172,13 +173,14 @@ impl<D: DerivatorMultiVariable> GaussNewton<D> {
 
             // Gauss-Newton step (errors on a rank-deficient Jacobian).
             let p = qr.solve_least_squares(Vector::new(residuals))?;
+            let pa = *p.as_array();
 
             // Take a step, shrinking it (when backtracking) until it is finite and lowers the
             // cost. A non-finite or cost-increasing trial triggers another halving.
             let mut alpha = D::Scalar::ONE;
             let mut tries = 0;
             let (x_new, residuals_new, fnorm_new) = loop {
-                let candidate: [D::Scalar; N] = core::array::from_fn(|k| x[k] - alpha * p[k]);
+                let candidate: [D::Scalar; N] = core::array::from_fn(|k| x[k] - alpha * pa[k]);
                 let trial = f.eval(&candidate);
                 evaluations += 1;
                 let finite = is_finite(&trial);

--- a/crates/multicalc/src/optimization/levenberg_marquardt.rs
+++ b/crates/multicalc/src/optimization/levenberg_marquardt.rs
@@ -199,13 +199,14 @@ impl<D: DerivatorMultiVariable> LevenbergMarquardt<D> {
                 let update = determine_lambda_and_parameter_update(&dls, &diag, delta, par);
                 par = update.lambda;
                 let p = update.step;
-                let pnorm = enorm(&core::array::from_fn::<_, N, _>(|j| diag[j] * p[j]));
+                let pa = *p.as_array();
+                let pnorm = enorm(&core::array::from_fn::<_, N, _>(|j| diag[j] * pa[j]));
                 if first {
                     delta = min(delta, pnorm);
                     first = false;
                 }
 
-                let x_new: [D::Scalar; N] = core::array::from_fn(|j| x[j] - p[j]);
+                let x_new: [D::Scalar; N] = core::array::from_fn(|j| x[j] - pa[j]);
                 let residuals_new = f.eval(&x_new);
                 evaluations += 1;
                 if !is_finite(&residuals_new) {

--- a/crates/multicalc/src/optimization/trust_region.rs
+++ b/crates/multicalc/src/optimization/trust_region.rs
@@ -56,7 +56,8 @@ pub(crate) fn determine_lambda_and_parameter_update<const N: usize, T: Numeric>(
             for (i, &wi) in w.iter().enumerate().take(j) {
                 sum += dls.r[(i, j)] * wi;
             }
-            w[j] = (w[j] - sum) / dls.r[(j, j)];
+            let diag_r = dls.r[(j, j)];
+            w[j] = (w[j] - sum) / diag_r;
         }
         let temp = enorm(&w);
         parl = ((fp / delta) / temp) / temp;

--- a/crates/multicalc/src/root_finding/newton_system.rs
+++ b/crates/multicalc/src/root_finding/newton_system.rs
@@ -159,13 +159,14 @@ impl<D: DerivatorMultiVariable> NewtonSystem<D> {
             let neg_r: [D::Scalar; N] = core::array::from_fn(|i| -r[i]);
             // Solve J·step = -F; returns SingularMatrix if J is rank-deficient.
             let step = j.solve(Vector::new(neg_r))?;
+            let sa = *step.as_array();
 
             // Try the full Newton step; when backtracking is on, halve alpha until ‖F‖
             // decreases or the per-iteration safeguard runs out.
             let mut alpha = one;
             let mut tries = 0usize;
             let (x_new, r_new, fnorm_new) = loop {
-                let candidate: [D::Scalar; N] = core::array::from_fn(|k| x[k] + alpha * step[k]);
+                let candidate: [D::Scalar; N] = core::array::from_fn(|k| x[k] + alpha * sa[k]);
                 let trial = f.eval(&candidate);
                 let trial_finite = all_finite(&trial);
                 let trial_fnorm = if trial_finite {

--- a/crates/multicalc/src/spatial/lie/mod.rs
+++ b/crates/multicalc/src/spatial/lie/mod.rs
@@ -27,11 +27,8 @@ use crate::spatial::small_angle_sq;
 /// The 3×3 skew-symmetric matrix `[v]×`, so that `[v]× · p = v × p`.
 #[inline]
 pub(crate) fn skew3<T: Numeric>(v: Vector<3, T>) -> Matrix<3, 3, T> {
-    Matrix::new([
-        [T::ZERO, -v[2], v[1]],
-        [v[2], T::ZERO, -v[0]],
-        [-v[1], v[0], T::ZERO],
-    ])
+    let [x, y, z] = *v.as_array();
+    Matrix::new([[T::ZERO, -z, y], [z, T::ZERO, -x], [-y, x, T::ZERO]])
 }
 
 /// The SO(3) left Jacobian `J_l(φ) = I + c1·[φ]× + c2·[φ]×²`. Near θ = 0 the coefficients use a
@@ -109,8 +106,9 @@ pub(crate) fn q_matrix_se3<T: Numeric>(rho: Vector<3, T>, phi: Vector<3, T>) -> 
 /// SO(3) left Jacobian of the rotation part and `Q` the Barfoot block.
 #[inline]
 pub(crate) fn left_jacobian_se3<T: Numeric>(xi: Vector<6, T>) -> Matrix<6, 6, T> {
-    let rho = Vector::new([xi[0], xi[1], xi[2]]);
-    let phi = Vector::new([xi[3], xi[4], xi[5]]);
+    let [rx, ry, rz, px, py, pz] = *xi.as_array();
+    let rho = Vector::new([rx, ry, rz]);
+    let phi = Vector::new([px, py, pz]);
     let j = left_jacobian_so3(phi);
     let q = q_matrix_se3(rho, phi);
     Matrix::from_fn(|i, k| {
@@ -129,8 +127,9 @@ pub(crate) fn left_jacobian_se3<T: Numeric>(xi: Vector<6, T>) -> Matrix<6, 6, T>
 /// The inverse SE(3) left Jacobian `J_l⁻¹(ξ) = [[Jᵢ, −Jᵢ·Q·Jᵢ], [0, Jᵢ]]`.
 #[inline]
 pub(crate) fn inverse_left_jacobian_se3<T: Numeric>(xi: Vector<6, T>) -> Matrix<6, 6, T> {
-    let rho = Vector::new([xi[0], xi[1], xi[2]]);
-    let phi = Vector::new([xi[3], xi[4], xi[5]]);
+    let [rx, ry, rz, px, py, pz] = *xi.as_array();
+    let rho = Vector::new([rx, ry, rz]);
+    let phi = Vector::new([px, py, pz]);
     let ji = inverse_left_jacobian_so3(phi);
     let q = q_matrix_se3(rho, phi);
     let top_right = -(ji * q * ji);

--- a/crates/multicalc/src/spatial/lie/se2.rs
+++ b/crates/multicalc/src/spatial/lie/se2.rs
@@ -75,7 +75,7 @@ impl<T: Numeric> SE2<T> {
     /// series, keeping the value and its derivative finite.
     #[inline]
     pub fn exp(xi: Vector<3, T>) -> Self {
-        let omega = xi[2];
+        let [vx, vy, omega] = *xi.as_array();
         let theta_sq = omega * omega;
         let (a, b) = if theta_sq < small_angle_sq::<T>() {
             (
@@ -85,7 +85,7 @@ impl<T: Numeric> SE2<T> {
         } else {
             (omega.sin() / omega, (T::ONE - omega.cos()) / omega)
         };
-        let translation = Vector::new([a * xi[0] - b * xi[1], b * xi[0] + a * xi[1]]);
+        let translation = Vector::new([a * vx - b * vy, b * vx + a * vy]);
         SE2 {
             rotation: SO2::exp(omega),
             translation,
@@ -103,28 +103,25 @@ impl<T: Numeric> SE2<T> {
             let half = omega * T::HALF;
             (half * (half.cos() / half.sin()), half)
         };
-        let t = self.translation;
-        Vector::new([
-            alpha * t[0] + beta * t[1],
-            -beta * t[0] + alpha * t[1],
-            omega,
-        ])
+        let [tx, ty] = *self.translation.as_array();
+        Vector::new([alpha * tx + beta * ty, -beta * tx + alpha * ty, omega])
     }
 
     /// The 3×3 adjoint for the `[v; ω]` ordering.
     #[inline]
     pub fn adjoint(self) -> Matrix<3, 3, T> {
         let (c, s) = self.rotation.cos_sin();
-        let (tx, ty) = (self.translation[0], self.translation[1]);
+        let [tx, ty] = *self.translation.as_array();
         Matrix::new([[c, -s, ty], [s, c, -tx], [T::ZERO, T::ZERO, T::ONE]])
     }
 
     /// The Lie-algebra element for a `[vx, vy, ω]` twist.
     #[inline]
     pub fn hat(xi: Vector<3, T>) -> Matrix<3, 3, T> {
+        let [vx, vy, omega] = *xi.as_array();
         Matrix::new([
-            [T::ZERO, -xi[2], xi[0]],
-            [xi[2], T::ZERO, xi[1]],
+            [T::ZERO, -omega, vx],
+            [omega, T::ZERO, vy],
             [T::ZERO, T::ZERO, T::ZERO],
         ])
     }
@@ -132,30 +129,26 @@ impl<T: Numeric> SE2<T> {
     /// The inverse of [`SE2::hat`].
     #[inline]
     pub fn vee(m: Matrix<3, 3, T>) -> Vector<3, T> {
-        Vector::new([m[(0, 2)], m[(1, 2)], m[(1, 0)]])
+        let [[_, _, m02], [m10, _, m12], _] = m.into_array();
+        Vector::new([m02, m12, m10])
     }
 
     /// The 3×3 homogeneous transform matrix.
     #[inline]
     pub fn to_matrix(self) -> Matrix<3, 3, T> {
         let (c, s) = self.rotation.cos_sin();
-        Matrix::new([
-            [c, -s, self.translation[0]],
-            [s, c, self.translation[1]],
-            [T::ZERO, T::ZERO, T::ONE],
-        ])
+        let [tx, ty] = *self.translation.as_array();
+        Matrix::new([[c, -s, tx], [s, c, ty], [T::ZERO, T::ZERO, T::ONE]])
     }
 
     /// Builds a transform from a 3×3 homogeneous matrix; `None` if the rotation block is degenerate.
     #[inline]
     pub fn try_from_matrix(m: Matrix<3, 3, T>) -> Option<Self> {
-        let r = SO2::try_from_matrix(Matrix::new([
-            [m[(0, 0)], m[(0, 1)]],
-            [m[(1, 0)], m[(1, 1)]],
-        ]))?;
+        let [[m00, m01, m02], [m10, m11, m12], _] = m.into_array();
+        let r = SO2::try_from_matrix(Matrix::new([[m00, m01], [m10, m11]]))?;
         Some(SE2 {
             rotation: r,
-            translation: Vector::new([m[(0, 2)], m[(1, 2)]]),
+            translation: Vector::new([m02, m12]),
         })
     }
 
@@ -173,12 +166,12 @@ impl<T: Numeric> SE2<T> {
     /// use multicalc::spatial::SE2;
     /// use multicalc::linear_algebra::Vector;
     /// let xi = Vector::new([0.4_f64, -0.2, 0.3]);
-    /// let prod = SE2::left_jacobian(xi) * SE2::left_jacobian_inverse(xi);
+    /// let prod = (SE2::left_jacobian(xi) * SE2::left_jacobian_inverse(xi));
     /// for i in 0..3 { assert!((prod[(i, i)] - 1.0).abs() < 1e-12); }
     /// ```
     #[inline]
     pub fn left_jacobian(xi: Vector<3, T>) -> Matrix<3, 3, T> {
-        let omega = xi[2];
+        let [rx, ry, omega] = *xi.as_array();
         let theta_sq = omega * omega;
         // a = sinθ/θ, b = (1−cosθ)/θ (the V(θ) block); p = (1−cosθ)/θ², r = (θ−sinθ)/θ² (q).
         let (a, b, p, r) = if theta_sq < small_angle_sq::<T>() {
@@ -197,7 +190,6 @@ impl<T: Numeric> SE2<T> {
                 (omega - s) / theta_sq,
             )
         };
-        let (rx, ry) = (xi[0], xi[1]);
         let qx = p * ry + r * rx;
         let qy = r * ry - p * rx;
         Matrix::new([[a, -b, qx], [b, a, qy], [T::ZERO, T::ZERO, T::ONE]])
@@ -213,7 +205,7 @@ impl<T: Numeric> SE2<T> {
     /// coupling column as [`SE2::left_jacobian`] and `V⁻¹` the `alpha, beta` block from [`SE2::log`].
     #[inline]
     pub fn left_jacobian_inverse(xi: Vector<3, T>) -> Matrix<3, 3, T> {
-        let omega = xi[2];
+        let [rx, ry, omega] = *xi.as_array();
         let theta_sq = omega * omega;
         // p = (1−cosθ)/θ², r = (θ−sinθ)/θ²: the coupling coefficients of the forward Jacobian.
         let (p, r) = if theta_sq < small_angle_sq::<T>() {
@@ -225,7 +217,6 @@ impl<T: Numeric> SE2<T> {
             let (s, c) = (omega.sin(), omega.cos());
             ((T::ONE - c) / theta_sq, (omega - s) / theta_sq)
         };
-        let (rx, ry) = (xi[0], xi[1]);
         let qx = p * ry + r * rx;
         let qy = r * ry - p * rx;
         let (alpha, beta) = if theta_sq < small_angle_sq::<T>() {

--- a/crates/multicalc/src/spatial/lie/se3.rs
+++ b/crates/multicalc/src/spatial/lie/se3.rs
@@ -77,8 +77,9 @@ impl<T: Numeric> SE3<T> {
     /// series, keeping the value and its derivative finite.
     #[inline]
     pub fn exp(xi: Vector<6, T>) -> Self {
-        let v = Vector::new([xi[0], xi[1], xi[2]]);
-        let phi = Vector::new([xi[3], xi[4], xi[5]]);
+        let [vx, vy, vz, px, py, pz] = *xi.as_array();
+        let v = Vector::new([vx, vy, vz]);
+        let phi = Vector::new([px, py, pz]);
         SE3 {
             rotation: SO3::exp(phi),
             translation: left_jacobian_so3(phi) * v,
@@ -90,7 +91,9 @@ impl<T: Numeric> SE3<T> {
     pub fn log(self) -> Vector<6, T> {
         let phi = self.rotation.log();
         let v = inverse_left_jacobian_so3(phi) * self.translation;
-        Vector::new([v[0], v[1], v[2], phi[0], phi[1], phi[2]])
+        let [vx, vy, vz] = *v.as_array();
+        let [px, py, pz] = *phi.as_array();
+        Vector::new([vx, vy, vz, px, py, pz])
     }
 
     /// The 6×6 adjoint `[[R, [t]×·R], [0, R]]` for the `[v; ω]` ordering.
@@ -101,9 +104,11 @@ impl<T: Numeric> SE3<T> {
         let mut ad = Matrix::zeros();
         for i in 0..3 {
             for j in 0..3 {
-                ad[(i, j)] = r[(i, j)];
-                ad[(i, j + 3)] = tr[(i, j)];
-                ad[(i + 3, j + 3)] = r[(i, j)];
+                let rij = r[(i, j)];
+                let trij = tr[(i, j)];
+                ad[(i, j)] = rij;
+                ad[(i, j + 3)] = trij;
+                ad[(i + 3, j + 3)] = rij;
             }
         }
         ad
@@ -112,10 +117,11 @@ impl<T: Numeric> SE3<T> {
     /// The 4×4 Lie-algebra element for a `[v; ω]` twist.
     #[inline]
     pub fn hat(xi: Vector<6, T>) -> Matrix<4, 4, T> {
+        let [vx, vy, vz, wx, wy, wz] = *xi.as_array();
         Matrix::new([
-            [T::ZERO, -xi[5], xi[4], xi[0]],
-            [xi[5], T::ZERO, -xi[3], xi[1]],
-            [-xi[4], xi[3], T::ZERO, xi[2]],
+            [T::ZERO, -wz, wy, vx],
+            [wz, T::ZERO, -wx, vy],
+            [-wy, wx, T::ZERO, vz],
             [T::ZERO, T::ZERO, T::ZERO, T::ZERO],
         ])
     }
@@ -123,14 +129,8 @@ impl<T: Numeric> SE3<T> {
     /// The inverse of [`SE3::hat`].
     #[inline]
     pub fn vee(m: Matrix<4, 4, T>) -> Vector<6, T> {
-        Vector::new([
-            m[(0, 3)],
-            m[(1, 3)],
-            m[(2, 3)],
-            m[(2, 1)],
-            m[(0, 2)],
-            m[(1, 0)],
-        ])
+        let [[_, _, m02, m03], [m10, _, _, m13], [_, m21, _, m23], _] = m.into_array();
+        Vector::new([m03, m13, m23, m21, m02, m10])
     }
 
     /// The 4×4 homogeneous transform matrix.
@@ -159,9 +159,10 @@ impl<T: Numeric> SE3<T> {
             }
         }
         let rotation = SO3::try_from_matrix(r)?;
+        let [[_, _, _, m03], [_, _, _, m13], [_, _, _, m23], _] = m.into_array();
         Some(SE3 {
             rotation,
-            translation: Vector::new([m[(0, 3)], m[(1, 3)], m[(2, 3)]]),
+            translation: Vector::new([m03, m13, m23]),
         })
     }
 
@@ -177,7 +178,7 @@ impl<T: Numeric> SE3<T> {
     /// use multicalc::spatial::SE3;
     /// use multicalc::linear_algebra::Vector;
     /// let xi = Vector::new([0.1_f64, -0.2, 0.3, 0.2, -0.1, 0.4]);
-    /// let prod = SE3::left_jacobian(xi) * SE3::left_jacobian_inverse(xi);
+    /// let prod = (SE3::left_jacobian(xi) * SE3::left_jacobian_inverse(xi));
     /// for i in 0..6 { assert!((prod[(i, i)] - 1.0).abs() < 1e-10); }
     /// ```
     #[inline]

--- a/crates/multicalc/src/spatial/lie/so2.rs
+++ b/crates/multicalc/src/spatial/lie/so2.rs
@@ -60,7 +60,8 @@ impl<T: Numeric> SO2<T> {
     /// Rotates a 2D point.
     #[inline]
     pub fn act(self, p: Vector<2, T>) -> Vector<2, T> {
-        Vector::new([self.c * p[0] - self.s * p[1], self.s * p[0] + self.c * p[1]])
+        let [px, py] = *p.as_array();
+        Vector::new([self.c * px - self.s * py, self.s * px + self.c * py])
     }
 
     /// The exponential map from the tangent angle.
@@ -84,7 +85,8 @@ impl<T: Numeric> SO2<T> {
     /// The inverse of [`SO2::hat`].
     #[inline]
     pub fn vee(m: Matrix<2, 2, T>) -> T {
-        m[(1, 0)]
+        let [[_, _], [m10, _]] = m.into_array();
+        m10
     }
 
     /// The adjoint, which is `1` (SO(2) is abelian).
@@ -103,7 +105,7 @@ impl<T: Numeric> SO2<T> {
     /// non-finite or degenerate.
     #[inline]
     pub fn try_from_matrix(m: Matrix<2, 2, T>) -> Option<Self> {
-        let (c, s) = (m[(0, 0)], m[(1, 0)]);
+        let [[c, _], [s, _]] = m.into_array();
         let n = (c * c + s * s).sqrt();
         if !n.is_finite() || n <= T::EPSILON {
             None

--- a/crates/multicalc/src/spatial/lie/so3.rs
+++ b/crates/multicalc/src/spatial/lie/so3.rs
@@ -97,7 +97,8 @@ impl<T: Numeric> SO3<T> {
     /// The inverse of [`SO3::hat`].
     #[inline]
     pub fn vee(m: Matrix<3, 3, T>) -> Vector<3, T> {
-        Vector::new([m[(2, 1)], m[(0, 2)], m[(1, 0)]])
+        let [[_, _, m02], [m10, _, _], [_, m21, _]] = m.into_array();
+        Vector::new([m21, m02, m10])
     }
 
     /// The adjoint, equal to the rotation matrix (`Ad_R = R`).
@@ -152,7 +153,7 @@ impl<T: Numeric> SO3<T> {
     /// use multicalc::spatial::SO3;
     /// use multicalc::linear_algebra::{Matrix, Vector};
     /// let phi = Vector::new([0.2_f64, -0.1, 0.4]);
-    /// let prod = SO3::left_jacobian(phi) * SO3::left_jacobian_inverse(phi);
+    /// let prod = (SO3::left_jacobian(phi) * SO3::left_jacobian_inverse(phi));
     /// for i in 0..3 { assert!((prod[(i, i)] - 1.0).abs() < 1e-12); }
     /// ```
     #[inline]

--- a/crates/multicalc/src/spatial/quaternion.rs
+++ b/crates/multicalc/src/spatial/quaternion.rs
@@ -62,23 +62,15 @@ impl<T: Numeric> Quaternion<T> {
     /// Builds a quaternion from a `[w, x, y, z]` array.
     #[inline]
     pub fn from_array(a: [T; 4]) -> Self {
-        Quaternion {
-            w: a[0],
-            x: a[1],
-            y: a[2],
-            z: a[3],
-        }
+        let [w, x, y, z] = a;
+        Quaternion { w, x, y, z }
     }
 
     /// Builds a quaternion from a scalar part and a vector part.
     #[inline]
     pub fn from_scalar_vector(w: T, v: Vector<3, T>) -> Self {
-        Quaternion {
-            w,
-            x: v[0],
-            y: v[1],
-            z: v[2],
-        }
+        let [x, y, z] = *v.as_array();
+        Quaternion { w, x, y, z }
     }
 
     /// The scalar (real) component.
@@ -241,11 +233,12 @@ impl<T: Numeric> Quaternion<T> {
         }
         let half = angle * T::HALF;
         let s = half.sin() / an;
+        let [ax, ay, az] = *axis.as_array();
         Quaternion {
             w: half.cos(),
-            x: axis[0] * s,
-            y: axis[1] * s,
-            z: axis[2] * s,
+            x: ax * s,
+            y: ay * s,
+            z: az * s,
         }
     }
 
@@ -267,11 +260,12 @@ impl<T: Numeric> Quaternion<T> {
             let half = theta * T::HALF;
             (half.cos(), half.sin() / theta)
         };
+        let [rx, ry, rz] = *rotvec.as_array();
         Quaternion {
             w,
-            x: rotvec[0] * scale,
-            y: rotvec[1] * scale,
-            z: rotvec[2] * scale,
+            x: rx * scale,
+            y: ry * scale,
+            z: rz * scale,
         }
     }
 
@@ -297,37 +291,38 @@ impl<T: Numeric> Quaternion<T> {
     #[inline]
     pub fn try_from_rotation_matrix(m: Matrix<3, 3, T>) -> Option<Self> {
         let quarter = T::from_f64(0.25);
-        let trace = m[(0, 0)] + m[(1, 1)] + m[(2, 2)];
+        let [[m00, m01, m02], [m10, m11, m12], [m20, m21, m22]] = m.into_array();
+        let trace = m00 + m11 + m22;
         let q = if trace > T::ZERO {
             let s = (trace + T::ONE).sqrt() * T::TWO; // s = 4·w
             Quaternion::new(
                 quarter * s,
-                (m[(2, 1)] - m[(1, 2)]) / s,
-                (m[(0, 2)] - m[(2, 0)]) / s,
-                (m[(1, 0)] - m[(0, 1)]) / s,
+                (m21 - m12) / s,
+                (m02 - m20) / s,
+                (m10 - m01) / s,
             )
-        } else if m[(0, 0)] > m[(1, 1)] && m[(0, 0)] > m[(2, 2)] {
-            let s = (T::ONE + m[(0, 0)] - m[(1, 1)] - m[(2, 2)]).sqrt() * T::TWO; // s = 4·x
+        } else if m00 > m11 && m00 > m22 {
+            let s = (T::ONE + m00 - m11 - m22).sqrt() * T::TWO; // s = 4·x
             Quaternion::new(
-                (m[(2, 1)] - m[(1, 2)]) / s,
+                (m21 - m12) / s,
                 quarter * s,
-                (m[(0, 1)] + m[(1, 0)]) / s,
-                (m[(0, 2)] + m[(2, 0)]) / s,
+                (m01 + m10) / s,
+                (m02 + m20) / s,
             )
-        } else if m[(1, 1)] > m[(2, 2)] {
-            let s = (T::ONE + m[(1, 1)] - m[(0, 0)] - m[(2, 2)]).sqrt() * T::TWO; // s = 4·y
+        } else if m11 > m22 {
+            let s = (T::ONE + m11 - m00 - m22).sqrt() * T::TWO; // s = 4·y
             Quaternion::new(
-                (m[(0, 2)] - m[(2, 0)]) / s,
-                (m[(0, 1)] + m[(1, 0)]) / s,
+                (m02 - m20) / s,
+                (m01 + m10) / s,
                 quarter * s,
-                (m[(1, 2)] + m[(2, 1)]) / s,
+                (m12 + m21) / s,
             )
         } else {
-            let s = (T::ONE + m[(2, 2)] - m[(0, 0)] - m[(1, 1)]).sqrt() * T::TWO; // s = 4·z
+            let s = (T::ONE + m22 - m00 - m11).sqrt() * T::TWO; // s = 4·z
             Quaternion::new(
-                (m[(1, 0)] - m[(0, 1)]) / s,
-                (m[(0, 2)] + m[(2, 0)]) / s,
-                (m[(1, 2)] + m[(2, 1)]) / s,
+                (m10 - m01) / s,
+                (m02 + m20) / s,
+                (m12 + m21) / s,
                 quarter * s,
             )
         };
@@ -417,11 +412,12 @@ impl<T: Numeric> Quaternion<T> {
     /// Rotates a point by the sandwich product `q · (0, v) · q⁻¹`. Assumes a unit quaternion.
     #[inline]
     pub fn transform_point(self, v: Vector<3, T>) -> Vector<3, T> {
+        let [x, y, z] = *v.as_array();
         let p = Quaternion {
             w: T::ZERO,
-            x: v[0],
-            y: v[1],
-            z: v[2],
+            x,
+            y,
+            z,
         };
         let r = self * p * self.conjugate();
         Vector::new([r.x, r.y, r.z])

--- a/crates/multicalc/src/spatial/twist.rs
+++ b/crates/multicalc/src/spatial/twist.rs
@@ -69,9 +69,10 @@ impl<T: Numeric> Twist<T> {
     /// ```
     #[inline]
     pub fn from_array(a: [T; 6]) -> Self {
+        let [vx, vy, vz, wx, wy, wz] = a;
         Twist {
-            linear: Vector::new([a[0], a[1], a[2]]),
-            angular: Vector::new([a[3], a[4], a[5]]),
+            linear: Vector::new([vx, vy, vz]),
+            angular: Vector::new([wx, wy, wz]),
         }
     }
 
@@ -84,9 +85,9 @@ impl<T: Numeric> Twist<T> {
     /// ```
     #[inline]
     pub fn as_array(self) -> [T; 6] {
-        let v = self.linear;
-        let w = self.angular;
-        [v[0], v[1], v[2], w[0], w[1], w[2]]
+        let [vx, vy, vz] = *self.linear.as_array();
+        let [wx, wy, wz] = *self.angular.as_array();
+        [vx, vy, vz, wx, wy, wz]
     }
 
     /// A twist from a flat `[v; ω]` `Vector<6>` (the group-API ordering).

--- a/crates/multicalc/src/spatial/wrench.rs
+++ b/crates/multicalc/src/spatial/wrench.rs
@@ -67,9 +67,10 @@ impl<T: Numeric> Wrench<T> {
     /// ```
     #[inline]
     pub fn from_array(a: [T; 6]) -> Self {
+        let [vx, vy, vz, wx, wy, wz] = a;
         Wrench {
-            force: Vector::new([a[0], a[1], a[2]]),
-            torque: Vector::new([a[3], a[4], a[5]]),
+            force: Vector::new([vx, vy, vz]),
+            torque: Vector::new([wx, wy, wz]),
         }
     }
 
@@ -82,9 +83,9 @@ impl<T: Numeric> Wrench<T> {
     /// ```
     #[inline]
     pub fn as_array(self) -> [T; 6] {
-        let f = self.force;
-        let t = self.torque;
-        [f[0], f[1], f[2], t[0], t[1], t[2]]
+        let [fx, fy, fz] = *self.force.as_array();
+        let [tx, ty, tz] = *self.torque.as_array();
+        [fx, fy, fz, tx, ty, tz]
     }
 
     /// A wrench from a flat `[f; τ]` `Vector<6>`.

--- a/crates/multicalc/tests/suite/discretization.rs
+++ b/crates/multicalc/tests/suite/discretization.rs
@@ -40,8 +40,9 @@ fn expm_derivative_finite_and_correct() {
         .unwrap();
     for i in 0..3 {
         for j in 0..3 {
-            assert!(ad[(i, j)].deriv.is_finite());
-            assert!((ad[(i, j)].deriv - m[(i, j)]).abs() < 1e-9);
+            let cell = ad[(i, j)];
+            assert!(cell.deriv.is_finite());
+            assert!((cell.deriv - m[(i, j)]).abs() < 1e-9);
         }
     }
 }
@@ -53,9 +54,9 @@ fn zoh_double_integrator() {
     let dt = 0.1;
     let (f, g) = zoh::<2, 1, 3, f64>(a, b, dt).unwrap();
     let want_f = [[1.0, dt], [0.0, 1.0]];
-    for i in 0..2 {
-        for j in 0..2 {
-            assert!((f[(i, j)] - want_f[i][j]).abs() < 1e-9);
+    for (i, row) in want_f.iter().enumerate() {
+        for (j, &want) in row.iter().enumerate() {
+            assert!((f[(i, j)] - want).abs() < 1e-9);
         }
     }
     assert!((g[(0, 0)] - dt * dt / 2.0).abs() < 1e-9);

--- a/crates/multicalc/tests/suite/estimation/extended_kalman_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/extended_kalman_filter.rs
@@ -241,9 +241,18 @@ proptest! {
         filter.update(&model, measurement).unwrap();
 
         let covariance = filter.covariance();
-        prop_assert!((covariance[(0, 1)] - covariance[(1, 0)]).abs() < 1e-12);
-        prop_assert!((covariance[(0, 2)] - covariance[(2, 0)]).abs() < 1e-12);
-        prop_assert!((covariance[(1, 2)] - covariance[(2, 1)]).abs() < 1e-12);
+        prop_assert!(
+            (covariance[(0, 1)] - covariance[(1, 0)]).abs()
+            < 1e-12
+        );
+        prop_assert!(
+            (covariance[(0, 2)] - covariance[(2, 0)]).abs()
+            < 1e-12
+        );
+        prop_assert!(
+            (covariance[(1, 2)] - covariance[(2, 1)]).abs()
+            < 1e-12
+        );
         prop_assert!(covariance.cholesky().is_ok());
     }
 

--- a/crates/multicalc/tests/suite/estimation/kalman_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/kalman_filter.rs
@@ -97,7 +97,10 @@ proptest! {
         filter.update(Vector::new([measurement])).unwrap();
 
         let covariance = filter.covariance();
-        prop_assert!((covariance[(0, 1)] - covariance[(1, 0)]).abs() < 1e-12);
+        prop_assert!(
+            (covariance[(0, 1)] - covariance[(1, 0)]).abs()
+            < 1e-12
+        );
     }
 
     #[test]

--- a/crates/multicalc/tests/suite/estimation/particle_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/particle_filter.rs
@@ -264,24 +264,22 @@ fn converges_to_kalman_on_linear_gaussian_model() {
             .unwrap();
     }
 
-    let kalman_state = kalman.state();
-    let particle_mean = particle.mean();
     assert!(
-        (particle_mean[0] - kalman_state[0]).abs() < 0.05,
+        (particle.mean()[0] - kalman.state()[0]).abs() < 0.05,
         "position off the Kalman estimate: {} vs {}",
-        particle_mean[0],
-        kalman_state[0]
+        particle.mean()[0],
+        kalman.state()[0]
     );
     assert!(
-        (particle_mean[1] - kalman_state[1]).abs() < 0.10,
+        (particle.mean()[1] - kalman.state()[1]).abs() < 0.10,
         "velocity off the Kalman estimate: {} vs {}",
-        particle_mean[1],
-        kalman_state[1]
+        particle.mean()[1],
+        kalman.state()[1]
     );
     assert!(
-        (particle_mean[0] - truth[0]).abs() < 0.15,
+        (particle.mean()[0] - truth[0]).abs() < 0.15,
         "position off the truth: {} vs {}",
-        particle_mean[0],
+        particle.mean()[0],
         truth[0]
     );
 }

--- a/crates/multicalc/tests/suite/kinematics/odometry.rs
+++ b/crates/multicalc/tests/suite/kinematics/odometry.rs
@@ -46,23 +46,24 @@ fn arc_matches_rk45() {
 
         let arc = integrate(SE2::identity(), rate.integrate_over(tf));
         let t = arc.translation();
+        let s = solved;
         assert!(
-            (t[0] - solved[0]).abs() < 1e-9,
+            (t[0] - s[0]).abs() < 1e-9,
             "(v={v}, w={w}) x: arc {} vs rk45 {}",
             t[0],
-            solved[0]
+            s[0]
         );
         assert!(
-            (t[1] - solved[1]).abs() < 1e-9,
+            (t[1] - s[1]).abs() < 1e-9,
             "(v={v}, w={w}) y: arc {} vs rk45 {}",
             t[1],
-            solved[1]
+            s[1]
         );
         assert!(
-            (arc.rotation().log() - solved[2]).abs() < 1e-12,
+            (arc.rotation().log() - s[2]).abs() < 1e-12,
             "(v={v}, w={w}) heading: arc {} vs rk45 {}",
             arc.rotation().log(),
-            solved[2]
+            s[2]
         );
     }
 }

--- a/crates/multicalc/tests/suite/linear_algebra/cholesky.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/cholesky.rs
@@ -86,7 +86,7 @@ fn cholesky_solves() {
     let xm = f.solve_matrix(rhs);
     assert_matrix_close(s * xm, rhs, 1e-12);
     for c in 0..3 {
-        let single = f.solve(rhs.column(c));
+        let single = f.solve(Vector::from_fn(|r| rhs[(r, c)]));
         for r in 0..2 {
             assert!((xm[(r, c)] - single[r]).abs() < 1e-12);
         }

--- a/crates/multicalc/tests/suite/linear_algebra/lu.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/lu.rs
@@ -74,7 +74,7 @@ fn lu_solves() {
     let xm = f.solve_matrix(rhs);
     assert_matrix_close(a * xm, rhs, 1e-12);
     for c in 0..2 {
-        let single = f.solve(rhs.column(c));
+        let single = f.solve(Vector::from_fn(|r| rhs[(r, c)]));
         for r in 0..3 {
             assert!((xm[(r, c)] - single[r]).abs() < 1e-12);
         }

--- a/crates/multicalc/tests/suite/linear_algebra/matrix.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/matrix.rs
@@ -22,6 +22,19 @@ fn matrix_arithmetic() {
 }
 
 #[test]
+fn try_row_column() {
+    let m = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
+
+    assert_eq!(m.try_row(1), Some(Vector::new([3.0, 4.0])));
+    assert_eq!(m.try_row(2), None);
+    assert_eq!(m.try_row(1), Some(m.row(1)));
+
+    assert_eq!(m.try_column(0), Some(Vector::new([1.0, 3.0])));
+    assert_eq!(m.try_column(2), None);
+    assert_eq!(m.try_column(0), Some(m.column(0)));
+}
+
+#[test]
 fn matrix_multiply() {
     let a = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
     let b = Matrix::new([[5.0, 6.0], [7.0, 8.0]]);

--- a/crates/multicalc/tests/suite/linear_algebra/matrix.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/matrix.rs
@@ -27,11 +27,13 @@ fn try_row_column() {
 
     assert_eq!(m.try_row(1), Some(Vector::new([3.0, 4.0])));
     assert_eq!(m.try_row(2), None);
-    assert_eq!(m.try_row(1), Some(m.row(1)));
 
     assert_eq!(m.try_column(0), Some(Vector::new([1.0, 3.0])));
     assert_eq!(m.try_column(2), None);
-    assert_eq!(m.try_column(0), Some(m.column(0)));
+
+    let empty: Matrix<0, 3> = Matrix::zeros();
+    assert_eq!(empty.try_column(0), Some(Vector::<0, f64>::zeros()));
+    assert_eq!(empty.try_column(3), None);
 }
 
 #[test]

--- a/crates/multicalc/tests/suite/linear_algebra/qr.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/qr.rs
@@ -119,7 +119,7 @@ fn damped_accessors() {
     let jtb = j.transpose() * b;
     let mut expected = 0.0_f64;
     for l in 0..3 {
-        let scaled = (jtb[l] / b_norm / j.column(l).norm()).abs();
+        let scaled = (jtb[l] / b_norm / Vector::<4>::from_fn(|r| j[(r, l)]).norm()).abs();
         expected = expected.max(scaled);
     }
     assert!((dls.max_a_t_b_scaled(b_norm) - expected).abs() < 1e-12);

--- a/crates/multicalc/tests/suite/linear_algebra/svd.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/svd.rs
@@ -264,7 +264,8 @@ fn svd_near_singular_jacobian() {
         }
     });
     for r in 0..6 {
-        j[(r, 5)] = j[(r, 4)] + 1e-8 * (r as f64 + 1.0);
+        let j4 = j[(r, 4)];
+        j[(r, 5)] = j4 + 1e-8 * (r as f64 + 1.0);
     }
     let f = j.svd().unwrap();
     let s = f.singular_values();

--- a/crates/multicalc/tests/suite/linear_algebra/vector.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/vector.rs
@@ -5,11 +5,13 @@ use multicalc::linear_algebra::{Matrix, Vector};
 #[test]
 fn construct_and_access() {
     let v = Vector::new([1.0, 2.0, 3.0]);
-    assert_eq!(v[0], 1.0);
+    assert_eq!(v.get(0), Some(&1.0));
     assert_eq!(v.into_array(), [1.0, 2.0, 3.0]);
 
     let mut w = Vector::from([4.0, 5.0]);
-    w[1] = 9.0;
+    if let Some(x) = w.get_mut(1) {
+        *x = 9.0;
+    }
     assert_eq!(w, Vector::new([4.0, 9.0]));
 
     let z: Vector<3> = Vector::zeros();
@@ -21,9 +23,11 @@ fn construct_and_access() {
     );
 
     let mut m = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
-    assert_eq!(m[(1, 0)], 3.0);
-    m[(0, 1)] = 7.0;
-    assert_eq!(m[(0, 1)], 7.0);
+    assert_eq!(m.get(1, 0), Some(&3.0));
+    if let Some(x) = m.get_mut(0, 1) {
+        *x = 7.0;
+    }
+    assert_eq!(m.get(0, 1), Some(&7.0));
 
     let id: Matrix<3, 3> = Matrix::identity();
     assert_eq!(
@@ -50,6 +54,31 @@ fn try_from_slice_length() {
         Some(Matrix::new([[1.0, 2.0], [3.0, 4.0]]))
     );
     assert!(Matrix::<2, 2>::try_from_row_slice(&[1.0, 2.0, 3.0]).is_none());
+}
+
+#[test]
+fn get_checked_access() {
+    let v = Vector::new([1.0, 2.0, 3.0]);
+    assert_eq!(v.get(0), Some(&1.0));
+    assert_eq!(v.get(3), None);
+
+    let mut w = Vector::new([4.0, 5.0]);
+    if let Some(x) = w.get_mut(1) {
+        *x = 9.0;
+    }
+    assert_eq!(w.get(1), Some(&9.0));
+
+    let mut m = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
+    assert_eq!(m.get(1, 0), Some(&3.0));
+    assert_eq!(m.get(2, 0), None);
+    assert_eq!(m.get(0, 2), None);
+    if let Some(x) = m.get_mut(0, 1) {
+        *x = 7.0;
+    }
+    assert_eq!(m.get(0, 1), Some(&7.0));
+
+    m.as_mut_slice_rows()[1][1] = 8.0;
+    assert_eq!(m.get(1, 1), Some(&8.0));
 }
 
 // ----- vector arithmetic -----

--- a/crates/multicalc/tests/suite/numerical_derivative.rs
+++ b/crates/multicalc/tests/suite/numerical_derivative.rs
@@ -89,9 +89,9 @@ fn ad_jacobian() {
     let result = jacobian.get(&f, &[1.0, 2.0, 3.0]).unwrap();
 
     let expected = [[6.0, 3.0, 2.0], [2.0, 4.0, 0.0]];
-    for i in 0..2 {
-        for j in 0..3 {
-            assert!(f64::abs(result[(i, j)] - expected[i][j]) < 1e-12);
+    for (i, row) in expected.iter().enumerate() {
+        for (j, &want) in row.iter().enumerate() {
+            assert!(f64::abs(result[(i, j)] - want) < 1e-12);
         }
     }
 }
@@ -104,9 +104,9 @@ fn ad_jacobian_on_heap() {
     let result = jacobian.get_on_heap(&f, &[1.0, 2.0, 3.0]).unwrap();
 
     let expected = [[6.0, 3.0, 2.0], [2.0, 4.0, 0.0]];
-    for i in 0..2 {
-        for j in 0..3 {
-            assert!(f64::abs(result[i][j] - expected[i][j]) < 1e-12);
+    for (i, row) in expected.iter().enumerate() {
+        for (j, &want) in row.iter().enumerate() {
+            assert!(f64::abs(result[i][j] - want) < 1e-12);
         }
     }
 }
@@ -122,9 +122,9 @@ fn ad_hessian() {
         [-2.0 * f64::sin(1.0), f64::cos(1.0) + 2.0 * f64::exp(2.0)],
         [f64::cos(1.0) + 2.0 * f64::exp(2.0), 2.0 * f64::exp(2.0)],
     ];
-    for i in 0..2 {
-        for j in 0..2 {
-            assert!(f64::abs(result[(i, j)] - expected[i][j]) < 1e-12);
+    for (i, row) in expected.iter().enumerate() {
+        for (j, &want) in row.iter().enumerate() {
+            assert!(f64::abs(result[(i, j)] - want) < 1e-12);
         }
     }
 }
@@ -210,9 +210,9 @@ fn ad_jacobian_is_column_seeded() {
 
     // values are unchanged from the old harness
     let expected = [[6.0, 3.0, 2.0], [2.0, 4.0, 0.0]];
-    for i in 0..2 {
-        for j in 0..3 {
-            assert!(f64::abs(result[(i, j)] - expected[i][j]) < 1e-12);
+    for (i, row) in expected.iter().enumerate() {
+        for (j, &want) in row.iter().enumerate() {
+            assert!(f64::abs(result[(i, j)] - want) < 1e-12);
         }
     }
 
@@ -247,9 +247,9 @@ fn fd_jacobian_column_matches() {
     let result = jacobian.get(&f, &[1.0, 2.0, 3.0]).unwrap();
 
     let expected = [[6.0, 3.0, 2.0], [2.0, 4.0, 0.0]];
-    for i in 0..2 {
-        for j in 0..3 {
-            assert!(f64::abs(result[(i, j)] - expected[i][j]) < 1e-5);
+    for (i, row) in expected.iter().enumerate() {
+        for (j, &want) in row.iter().enumerate() {
+            assert!(f64::abs(result[(i, j)] - want) < 1e-5);
         }
     }
 }

--- a/crates/multicalc/tests/suite/spatial/lie.rs
+++ b/crates/multicalc/tests/suite/spatial/lie.rs
@@ -76,19 +76,16 @@ fn assert_mat_close<const R: usize, const C: usize>(
 ) {
     for i in 0..R {
         for j in 0..C {
-            assert!(
-                (a[(i, j)] - b[(i, j)]).abs() < tol,
-                "({i},{j}): {} vs {}",
-                a[(i, j)],
-                b[(i, j)]
-            );
+            let (aij, bij) = (a[(i, j)], b[(i, j)]);
+            assert!((aij - bij).abs() < tol, "({i},{j}): {aij} vs {bij}");
         }
     }
 }
 
 fn assert_vec_close<const N: usize>(a: Vector<N, f64>, b: Vector<N, f64>, tol: f64) {
     for i in 0..N {
-        assert!((a[i] - b[i]).abs() < tol, "[{i}]: {} vs {}", a[i], b[i]);
+        let (ai, bi) = (a[i], b[i]);
+        assert!((ai - bi).abs() < tol, "[{i}]: {ai} vs {bi}");
     }
 }
 
@@ -520,7 +517,8 @@ fn se3_left_jacobian_finite_at_zero_under_dual() {
     let jl = SE3::left_jacobian(xi);
     for i in 0..6 {
         for j in 0..6 {
-            assert!(jl[(i, j)].value.is_finite() && jl[(i, j)].deriv.is_finite());
+            let cell = jl[(i, j)];
+            assert!(cell.value.is_finite() && cell.deriv.is_finite());
         }
     }
 }

--- a/crates/multicalc/tests/suite/spatial/quaternion.rs
+++ b/crates/multicalc/tests/suite/spatial/quaternion.rs
@@ -53,7 +53,8 @@ fn assert_close_q(a: Quaternion<f64>, b: Quaternion<f64>, tol: f64) {
 
 fn assert_close_v(a: Vector<3, f64>, b: Vector<3, f64>, tol: f64) {
     for i in 0..3 {
-        assert!((a[i] - b[i]).abs() < tol, "{} vs {}", a[i], b[i]);
+        let (ai, bi) = (a[i], b[i]);
+        assert!((ai - bi).abs() < tol, "{ai} vs {bi}");
     }
 }
 

--- a/crates/multicalc/tests/suite/spatial/twist_wrench.rs
+++ b/crates/multicalc/tests/suite/spatial/twist_wrench.rs
@@ -95,7 +95,8 @@ fn ad_transparent_under_dual() {
     assert!((out[0].value - 6.0).abs() < 1e-12);
     assert!((out[0].deriv - 3.0).abs() < 1e-12);
     for i in 1..6 {
-        assert!(out[i].value.is_finite() && out[i].deriv.is_finite());
-        assert!(out[i].deriv.abs() < 1e-12);
+        let oi = out[i];
+        assert!(oi.value.is_finite() && oi.deriv.is_finite());
+        assert!(oi.deriv.abs() < 1e-12);
     }
 }

--- a/demos/examples/basics/estimation.rs
+++ b/demos/examples/basics/estimation.rs
@@ -234,7 +234,8 @@ fn position_spread<R: multicalc::random::RandomSource>(
     let mean = filter.mean();
     let mut variance = 0.0;
     for (particle, &weight) in filter.particles().iter().zip(filter.weights()) {
-        variance += weight * ((particle[0] - mean[0]).powi(2) + (particle[1] - mean[1]).powi(2));
+        let p = *particle;
+        variance += weight * ((p[0] - mean[0]).powi(2) + (p[1] - mean[1]).powi(2));
     }
     variance.sqrt()
 }

--- a/demos/examples/basics/jacobian_hessian.rs
+++ b/demos/examples/basics/jacobian_hessian.rs
@@ -28,9 +28,9 @@ fn main() {
     }
     println!("  (exact [[6, 3, 2], [2, 4, 0]])");
     let exact = [[6.0, 3.0, 2.0], [2.0, 4.0, 0.0]];
-    for i in 0..2 {
-        for j in 0..3 {
-            assert!((result[(i, j)] - exact[i][j]).abs() < 1e-9);
+    for (i, row) in exact.iter().enumerate() {
+        for (j, &want) in row.iter().enumerate() {
+            assert!((result[(i, j)] - want).abs() < 1e-9);
         }
     }
 

--- a/demos/examples/basics/kinematics.rs
+++ b/demos/examples/basics/kinematics.rs
@@ -47,8 +47,9 @@ fn main() {
     let pose = integrate(SE2::identity(), BodyTwist::new(v, w).integrate_over(t));
     let (theta, radius) = (w * t, v / w);
     println!("\nArc of a constant twist (v = 0.4, omega = 0.9) held for 1.3 s");
-    report("x [m]", pose.translation()[0], radius * theta.sin());
-    report("y [m]", pose.translation()[1], radius * (1.0 - theta.cos()));
+    let xy = pose.translation();
+    report("x [m]", xy[0], radius * theta.sin());
+    report("y [m]", xy[1], radius * (1.0 - theta.cos()));
     report("heading [rad]", pose.rotation().log(), theta);
 
     // (4) The encoder path, end to end: two full circles of opposite curvature must return to the
@@ -68,8 +69,9 @@ fn main() {
         }
     }
     println!("\nFigure eight: two opposed circles through the encoder path");
-    report("x [m]", figure_eight.translation()[0], 0.0);
-    report("y [m]", figure_eight.translation()[1], 0.0);
+    let xy = figure_eight.translation();
+    report("x [m]", xy[0], 0.0);
+    report("y [m]", xy[1], 0.0);
     report("heading [rad]", figure_eight.rotation().log(), 0.0);
 
     // (5) One Dual through an odometry step: d(x)/d(arc length), exact, no hand-derived formula.
@@ -79,12 +81,9 @@ fn main() {
     );
     println!("\nAutodiff through an odometry step");
     // x = (v/omega)*sin(omega*t), so dx/dv = sin(omega*t)/omega.
-    report("dx/dv [s]", step.translation()[0].deriv, theta.sin() / w);
-    report(
-        "dy/dv [s]",
-        step.translation()[1].deriv,
-        (1.0 - theta.cos()) / w,
-    );
+    let t = step.translation();
+    report("dx/dv [s]", t[0].deriv, theta.sin() / w);
+    report("dy/dv [s]", t[1].deriv, (1.0 - theta.cos()) / w);
 
     println!("\nAll checks passed.");
 }

--- a/demos/examples/basics/ode.rs
+++ b/demos/examples/basics/ode.rs
@@ -136,7 +136,7 @@ fn acrobot_mass(c2: f64) -> (f64, f64, f64) {
 }
 
 fn acrobot_rhs(_t: f64, y: &Vector<4, f64>) -> Vector<4, f64> {
-    let (th1, th2, w1, w2) = (y[0], y[1], y[2], y[3]);
+    let [th1, th2, w1, w2] = [y[0], y[1], y[2], y[3]];
     let (d11, d12, d22) = acrobot_mass(th2.cos());
     let s2 = th2.sin();
     let h1 = -ACRO_M2 * ACRO_L1 * ACRO_LC2 * s2 * (2.0 * w1 * w2 + w2 * w2);
@@ -151,7 +151,7 @@ fn acrobot_rhs(_t: f64, y: &Vector<4, f64>) -> Vector<4, f64> {
 }
 
 fn acrobot_energy(y: &Vector<4, f64>) -> f64 {
-    let (th1, th2, w1, w2) = (y[0], y[1], y[2], y[3]);
+    let [th1, th2, w1, w2] = [y[0], y[1], y[2], y[3]];
     let (d11, d12, d22) = acrobot_mass(th2.cos());
     let ke = 0.5 * (d11 * w1 * w1 + 2.0 * d12 * w1 * w2 + d22 * w2 * w2);
     let pe = ACRO_G
@@ -178,8 +178,7 @@ const QUAD_IY: f64 = 0.02;
 const QUAD_IZ: f64 = 0.03;
 
 fn quadrotor_rhs(_t: f64, y: &Vector<7, f64>) -> Vector<7, f64> {
-    let (qw, qx, qy, qz) = (y[0], y[1], y[2], y[3]);
-    let (wx, wy, wz) = (y[4], y[5], y[6]);
+    let [qw, qx, qy, qz, wx, wy, wz] = [y[0], y[1], y[2], y[3], y[4], y[5], y[6]];
     let qwd = -0.5 * (qx * wx + qy * wy + qz * wz);
     let qxd = 0.5 * (qw * wx + qy * wz - qz * wy);
     let qyd = 0.5 * (qw * wy - qx * wz + qz * wx);

--- a/demos/examples/basics/svd.rs
+++ b/demos/examples/basics/svd.rs
@@ -126,7 +126,8 @@ fn near_singular() {
         }
     });
     for r in 0..6 {
-        j[(r, 5)] = j[(r, 4)] + 1e-8 * (r as f64 + 1.0);
+        let j4 = j[(r, 4)];
+        j[(r, 5)] = j4 + 1e-8 * (r as f64 + 1.0);
     }
     let (f, ns) = time(100_000, || black_box(j).svd().unwrap());
     let cond = f.condition_number();


### PR DESCRIPTION
Closes #152
Closes #183 

Dual public access for `Matrix` / `Vector`:
- **Primary:** panicking `Index` / `IndexMut` (`v[i]`, `m[(r, c)]`) — ergonomic path for
  known-in-bounds code (kernels, demos, tests).
- **Secondary:** `get` / `get_mut`, `try_row` / `try_column`, and `as_mut_slice_rows` for
  Option-based access when the index may be invalid.
- **Removed:** panicking `row` / `column` (use `try_row` / `try_column`).
- 
Factorization kernels (QR / LU / Cholesky / SVD) and call sites use Index again so formulas
stay readable; soft accessors remain for the safety-minded path.

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
