### PR TITLE
fix(spatial): scale small-angle cutoffs to EPSILON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RK45 now handles zero-dimensional states without producing NaN norms. (#159)
 - 2×2/3×3/4×4 `Matrix::inverse` reject near-singular inputs via an
   `EPSILON`-scaled det check instead of exact `det == 0`. @rtmongold (#181)
+- Spatial small-angle Taylor cutoffs use `30 · EPSILON` and `(30 · EPSILON)²`
+  instead of fixed `1e-6` / `1e-12`. @rtmongold (#190)
 
 ### Changed
 

--- a/crates/multicalc/src/spatial/mod.rs
+++ b/crates/multicalc/src/spatial/mod.rs
@@ -16,18 +16,17 @@ pub use quaternion::Quaternion;
 pub use twist::Twist;
 pub use wrench::Wrench;
 
-/// The angle threshold below which trig ratios switch to their Taylor series, keeping values
-/// finite and derivatives continuous. A fixed absolute cutoff (not `EPSILON`-relative); correct for
-/// both f32 and f64.
+/// Angle threshold below which trig ratios switch to their Taylor series.
+/// Also used for eps-scale proximity checks (e.g. Euler gimbal lock vs ±1).
+/// Scaled as `30 · EPSILON` so each scalar type gets a type-appropriate cutoff.
 #[inline]
 pub(crate) fn small_angle<T: Numeric>() -> T {
-    T::from_f64(1e-6)
+    T::EPSILON_X30
 }
 
-/// The squared small-angle threshold, for branches taken on a squared magnitude (θ², ‖v‖²) before
-/// any `sqrt`. Branching pre-`sqrt` keeps the AD derivative finite at exactly zero, where `sqrt`'s
-/// derivative is NaN.
+/// Squared small-angle threshold, `(30 · EPSILON)²`, for branches on θ² / ‖v‖² before
+/// `sqrt`.
 #[inline]
 pub(crate) fn small_angle_sq<T: Numeric>() -> T {
-    T::from_f64(1e-12)
+    small_angle::<T>() * small_angle::<T>()
 }

--- a/crates/multicalc/src/spatial/quaternion.rs
+++ b/crates/multicalc/src/spatial/quaternion.rs
@@ -397,7 +397,7 @@ impl<T: Numeric> Quaternion<T> {
         let (w, x, y, z) = (self.w, self.x, self.y, self.z);
         let two = T::TWO;
         let sinp = two * (w * y - z * x);
-        if sinp.abs() >= T::ONE - small_angle_sq::<T>() {
+        if sinp.abs() >= T::ONE - small_angle::<T>() {
             // Gimbal lock: at pitch = ±π/2 the standard roll/yaw formulas divide 0/0. Snap pitch
             // to the pole, fix roll = 0, and fold the whole rotation into yaw (sign set by the
             // pole). Reconstruction still matches; only the roll/yaw split is not unique here.

--- a/crates/multicalc/tests/suite/spatial/lie.rs
+++ b/crates/multicalc/tests/suite/spatial/lie.rs
@@ -665,3 +665,83 @@ fn se3_to_matrix_goldens() {
         1e-12,
     );
 }
+
+#[test]
+fn near_zero_exp_log_and_jacobians_f64() {
+    let z3 = Vector::new([0.0_f64, 0.0, 0.0]);
+    assert_components_close(SO3::exp(z3).log(), z3, 1e-14);
+    assert_entries_close(
+        SO3::left_jacobian(z3) * SO3::left_jacobian_inverse(z3),
+        Matrix::identity(),
+        1e-14,
+    );
+
+    let tiny3 = Vector::new([1e-9_f64, 0.0, 0.0]);
+    assert_components_close(SO3::exp(tiny3).log(), tiny3, 1e-12);
+    assert_entries_close(
+        SO3::left_jacobian(tiny3) * SO3::left_jacobian_inverse(tiny3),
+        Matrix::identity(),
+        1e-9,
+    );
+
+    let z6 = Vector::new([0.0_f64; 6]);
+    assert_components_close(SE3::exp(z6).log(), z6, 1e-14);
+    let tiny6 = Vector::new([0.0, 0.0, 0.0, 1e-9_f64, 0.0, 0.0]);
+    assert_components_close(SE3::exp(tiny6).log(), tiny6, 1e-12);
+
+    let z3_se2 = Vector::new([0.0_f64, 0.0, 0.0]);
+    assert_components_close(SE2::exp(z3_se2).log(), z3_se2, 1e-14);
+    let tiny_se2 = Vector::new([0.0, 0.0, 1e-9_f64]);
+    assert_components_close(SE2::exp(tiny_se2).log(), tiny_se2, 1e-12);
+}
+
+#[test]
+fn near_zero_exp_log_and_jacobians_f32() {
+    let z3 = Vector::new([0.0_f32, 0.0, 0.0]);
+    let back = SO3::exp(z3).log();
+    for i in 0..3 {
+        assert!(back[i].abs() < 1e-5);
+    }
+    let jl = SO3::left_jacobian(z3) * SO3::left_jacobian_inverse(z3);
+    for i in 0..3 {
+        for j in 0..3 {
+            let expect = if i == j { 1.0 } else { 0.0 };
+            assert!((jl[(i, j)] - expect).abs() < 1e-4);
+        }
+    }
+
+    let tiny3 = Vector::new([1e-9_f32, 0.0, 0.0]);
+    let back_tiny = SO3::exp(tiny3).log();
+    for i in 0..3 {
+        assert!((back_tiny[i] - tiny3[i]).abs() < 1e-5);
+    }
+    let jl_tiny = SO3::left_jacobian(tiny3) * SO3::left_jacobian_inverse(tiny3);
+    for i in 0..3 {
+        for j in 0..3 {
+            let expect = if i == j { 1.0 } else { 0.0 };
+            assert!((jl_tiny[(i, j)] - expect).abs() < 1e-4);
+        }
+    }
+
+    let z6 = Vector::new([0.0_f32; 6]);
+    let back6 = SE3::exp(z6).log();
+    for i in 0..6 {
+        assert!(back6[i].abs() < 1e-5);
+    }
+    let tiny6 = Vector::new([0.0, 0.0, 0.0, 1e-9_f32, 0.0, 0.0]);
+    let back6_tiny = SE3::exp(tiny6).log();
+    for i in 0..6 {
+        assert!((back6_tiny[i] - tiny6[i]).abs() < 1e-5);
+    }
+
+    let z3_se2 = Vector::new([0.0_f32, 0.0, 0.0]);
+    let back_se2 = SE2::exp(z3_se2).log();
+    for i in 0..3 {
+        assert!(back_se2[i].abs() < 1e-5);
+    }
+    let tiny_se2 = Vector::new([0.0, 0.0, 1e-9_f32]);
+    let back_se2_tiny = SE2::exp(tiny_se2).log();
+    for i in 0..3 {
+        assert!((back_se2_tiny[i] - tiny_se2[i]).abs() < 1e-5);
+    }
+}

--- a/crates/multicalc/tests/suite/spatial/quaternion.rs
+++ b/crates/multicalc/tests/suite/spatial/quaternion.rs
@@ -449,3 +449,40 @@ fn f32_identities() {
         }
     }
 }
+
+//---- near-zero identities (f32 + f64) ----------------------------------------
+
+fn near_zero_scaled_axis_roundtrip<T: Numeric>() {
+    let zero = Vector::new([T::ZERO, T::ZERO, T::ZERO]);
+    let q0 = Quaternion::from_scaled_axis(zero);
+    assert!((q0.norm() - T::ONE).abs() < T::from_f64(1e-5));
+    let back0 = q0.to_scaled_axis();
+    for &comp in back0.as_array() {
+        assert!(comp.abs() < T::from_f64(1e-5));
+    }
+
+    // Sub threshold angle stays on Taylor path; round-trip stays finite/unit.
+    let tiny = Vector::new([T::from_f64(1e-9), T::ZERO, T::ZERO]);
+    let q = Quaternion::from_scaled_axis(tiny);
+    assert!(q.norm().is_finite());
+    assert!((q.norm() - T::ONE).abs() < T::from_f64(1e-4));
+    let back = Quaternion::from_scaled_axis(q.to_scaled_axis());
+    for (a, b) in q.as_array().iter().zip(back.as_array().iter()) {
+        assert!((*a - *b).abs() < T::from_f64(1e-4));
+    }
+
+    let [tx, ty, tz] = *tiny.as_array();
+    let q_exp = Quaternion::new(T::ZERO, tx, ty, tz).exp();
+    let q_ln = q_exp.ln();
+    assert!(q_ln.w().is_finite() && q_ln.x().is_finite());
+}
+
+#[test]
+fn near_zero_identities_f64() {
+    near_zero_scaled_axis_roundtrip::<f64>();
+}
+
+#[test]
+fn near_zero_identities_f32() {
+    near_zero_scaled_axis_roundtrip::<f32>();
+}


### PR DESCRIPTION
Closes #160 
Pending #185 

Replace fixed `1e-6` / `1e-12` Taylor thresholds with type-scaled cutoffs:
- `small_angle = EPSILON_X30`
- `small_angle_sq = (small_angle)²`

Euler gimbal lock proximity (`1 - |sinp|`) uses `small_angle`, not the squared helper.
Near-zero exp/log/Jacobian identities covered for f32 and f64.

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
