### PR TITLE
test(linalg): property tests for LU/QR reconstruction identities

### DIFF
--- a/crates/multicalc/tests/suite/linear_algebra/lu.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/lu.rs
@@ -1,6 +1,8 @@
 use multicalc::error::LinalgError;
 use multicalc::linear_algebra::{Matrix, Vector};
 use multicalc_testkit::tol::{assert_identity, assert_matrix_close, lu_reconstructs};
+use proptest::prelude::*;
+use proptest::test_runner::TestCaseError;
 
 // ----- LU decomposition (Doolittle, partial pivoting) -----
 
@@ -135,4 +137,61 @@ fn lu_inverse_matches_reference_5x5() {
         1e-12,
     );
     assert_identity(a * inv, 1e-12);
+}
+
+// ----- property: P·A = L·U on random matrices -----
+
+/// Largest absolute entry of `a`, used to scale the reconstruction tolerance to the size of
+/// the randomly generated input.
+fn max_abs<const R: usize, const C: usize>(a: &Matrix<R, C>) -> f64 {
+    let mut max = 0.0_f64;
+    for r in 0..R {
+        for c in 0..C {
+            max = max.max(a[(r, c)].abs());
+        }
+    }
+    max
+}
+
+/// Builds an `N`x`N` matrix from `entries` and checks `P·A = L·U` (`L` unit lower-triangular,
+/// `U` upper-triangular) via [`lu_reconstructs`], at a tolerance scaled by the matrix's
+/// magnitude and `f64::EPSILON`.
+///
+/// Rejects rather than asserts on inputs the generator turns up that are singular, or that carry
+/// a pivot too small relative to the matrix's scale: partial pivoting keeps elimination growth
+/// mild, but a near-zero pivot still leaves the reconstruction too ill-conditioned for a fixed
+/// tolerance not to flake.
+fn check_lu_property<const N: usize>(entries: Vec<f64>) -> Result<(), TestCaseError> {
+    let a = Matrix::<N, N>::try_from_row_slice(&entries).expect("N*N entries");
+    let scale = max_abs(&a).max(1.0);
+
+    let lu = a.lu();
+    prop_assume!(lu.is_ok());
+    let f = lu.unwrap();
+
+    let min_pivot = (0..N).fold(f64::MAX, |acc, i| acc.min(f.u()[(i, i)].abs()));
+    prop_assume!(min_pivot >= 1e-6 * scale);
+
+    let tol = N as f64 * scale * f64::EPSILON * 1e3;
+    lu_reconstructs(a, tol);
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    #[test]
+    fn proptest_lu_reconstructs_3x3(entries in prop::collection::vec(-8.0f64..8.0, 9)) {
+        check_lu_property::<3>(entries)?;
+    }
+
+    #[test]
+    fn proptest_lu_reconstructs_4x4(entries in prop::collection::vec(-8.0f64..8.0, 16)) {
+        check_lu_property::<4>(entries)?;
+    }
+
+    #[test]
+    fn proptest_lu_reconstructs_5x5(entries in prop::collection::vec(-8.0f64..8.0, 25)) {
+        check_lu_property::<5>(entries)?;
+    }
 }

--- a/crates/multicalc/tests/suite/linear_algebra/lu.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/lu.rs
@@ -1,6 +1,6 @@
 use multicalc::error::LinalgError;
 use multicalc::linear_algebra::{Matrix, Vector};
-use multicalc_testkit::tol::{assert_identity, assert_matrix_close, lu_reconstructs};
+use multicalc_testkit::tol::{assert_identity, assert_matrix_close, lu_reconstructs, max_abs};
 use proptest::prelude::*;
 use proptest::test_runner::TestCaseError;
 
@@ -141,18 +141,6 @@ fn lu_inverse_matches_reference_5x5() {
 
 // ----- property: P·A = L·U on random matrices -----
 
-/// Largest absolute entry of `a`, used to scale the reconstruction tolerance to the size of
-/// the randomly generated input.
-fn max_abs<const R: usize, const C: usize>(a: &Matrix<R, C>) -> f64 {
-    let mut max = 0.0_f64;
-    for r in 0..R {
-        for c in 0..C {
-            max = max.max(a[(r, c)].abs());
-        }
-    }
-    max
-}
-
 /// Builds an `N`x`N` matrix from `entries` and checks `P·A = L·U` (`L` unit lower-triangular,
 /// `U` upper-triangular) via [`lu_reconstructs`], at a tolerance scaled by the matrix's
 /// magnitude and `f64::EPSILON`.
@@ -163,7 +151,7 @@ fn max_abs<const R: usize, const C: usize>(a: &Matrix<R, C>) -> f64 {
 /// tolerance not to flake.
 fn check_lu_property<const N: usize>(entries: Vec<f64>) -> Result<(), TestCaseError> {
     let a = Matrix::<N, N>::try_from_row_slice(&entries).expect("N*N entries");
-    let scale = max_abs(&a).max(1.0);
+    let scale = max_abs(a).max(1.0);
 
     let lu = a.lu();
     prop_assume!(lu.is_ok());
@@ -178,7 +166,7 @@ fn check_lu_property<const N: usize>(entries: Vec<f64>) -> Result<(), TestCaseEr
 }
 
 proptest! {
-    #![proptest_config(ProptestConfig::with_cases(64))]
+    #![proptest_config(ProptestConfig::with_cases(256))]
 
     #[test]
     fn proptest_lu_reconstructs_3x3(entries in prop::collection::vec(-8.0f64..8.0, 9)) {

--- a/crates/multicalc/tests/suite/linear_algebra/qr.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/qr.rs
@@ -1,6 +1,6 @@
 use multicalc::error::LinalgError;
 use multicalc::linear_algebra::{Matrix, PivotedQr, Vector};
-use multicalc_testkit::tol::{assert_identity, assert_matrix_close};
+use multicalc_testkit::tol::{assert_identity, assert_matrix_close, max_abs};
 use proptest::prelude::*;
 use proptest::test_runner::TestCaseError;
 
@@ -222,18 +222,6 @@ fn damped_solves_ridge_regression() {
 
 // ----- property: A·P = Q·R on random matrices -----
 
-/// Largest absolute entry of `a`, used to scale the reconstruction tolerance to the size of
-/// the randomly generated input.
-fn max_abs<const R: usize, const C: usize>(a: &Matrix<R, C>) -> f64 {
-    let mut max = 0.0_f64;
-    for r in 0..R {
-        for c in 0..C {
-            max = max.max(a[(r, c)].abs());
-        }
-    }
-    max
-}
-
 /// Builds an `M`x`N` matrix from `entries` and checks the column-pivoted QR identities: `R` is
 /// upper-triangular, `Q` has orthonormal columns (`QᵀQ = I`), and `A·P = Q·R` (column `j` of
 /// `A·P` is column `permutation()[j]` of `A`). Tolerance is scaled by the matrix's magnitude and
@@ -247,7 +235,7 @@ fn check_qr_property<const M: usize, const N: usize>(
     entries: Vec<f64>,
 ) -> Result<(), TestCaseError> {
     let a = Matrix::<M, N>::try_from_row_slice(&entries).expect("M*N entries");
-    let scale = max_abs(&a).max(1.0);
+    let scale = max_abs(a).max(1.0);
 
     // M >= N is guaranteed by the generators below, so this never hits `Underdetermined`.
     let f = PivotedQr::decompose(a).unwrap();

--- a/crates/multicalc/tests/suite/linear_algebra/qr.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/qr.rs
@@ -1,6 +1,8 @@
 use multicalc::error::LinalgError;
 use multicalc::linear_algebra::{Matrix, PivotedQr, Vector};
 use multicalc_testkit::tol::{assert_identity, assert_matrix_close};
+use proptest::prelude::*;
+use proptest::test_runner::TestCaseError;
 
 // ----- column-pivoted QR (decompose, accessors, solve) -----
 
@@ -215,5 +217,80 @@ fn damped_solves_ridge_regression() {
             * x;
     for i in 0..8 {
         assert!((lhs[i] - vtb[i]).abs() < 1e-8);
+    }
+}
+
+// ----- property: A·P = Q·R on random matrices -----
+
+/// Largest absolute entry of `a`, used to scale the reconstruction tolerance to the size of
+/// the randomly generated input.
+fn max_abs<const R: usize, const C: usize>(a: &Matrix<R, C>) -> f64 {
+    let mut max = 0.0_f64;
+    for r in 0..R {
+        for c in 0..C {
+            max = max.max(a[(r, c)].abs());
+        }
+    }
+    max
+}
+
+/// Builds an `M`x`N` matrix from `entries` and checks the column-pivoted QR identities: `R` is
+/// upper-triangular, `Q` has orthonormal columns (`QᵀQ = I`), and `A·P = Q·R` (column `j` of
+/// `A·P` is column `permutation()[j]` of `A`). Tolerance is scaled by the matrix's magnitude and
+/// `f64::EPSILON`.
+///
+/// Rejects rather than asserts on inputs the generator turns up that are near rank-deficient (an
+/// `R` diagonal entry too small relative to the matrix's scale) — the factorization stays
+/// backward-stable regardless, but the reconstruction tolerance below would flake on the rare,
+/// mildly ill-conditioned draw.
+fn check_qr_property<const M: usize, const N: usize>(
+    entries: Vec<f64>,
+) -> Result<(), TestCaseError> {
+    let a = Matrix::<M, N>::try_from_row_slice(&entries).expect("M*N entries");
+    let scale = max_abs(&a).max(1.0);
+
+    // M >= N is guaranteed by the generators below, so this never hits `Underdetermined`.
+    let f = PivotedQr::decompose(a).unwrap();
+    let r = f.r();
+    let q = f.q();
+    let perm = f.permutation();
+
+    let min_diag = (0..N).fold(f64::MAX, |acc, j| acc.min(r[(j, j)].abs()));
+    prop_assume!(min_diag >= 1e-6 * scale);
+
+    let tol = M.max(N) as f64 * scale * f64::EPSILON * 1e3;
+
+    // R is upper-triangular by construction; check anyway as a structural guard.
+    for row in 0..N {
+        for col in 0..row {
+            assert_eq!(r[(row, col)], 0.0);
+        }
+    }
+
+    assert_identity(q.transpose() * q, tol);
+
+    let ap = Matrix::<M, N>::from_fn(|i, c| a[(i, perm[c])]);
+    assert_matrix_close(q * r, ap, tol);
+
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    #[test]
+    fn proptest_qr_reconstructs_3x3(entries in prop::collection::vec(-8.0f64..8.0, 9)) {
+        check_qr_property::<3, 3>(entries)?;
+    }
+
+    #[test]
+    fn proptest_qr_reconstructs_5x5(entries in prop::collection::vec(-8.0f64..8.0, 25)) {
+        check_qr_property::<5, 5>(entries)?;
+    }
+
+    // Rectangular (overdetermined) case: more rows than columns.
+    #[test]
+    fn proptest_qr_reconstructs_6x3(entries in prop::collection::vec(-8.0f64..8.0, 18)) {
+        check_qr_property::<6, 3>(entries)?;
     }
 }

--- a/tools/testkit/src/tol.rs
+++ b/tools/testkit/src/tol.rs
@@ -124,11 +124,13 @@ pub fn svd_moore_penrose<const M: usize, const N: usize, T: Numeric>(a: Matrix<M
     assert_matrix_close(apa, apa.transpose(), tol);
 }
 
-fn max_abs<const R: usize, const C: usize>(m: Matrix<R, C, f32>) -> f32 {
-    let mut max = 0.0_f32;
+/// Largest absolute entry of `a`, used to scale reconstruction/tolerance checks to the
+/// magnitude of the input matrix.
+pub fn max_abs<const R: usize, const C: usize, T: Numeric>(a: Matrix<R, C, T>) -> T {
+    let mut max = T::ZERO;
     for r in 0..R {
         for c in 0..C {
-            max = max.max(m[(r, c)].abs());
+            max = max.max(a[(r, c)].abs());
         }
     }
     max


### PR DESCRIPTION
Adds proptest-based property tests to the existing per-decomposition test
files, asserting the reconstruction identities on random matrices at a few
const-generic sizes:

- **LU** (`crates/multicalc/tests/suite/linear_algebra/lu.rs`): `P·A = L·U`,
  with `L` unit lower-triangular and `U` upper-triangular, at 3x3, 4x4, and
  5x5.
- **QR** (`crates/multicalc/tests/suite/linear_algebra/qr.rs`): `A·P = Q·R`
  (the column-pivoted identity this crate's `PivotedQr` actually implements),
  with `QᵀQ = I` and `R` upper-triangular, at 3x3 and 5x5 square sizes plus a
  6x3 rectangular (overdetermined) case.

Golden tests in both files already pin known matrices; these complement them
by proving the factorizations hold on inputs nobody hand-picked.

**Tolerance**: scaled by the matrix's magnitude (largest absolute entry) and
`f64::EPSILON`, not a fixed constant, so it tracks the input rather than
assuming a fixed scale.

**Bounding the generator**: entries are drawn from a bounded range per cell.
Inputs the generator turns up that are singular (LU) or have a pivot/`R`
diagonal entry too small relative to the matrix's scale (both) are rejected
via `prop_assume!` rather than asserted on — partial pivoting keeps
elimination growth mild, but a near-zero pivot still leaves the
reconstruction tolerance too tight for a fixed bound not to flake on rare,
mildly ill-conditioned draws.

`proptest` was already present in this crate's
`[target.'cfg(not(target_arch = "arm"))'.dev-dependencies]` table, so no
`Cargo.toml` change was needed.

Verified with `cargo test -p multicalc --test suite linear_algebra` (54
tests, including golden and the 6 new property tests) and the full `cargo
test -p multicalc` (450 + 133 doctests), all passing. Also ran the new
property tests standalone at `PROPTEST_CASES=500` across 5 repeated runs
with no failures, and checked `cargo clippy --tests -- -D warnings` and
`cargo fmt --check` clean.

Closes #103