### PR TITLE
feat(linalg): Matrix and Vector extra methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ waypoint paths, plus a prelude and one-call entry points for the calculus core.
   @kmolan (#192)
 - docs.rs now builds with all features so gated items appear in the published docs.
   @kmolan (#197)
+- Add `Matrix` methods: `trace`, `frobenius_norm`, `from_diagonal` @birchmd (#191)
+- Add `Vector` methods: `normalize`, `normalized`, `map` @birchmd (#191)
+- Add impl Div<T> where T: Numeric for `Matrix` and `Vector` @birchmd (#191)
 
 ### Fixed
 

--- a/crates/multicalc/src/linear_algebra/matrix.rs
+++ b/crates/multicalc/src/linear_algebra/matrix.rs
@@ -1,6 +1,6 @@
 //! Fixed-size, stack-allocated matrix.
 
-use core::ops::{Add, AddAssign, Index, IndexMut, Mul, Neg, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Div, Index, IndexMut, Mul, Neg, Sub, SubAssign};
 
 use crate::error::LinalgError;
 use crate::linear_algebra::Vector;
@@ -620,6 +620,17 @@ impl<const ROWS: usize, const COLS: usize, T: Numeric> Mul<T> for Matrix<ROWS, C
     #[inline]
     fn mul(self, scalar: T) -> Self {
         self.scale(scalar)
+    }
+}
+
+// Note: this implementation could panic on division by zero if the underlying
+// implementation on `T` would panic.
+impl<const ROWS: usize, const COLS: usize, T: Numeric> Div<T> for Matrix<ROWS, COLS, T> {
+    type Output = Self;
+
+    #[inline]
+    fn div(self, scalar: T) -> Self {
+        self.scale(T::ONE / scalar)
     }
 }
 

--- a/crates/multicalc/src/linear_algebra/matrix.rs
+++ b/crates/multicalc/src/linear_algebra/matrix.rs
@@ -286,6 +286,23 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
         }
     }
 
+    /// Returns the trace of the matrix (sum of diagonal entries).
+    ///
+    /// Note: this method computes the sum of the entries in order from top left
+    /// to bottom right, which could have an impact on the accuracy of the result
+    /// in the case of floating-point types if the earlier elements are significantly
+    /// larger than the later ones.
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::Matrix;
+    /// assert_eq!(Matrix::new([[1.0, -2.0], [3.0, 4.0]]).trace(), 5.0);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn trace(&self) -> T {
+        (0..N).fold(T::ZERO, |acc, i| acc + self[(i, i)])
+    }
+
     /// The inverse, or [`LinalgError::Singular`] if the matrix is singular or near-singular.
     ///
     /// Sizes up to 4×4 use a closed form and reject a matrix whose `|det|` is at or below an

--- a/crates/multicalc/src/linear_algebra/matrix.rs
+++ b/crates/multicalc/src/linear_algebra/matrix.rs
@@ -291,6 +291,12 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
     }
 
     /// Returns the diagonal entries of the matrix as an array.
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::Matrix;
+    /// let m = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
+    /// assert_eq!(m.diagonal(), [1.0, 4.0]);
+    /// ```
     #[inline]
     #[must_use]
     pub fn diagonal(&self) -> [T; N] {

--- a/crates/multicalc/src/linear_algebra/matrix.rs
+++ b/crates/multicalc/src/linear_algebra/matrix.rs
@@ -229,15 +229,11 @@ impl<const ROWS: usize, const COLS: usize, T: Numeric> Matrix<ROWS, COLS, T> {
     #[inline]
     #[must_use]
     pub fn frobenius_norm(self) -> T {
-        let total = self.data.into_iter().flatten().fold(T::ZERO, |acc, x| {
-            // Note: implementing `|x|^2` as `x * x` is correct for real numbers,
-            // however would be incorrect for complex numbers. In that case it
-            // should be `x * x.conj()` (i.e. multiplying by the complex conjugate).
-            // If this library is expected to work will complex numbers in the future
-            // then this will need to be updated; the `Numeric` trait would also need
-            // updating to include a complex conjugate operation.
-            acc + x * x
-        });
+        let total = self
+            .data
+            .into_iter()
+            .flatten()
+            .fold(T::ZERO, |acc, x| acc + x * x);
         total.sqrt()
     }
 

--- a/crates/multicalc/src/linear_algebra/matrix.rs
+++ b/crates/multicalc/src/linear_algebra/matrix.rs
@@ -538,6 +538,15 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
     }
 }
 
+impl<const N: usize> Matrix<N, N> {
+    /// Builds a symmetric positive-definite matrix from arbitrary entries as `M·Mᵀ`, ridged so the
+    /// factorization is well conditioned rather than merely non-singular.
+    pub fn symmetric_positive_definite(entries: &[f64]) -> Self {
+        let factor = Self::from_fn(|row, column| entries[row * N + column]);
+        factor * factor.transpose() + Self::from_diagonal([0.25; N])
+    }
+}
+
 impl<const ROWS: usize, const COLS: usize, T> From<[[T; COLS]; ROWS]> for Matrix<ROWS, COLS, T> {
     #[inline]
     fn from(data: [[T; COLS]; ROWS]) -> Self {

--- a/crates/multicalc/src/linear_algebra/matrix.rs
+++ b/crates/multicalc/src/linear_algebra/matrix.rs
@@ -276,6 +276,24 @@ impl<const ROWS: usize, const COLS: usize, T: Numeric> Matrix<ROWS, COLS, T> {
 }
 
 impl<const N: usize, T: Numeric> Matrix<N, N, T> {
+    /// The `N`×`N` diagonal matrix with the given diagonal entries
+    /// (all off-diagonal elements are equal to zero).
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::Matrix;
+    /// let m = Matrix::from_diagonal([1.0, 2.0, 3.0]);
+    /// assert_eq!(m.into_array(), [[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]]);
+    /// ```
+    #[inline]
+    pub fn from_diagonal(diag: [T; N]) -> Self {
+        let rows = core::array::from_fn(|i| {
+            let mut r = [T::ZERO; N];
+            r[i] = diag[i];
+            r
+        });
+        Matrix::new(rows)
+    }
+
     /// The `N`×`N` identity matrix.
     ///
     /// ```
@@ -285,7 +303,7 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
     /// ```
     #[inline]
     pub fn identity() -> Self {
-        Matrix::from_fn(|r, c| if r == c { T::ONE } else { T::ZERO })
+        Self::from_diagonal([T::ONE; N])
     }
 
     /// The determinant.

--- a/crates/multicalc/src/linear_algebra/matrix.rs
+++ b/crates/multicalc/src/linear_algebra/matrix.rs
@@ -294,6 +294,13 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
         Matrix::new(rows)
     }
 
+    /// Returns the diagonal entries of the matrix as an array.
+    #[inline]
+    #[must_use]
+    pub fn diagonal(&self) -> [T; N] {
+        core::array::from_fn(|i| self[(i, i)])
+    }
+
     /// The `N`×`N` identity matrix.
     ///
     /// ```

--- a/crates/multicalc/src/linear_algebra/matrix.rs
+++ b/crates/multicalc/src/linear_algebra/matrix.rs
@@ -623,14 +623,12 @@ impl<const ROWS: usize, const COLS: usize, T: Numeric> Mul<T> for Matrix<ROWS, C
     }
 }
 
-// Note: this implementation could panic on division by zero if the underlying
-// implementation on `T` would panic.
 impl<const ROWS: usize, const COLS: usize, T: Numeric> Div<T> for Matrix<ROWS, COLS, T> {
     type Output = Self;
 
     #[inline]
     fn div(self, scalar: T) -> Self {
-        self.scale(T::ONE / scalar)
+        Self::from_fn(|i, j| self[(i, j)].safe_div(scalar))
     }
 }
 

--- a/crates/multicalc/src/linear_algebra/matrix.rs
+++ b/crates/multicalc/src/linear_algebra/matrix.rs
@@ -213,6 +213,34 @@ impl<const ROWS: usize, const COLS: usize, T: Numeric> Matrix<ROWS, COLS, T> {
         Matrix::from_fn(|r, c| self[(c, r)])
     }
 
+    /// The Frobenius norm, sometimes called the Euclidean norm:
+    /// the square root of the sum of the absolute squares of the elements.
+    ///
+    /// Note: this method computes the sum of the entries in row-major order from top left
+    /// to bottom right, which could have an impact on the accuracy of the result
+    /// in the case of floating-point types if the earlier elements are significantly
+    /// larger than the later ones.
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::Matrix;
+    /// let m = Matrix::new([[1.0, -2.0, 0.0], [3.0, 0.0, 4.0], [2.0, -1.0, 1.0]]);
+    /// assert_eq!(m.frobenius_norm(), 6.0);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn frobenius_norm(self) -> T {
+        let total = self.data.into_iter().flatten().fold(T::ZERO, |acc, x| {
+            // Note: implementing `|x|^2` as `x * x` is correct for real numbers,
+            // however would be incorrect for complex numbers. In that case it
+            // should be `x * x.conj()` (i.e. multiplying by the complex conjugate).
+            // If this library is expected to work will complex numbers in the future
+            // then this will need to be updated; the `Numeric` trait would also need
+            // updating to include a complex conjugate operation.
+            acc + x * x
+        });
+        total.sqrt()
+    }
+
     /// Returns `true` when every entry is neither infinite nor NaN.
     ///
     /// ```

--- a/crates/multicalc/src/linear_algebra/vector.rs
+++ b/crates/multicalc/src/linear_algebra/vector.rs
@@ -1,6 +1,6 @@
 //! Fixed-size, stack-allocated column vector.
 
-use core::ops::{Add, AddAssign, Index, IndexMut, Mul, Neg, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Div, Index, IndexMut, Mul, Neg, Sub, SubAssign};
 
 use crate::scalar::Numeric;
 
@@ -316,6 +316,17 @@ impl<const N: usize, T: Numeric> Mul<T> for Vector<N, T> {
     #[inline]
     fn mul(self, scalar: T) -> Self {
         self.scale(scalar)
+    }
+}
+
+// Note: this implementation panics on division by zero if the underlying
+// implementation on `T` would panic.
+impl<const N: usize, T: Numeric> Div<T> for Vector<N, T> {
+    type Output = Self;
+
+    #[inline]
+    fn div(self, scalar: T) -> Self {
+        self.scale(T::ONE / scalar)
     }
 }
 

--- a/crates/multicalc/src/linear_algebra/vector.rs
+++ b/crates/multicalc/src/linear_algebra/vector.rs
@@ -298,29 +298,30 @@ impl<const N: usize, T: Numeric> Vector<N, T> {
     }
 
     /// Attempt to normalize the vector in-place (i.e. after this operation the norm is equal to 1).
-    /// This method returns an error and leaves the vector unchanged if the norm is zero or NAN.
+    /// This method returns `None` and leaves the vector unchanged if the norm is zero or NAN.
     ///
     /// ```
     /// use multicalc::linear_algebra::Vector;
     /// let mut v = Vector::new([30.0, 40.0]);
-    /// assert!(v.try_normalize().is_ok());
+    /// assert!(v.try_normalize().is_some());
     /// assert_eq!(v, Vector::new([0.6, 0.8]));
     ///
     /// let mut v = Vector::new([0.0, 0.0]);
-    /// assert!(v.try_normalize().is_err());
+    /// assert!(v.try_normalize().is_none());
     /// assert_eq!(v, Vector::new([0.0, 0.0]));
     ///
     /// let mut v = Vector::new([f64::NAN, 1.0]);
-    /// assert!(v.try_normalize().is_err());
+    /// assert!(v.try_normalize().is_none());
     /// ```
     #[inline]
-    pub fn try_normalize(&mut self) -> Result<(), &'static str> {
+    #[must_use]
+    pub fn try_normalize(&mut self) -> Option<()> {
         let norm = self.norm();
         if norm.is_nan() || norm == T::ZERO {
-            return Err("Failed to normalize vector");
+            return None;
         }
         self.do_normalize(norm);
-        Ok(())
+        Some(())
     }
 
     fn do_normalize(&mut self, norm: T) {

--- a/crates/multicalc/src/linear_algebra/vector.rs
+++ b/crates/multicalc/src/linear_algebra/vector.rs
@@ -134,6 +134,22 @@ impl<const N: usize, T> Vector<N, T> {
     pub fn into_array(self) -> [T; N] {
         self.data
     }
+
+    /// Construct a new vector by applying a function to each component.
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::Vector;
+    /// let v = Vector::new([1.0, 2.0, 3.0]);
+    /// let u = v.map(|x| 2.0 * x);
+    /// assert_eq!(u, Vector::new([2.0, 4.0, 6.0]));
+    /// ```
+    #[inline]
+    pub fn map<F, U>(self, f: F) -> Vector<N, U>
+    where
+        F: Fn(T) -> U,
+    {
+        Vector::new(self.data.map(f))
+    }
 }
 
 impl<const N: usize, T: Copy> Vector<N, T> {

--- a/crates/multicalc/src/linear_algebra/vector.rs
+++ b/crates/multicalc/src/linear_algebra/vector.rs
@@ -236,6 +236,33 @@ impl<const N: usize, T: Numeric> Vector<N, T> {
     pub fn is_finite(self) -> bool {
         self.data.iter().all(|x| x.is_finite())
     }
+
+    /// Returns a normalized copy of the vector (i.e. one where the norm is equal to 1).
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::Vector;
+    /// assert_eq!(Vector::new([30.0, 40.0]).normalized(), Vector::new([0.6, 0.8]));
+    /// ```
+    #[inline]
+    pub fn normalized(self) -> Self {
+        self / self.norm()
+    }
+
+    /// Normalize the vector in-place (i.e. after this operation the norm is equal to 1).
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::Vector;
+    /// let mut v = Vector::new([30.0, 40.0]);
+    /// v.normalize();
+    /// assert_eq!(v, Vector::new([0.6, 0.8]));
+    /// ```
+    #[inline]
+    pub fn normalize(&mut self) {
+        let norm = self.norm();
+        for x in self.data.iter_mut() {
+            *x /= norm;
+        }
+    }
 }
 
 impl<const N: usize, T> From<[T; N]> for Vector<N, T> {

--- a/crates/multicalc/src/linear_algebra/vector.rs
+++ b/crates/multicalc/src/linear_algebra/vector.rs
@@ -276,7 +276,7 @@ impl<const N: usize, T: Numeric> Vector<N, T> {
     pub fn normalize(&mut self) {
         let norm = self.norm();
         for x in self.data.iter_mut() {
-            *x /= norm;
+            *x = x.safe_div(norm);
         }
     }
 }
@@ -362,14 +362,12 @@ impl<const N: usize, T: Numeric> Mul<T> for Vector<N, T> {
     }
 }
 
-// Note: this implementation panics on division by zero if the underlying
-// implementation on `T` would panic.
 impl<const N: usize, T: Numeric> Div<T> for Vector<N, T> {
     type Output = Self;
 
     #[inline]
     fn div(self, scalar: T) -> Self {
-        self.scale(T::ONE / scalar)
+        Self::from_fn(|i| self.data[i].safe_div(scalar))
     }
 }
 

--- a/crates/multicalc/src/linear_algebra/vector.rs
+++ b/crates/multicalc/src/linear_algebra/vector.rs
@@ -264,6 +264,25 @@ impl<const N: usize, T: Numeric> Vector<N, T> {
         self / self.norm()
     }
 
+    /// Attempts to return a normalized copy of the vector (i.e. one where the norm is equal to 1),
+    /// returning `None` in the case of a zero vector or a vector with a `NAN` entry.
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::Vector;
+    /// assert_eq!(Vector::new([30.0, 40.0]).try_normalized(), Some(Vector::new([0.6, 0.8])));
+    /// assert_eq!(Vector::new([0.0, 0.0]).try_normalized(), None);
+    /// assert_eq!(Vector::new([f64::NAN, 0.0]).try_normalized(), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn try_normalized(self) -> Option<Self> {
+        let norm = self.norm();
+        if norm.is_nan() || norm == T::ZERO {
+            return None;
+        }
+        Some(self / norm)
+    }
+
     /// Normalize the vector in-place (i.e. after this operation the norm is equal to 1).
     ///
     /// ```
@@ -275,6 +294,36 @@ impl<const N: usize, T: Numeric> Vector<N, T> {
     #[inline]
     pub fn normalize(&mut self) {
         let norm = self.norm();
+        self.do_normalize(norm);
+    }
+
+    /// Attempt to normalize the vector in-place (i.e. after this operation the norm is equal to 1).
+    /// This method returns an error and leaves the vector unchanged if the norm is zero or NAN.
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::Vector;
+    /// let mut v = Vector::new([30.0, 40.0]);
+    /// assert!(v.try_normalize().is_ok());
+    /// assert_eq!(v, Vector::new([0.6, 0.8]));
+    ///
+    /// let mut v = Vector::new([0.0, 0.0]);
+    /// assert!(v.try_normalize().is_err());
+    /// assert_eq!(v, Vector::new([0.0, 0.0]));
+    ///
+    /// let mut v = Vector::new([f64::NAN, 1.0]);
+    /// assert!(v.try_normalize().is_err());
+    /// ```
+    #[inline]
+    pub fn try_normalize(&mut self) -> Result<(), &'static str> {
+        let norm = self.norm();
+        if norm.is_nan() || norm == T::ZERO {
+            return Err("Failed to normalize vector");
+        }
+        self.do_normalize(norm);
+        Ok(())
+    }
+
+    fn do_normalize(&mut self, norm: T) {
         for x in self.data.iter_mut() {
             *x = x.safe_div(norm);
         }

--- a/crates/multicalc/src/scalar/numeric.rs
+++ b/crates/multicalc/src/scalar/numeric.rs
@@ -175,7 +175,7 @@ pub trait Numeric:
     /// Hyperbolic tangent.
     #[inline]
     fn tanh(self) -> Self {
-        self.sinh() / self.cosh()
+        self.sinh().safe_div(self.cosh())
     }
 
     /// Euclidean distance `√(self² + other²)`, scaled to avoid overflow and underflow.
@@ -208,7 +208,7 @@ pub trait Numeric:
     /// The reciprocal `1 / self`.
     #[inline]
     fn recip(self) -> Self {
-        Self::ONE / self
+        Self::ONE.safe_div(self)
     }
 
     /// `self` raised to an integer power, by exponentiation-by-squaring.
@@ -233,6 +233,32 @@ pub trait Numeric:
         }
 
         if n < 0 { Self::ONE / acc } else { acc }
+    }
+
+    /// Division with a zero check to prevent possible panics.
+    /// The behavior is meant to match the floating point standard.
+    /// I.e. this has the following rules:
+    /// (finite positive) / zero = INFINITY
+    /// (finite negative) / zero = NEG_INFINITY
+    /// INFINITY / zero = INFINITY
+    /// NEG_INFINITY / zero = NEG_INFINITY
+    /// zero / zero = NAN
+    /// NAN / zero = NAN
+    #[inline]
+    fn safe_div(self, other: Self) -> Self {
+        if other == Self::ZERO {
+            if self.is_nan() {
+                return Self::NAN;
+            } else if self < Self::ZERO {
+                return Self::NEG_INFINITY;
+            } else if Self::ZERO < self {
+                return Self::INFINITY;
+            } else {
+                return Self::NAN;
+            }
+        }
+
+        self / other
     }
 
     /// Returns `true` if `self` is NaN.

--- a/crates/multicalc/tests/suite/linear_algebra/matrix.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/matrix.rs
@@ -1,7 +1,6 @@
 use multicalc::error::LinalgError;
 use multicalc::linear_algebra::{Matrix, Vector};
-use multicalc_testkit::tol::{Tol, assert_scalar_close};
-use multicalc_testkit::tol::{assert_identity, assert_matrix_close};
+use multicalc_testkit::tol::{Tol, assert_identity, assert_matrix_close, assert_scalar_close};
 use proptest::prelude::*;
 
 // A strategy for producing matrices in property-based tests.

--- a/crates/multicalc/tests/suite/linear_algebra/matrix.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/matrix.rs
@@ -32,6 +32,29 @@ fn matrix_arithmetic() {
     assert_eq!(accumulated, left + right);
     accumulated -= right;
     assert_eq!(accumulated, left);
+
+    // Check division by zero behavior
+    let a = Matrix::new([
+        [1.0, -1.0, 0.0],
+        [f64::INFINITY, f64::NEG_INFINITY, f64::NAN],
+    ]);
+    let div_zero = a / 0.0;
+    let expected = Matrix::new([
+        [f64::INFINITY, f64::NEG_INFINITY, f64::NAN],
+        [f64::INFINITY, f64::NEG_INFINITY, f64::NAN],
+    ]);
+    div_zero
+        .into_array()
+        .into_iter()
+        .flatten()
+        .zip(expected.into_array().into_iter().flatten())
+        .for_each(|(got, want)| {
+            assert_eq!(
+                got.total_cmp(&want),
+                core::cmp::Ordering::Equal,
+                "{got} != {want}"
+            );
+        })
 }
 
 #[test]

--- a/crates/multicalc/tests/suite/linear_algebra/matrix.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/matrix.rs
@@ -153,6 +153,8 @@ fn check_matrix_from_diagonal<const N: usize>(diag: [f64; N]) {
             }
         }
     }
+    let extracted_diagonal = m.diagonal();
+    assert_eq!(extracted_diagonal, diag);
 }
 
 proptest! {

--- a/crates/multicalc/tests/suite/linear_algebra/matrix.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/matrix.rs
@@ -1,6 +1,18 @@
 use multicalc::error::LinalgError;
 use multicalc::linear_algebra::{Matrix, Vector};
 use multicalc_testkit::tol::{assert_identity, assert_matrix_close};
+use proptest::prelude::*;
+
+// A strategy for producing matrices in property-based tests.
+fn matrix_strategy<const ROWS: usize, const COLS: usize, S>(
+    num_strategy: S,
+) -> impl Strategy<Value = Matrix<ROWS, COLS>>
+where
+    S: Strategy<Value = f64>,
+{
+    prop::array::uniform::<_, ROWS>(prop::array::uniform::<_, COLS>(num_strategy))
+        .prop_map(Matrix::new)
+}
 
 // ----- matrix arithmetic, multiply, transpose -----
 
@@ -70,6 +82,47 @@ fn matrix_transpose() {
         (left * right).transpose(),
         right.transpose() * left.transpose()
     );
+}
+
+fn check_matrix_is_finite<const ROWS: usize, const COLS: usize>(m: Matrix<ROWS, COLS>) {
+    assert_eq!(
+        m.is_finite(),
+        m.into_array().iter().flatten().all(|x| x.is_finite())
+    );
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn matrix_is_finite_1x1(m in matrix_strategy::<1, 1, _>(prop::num::f64::ANY)) {
+        check_matrix_is_finite(m);
+    }
+
+    #[test]
+    fn matrix_is_finite_2x2(m in matrix_strategy::<2, 2, _>(prop::num::f64::ANY)) {
+        check_matrix_is_finite(m);
+    }
+
+    #[test]
+    fn matrix_is_finite_3x3(m in matrix_strategy::<3, 3, _>(prop::num::f64::ANY)) {
+        check_matrix_is_finite(m);
+    }
+
+    #[test]
+    fn matrix_is_finite_4x3(m in matrix_strategy::<4, 3, _>(prop::num::f64::ANY)) {
+        check_matrix_is_finite(m);
+    }
+
+    #[test]
+    fn matrix_is_finite_3x4(m in matrix_strategy::<3, 4, _>(prop::num::f64::ANY)) {
+        check_matrix_is_finite(m);
+    }
+
+    #[test]
+    fn matrix_is_finite_4x4(m in matrix_strategy::<4, 4, _>(prop::num::f64::ANY)) {
+        check_matrix_is_finite(m);
+    }
 }
 
 // ----- determinant & inverse (specialized) -----

--- a/crates/multicalc/tests/suite/linear_algebra/matrix.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/matrix.rs
@@ -120,13 +120,7 @@ fn check_matrix_is_finite<const ROWS: usize, const COLS: usize>(m: Matrix<ROWS, 
 fn check_matrix_frobenius_norm<const ROWS: usize, const COLS: usize>(m: Matrix<ROWS, COLS>) {
     let norm = m.frobenius_norm();
     let alt_def = (m * m.transpose()).trace().sqrt();
-    assert_eq!(
-        norm.is_finite(),
-        alt_def.is_finite(),
-        "{} != {}",
-        norm,
-        alt_def
-    );
+    assert_eq!(norm.is_finite(), alt_def.is_finite(), "{norm} != {alt_def}");
     if norm.is_finite() {
         assert_scalar_close(
             norm,
@@ -139,8 +133,26 @@ fn check_matrix_frobenius_norm<const ROWS: usize, const COLS: usize>(m: Matrix<R
     }
 }
 
-fn check_matrix_trace<const N: usize>(m: Matrix<N, N>) {
-    assert_eq!(m.trace(), (0..N).fold(0.0, |acc, i| acc + m[(i, i)]));
+fn check_matrix_trace<const N: usize>(a: Matrix<N, N>, b: Matrix<N, N>) {
+    // Property: `tr(I)=N`
+    let id: Matrix<N, N> = Matrix::identity();
+    assert_eq!(id.trace(), N as f64);
+
+    // Property: `tr(AB)=tr(BA)`
+    let ab = (a * b).trace();
+    let ba = (b * a).trace();
+
+    assert_eq!(ab.is_finite(), ba.is_finite(), "{ab} != {ba}");
+    if ab.is_finite() {
+        assert_scalar_close(
+            ab,
+            ba,
+            Tol {
+                abs: 0.0,
+                rel: 1e-8,
+            },
+        );
+    }
 }
 
 fn check_matrix_from_diagonal<const N: usize>(diag: [f64; N]) {
@@ -223,23 +235,36 @@ proptest! {
     // Note: using `prop::num::f64::NORMAL` as opposed to `prop::num::f64::ANY` because
     // if `NaN` or `Infinity` are involved then the equality check will fail (`NaN != NaN`).
     #[test]
-    fn matrix_trace_1x1(m in matrix_strategy::<1, 1, _>(prop::num::f64::NORMAL)) {
-        check_matrix_trace(m);
+    fn matrix_trace_1x1(
+        a in matrix_strategy::<1, 1, _>(prop::num::f64::NORMAL),
+        b in matrix_strategy::<1, 1, _>(prop::num::f64::NORMAL)
+    ) {
+        check_matrix_trace(a, b);
     }
 
     #[test]
-    fn matrix_trace_2x2(m in matrix_strategy::<2, 2, _>(prop::num::f64::NORMAL)) {
-        check_matrix_trace(m);
+    fn matrix_trace_2x2(
+        a in matrix_strategy::<2, 2, _>(prop::num::f64::NORMAL),
+        b in matrix_strategy::<2, 2, _>(prop::num::f64::NORMAL)
+    ) {
+        check_matrix_trace(a, b);
+
     }
 
     #[test]
-    fn matrix_trace_3x3(m in matrix_strategy::<3, 3, _>(prop::num::f64::NORMAL)) {
-        check_matrix_trace(m);
+    fn matrix_trace_3x3(
+        a in matrix_strategy::<3, 3, _>(prop::num::f64::NORMAL),
+        b in matrix_strategy::<3, 3, _>(prop::num::f64::NORMAL)
+    ) {
+        check_matrix_trace(a, b);
     }
 
     #[test]
-    fn matrix_trace_4x4(m in matrix_strategy::<4, 4, _>(prop::num::f64::NORMAL)) {
-        check_matrix_trace(m);
+    fn matrix_trace_4x4(
+        a in matrix_strategy::<4, 4, _>(prop::num::f64::NORMAL),
+        b in matrix_strategy::<4, 4, _>(prop::num::f64::NORMAL)
+    ) {
+        check_matrix_trace(a, b);
     }
 
     #[test]

--- a/crates/multicalc/tests/suite/linear_algebra/matrix.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/matrix.rs
@@ -169,6 +169,29 @@ fn check_matrix_from_diagonal<const N: usize>(diag: [f64; N]) {
     assert_eq!(extracted_diagonal, diag);
 }
 
+fn check_matrix_symmetric_positive_definite<const N: usize>(
+    entries: &[f64],
+    x: Matrix<N, 1>,
+) -> Result<(), TestCaseError> {
+    prop_assume!(x.frobenius_norm() > <f64 as multicalc::Numeric>::EPSILON);
+
+    assert_eq!(entries.len(), N * N);
+    let m: Matrix<N, N> = Matrix::symmetric_positive_definite(entries);
+
+    // Check symmetric
+    for i in 0..N {
+        for j in 0..N {
+            assert_eq!(m[(i, j)], m[(j, i)]);
+        }
+    }
+
+    // Check positive definite
+    let a = x.transpose() * (m * x);
+    assert!(a[(0, 0)] > 0.0);
+
+    Ok(())
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(256))]
 
@@ -285,6 +308,30 @@ proptest! {
     #[test]
     fn matrix_from_diagonal_4x4(diag in prop::array::uniform4(prop::num::f64::NORMAL)) {
         check_matrix_from_diagonal(diag);
+    }
+
+    #[test]
+    fn matrix_symmetric_positive_definite_2x2(
+        entries in prop::collection::vec(prop::num::f64::NORMAL, 4),
+        x in matrix_strategy::<2, 1, _>(prop::num::f64::NORMAL),
+    ) {
+        check_matrix_symmetric_positive_definite(&entries, x)?;
+    }
+
+    #[test]
+    fn matrix_symmetric_positive_definite_3x3(
+        entries in prop::collection::vec(prop::num::f64::NORMAL, 9),
+        x in matrix_strategy::<3, 1, _>(prop::num::f64::NORMAL),
+    ) {
+        check_matrix_symmetric_positive_definite(&entries, x)?;
+    }
+
+    #[test]
+    fn matrix_symmetric_positive_definite_4x4(
+        entries in prop::collection::vec(prop::num::f64::NORMAL, 16),
+        x in matrix_strategy::<4, 1, _>(prop::num::f64::NORMAL),
+    ) {
+        check_matrix_symmetric_positive_definite(&entries, x)?;
     }
 }
 

--- a/crates/multicalc/tests/suite/linear_algebra/matrix.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/matrix.rs
@@ -120,6 +120,18 @@ fn check_matrix_trace<const N: usize>(m: Matrix<N, N>) {
     assert_eq!(m.trace(), (0..N).fold(0.0, |acc, i| acc + m[(i, i)]));
 }
 
+fn check_matrix_from_diagonal<const N: usize>(diag: [f64; N]) {
+    let m = Matrix::from_diagonal(diag);
+    for i in 0..N {
+        assert_eq!(m[(i, i)], diag[i]);
+        for j in 0..N {
+            if i != j {
+                assert_eq!(m[(i, j)], 0.0);
+            }
+        }
+    }
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(256))]
 
@@ -203,6 +215,26 @@ proptest! {
     #[test]
     fn matrix_trace_4x4(m in matrix_strategy::<4, 4, _>(prop::num::f64::NORMAL)) {
         check_matrix_trace(m);
+    }
+
+    #[test]
+    fn matrix_from_diagonal_1x1(diag in prop::array::uniform1(prop::num::f64::NORMAL)) {
+        check_matrix_from_diagonal(diag);
+    }
+
+    #[test]
+    fn matrix_from_diagonal_2x2(diag in prop::array::uniform2(prop::num::f64::NORMAL)) {
+        check_matrix_from_diagonal(diag);
+    }
+
+    #[test]
+    fn matrix_from_diagonal_3x3(diag in prop::array::uniform3(prop::num::f64::NORMAL)) {
+        check_matrix_from_diagonal(diag);
+    }
+
+    #[test]
+    fn matrix_from_diagonal_4x4(diag in prop::array::uniform4(prop::num::f64::NORMAL)) {
+        check_matrix_from_diagonal(diag);
     }
 }
 

--- a/crates/multicalc/tests/suite/linear_algebra/matrix.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/matrix.rs
@@ -91,6 +91,10 @@ fn check_matrix_is_finite<const ROWS: usize, const COLS: usize>(m: Matrix<ROWS, 
     );
 }
 
+fn check_matrix_trace<const N: usize>(m: Matrix<N, N>) {
+    assert_eq!(m.trace(), (0..N).fold(0.0, |acc, i| acc + m[(i, i)]));
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(256))]
 
@@ -122,6 +126,28 @@ proptest! {
     #[test]
     fn matrix_is_finite_4x4(m in matrix_strategy::<4, 4, _>(prop::num::f64::ANY)) {
         check_matrix_is_finite(m);
+    }
+
+    // Note: using `prop::num::f64::NORMAL` as opposed to `prop::num::f64::ANY` because
+    // if `NaN` or `Infinity` are involved then the equality check will fail (`NaN != NaN`).
+    #[test]
+    fn matrix_trace_1x1(m in matrix_strategy::<1, 1, _>(prop::num::f64::NORMAL)) {
+        check_matrix_trace(m);
+    }
+
+    #[test]
+    fn matrix_trace_2x2(m in matrix_strategy::<2, 2, _>(prop::num::f64::NORMAL)) {
+        check_matrix_trace(m);
+    }
+
+    #[test]
+    fn matrix_trace_3x3(m in matrix_strategy::<3, 3, _>(prop::num::f64::NORMAL)) {
+        check_matrix_trace(m);
+    }
+
+    #[test]
+    fn matrix_trace_4x4(m in matrix_strategy::<4, 4, _>(prop::num::f64::NORMAL)) {
+        check_matrix_trace(m);
     }
 }
 

--- a/crates/multicalc/tests/suite/linear_algebra/matrix.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/matrix.rs
@@ -1,5 +1,6 @@
 use multicalc::error::LinalgError;
 use multicalc::linear_algebra::{Matrix, Vector};
+use multicalc_testkit::tol::{Tol, assert_scalar_close};
 use multicalc_testkit::tol::{assert_identity, assert_matrix_close};
 use proptest::prelude::*;
 
@@ -91,6 +92,30 @@ fn check_matrix_is_finite<const ROWS: usize, const COLS: usize>(m: Matrix<ROWS, 
     );
 }
 
+// Check the Frobenius norm implementation using the alternate definition
+// `||A||_F = sqrt(Tr(A * A^T))`.
+fn check_matrix_frobenius_norm<const ROWS: usize, const COLS: usize>(m: Matrix<ROWS, COLS>) {
+    let norm = m.frobenius_norm();
+    let alt_def = (m * m.transpose()).trace().sqrt();
+    assert_eq!(
+        norm.is_finite(),
+        alt_def.is_finite(),
+        "{} != {}",
+        norm,
+        alt_def
+    );
+    if norm.is_finite() {
+        assert_scalar_close(
+            norm,
+            alt_def,
+            Tol {
+                abs: 0.0,
+                rel: 1e-8,
+            },
+        );
+    }
+}
+
 fn check_matrix_trace<const N: usize>(m: Matrix<N, N>) {
     assert_eq!(m.trace(), (0..N).fold(0.0, |acc, i| acc + m[(i, i)]));
 }
@@ -126,6 +151,36 @@ proptest! {
     #[test]
     fn matrix_is_finite_4x4(m in matrix_strategy::<4, 4, _>(prop::num::f64::ANY)) {
         check_matrix_is_finite(m);
+    }
+
+    #[test]
+    fn matrix_frobenius_norm_1x1(m in matrix_strategy::<1, 1, _>(prop::num::f64::ANY)) {
+        check_matrix_frobenius_norm(m);
+    }
+
+    #[test]
+    fn matrix_frobenius_norm_2x2(m in matrix_strategy::<2, 2, _>(prop::num::f64::ANY)) {
+        check_matrix_frobenius_norm(m);
+    }
+
+    #[test]
+    fn matrix_frobenius_norm_3x3(m in matrix_strategy::<3, 3, _>(prop::num::f64::ANY)) {
+        check_matrix_frobenius_norm(m);
+    }
+
+    #[test]
+    fn matrix_frobenius_norm_4x3(m in matrix_strategy::<4, 3, _>(prop::num::f64::ANY)) {
+        check_matrix_frobenius_norm(m);
+    }
+
+    #[test]
+    fn matrix_frobenius_norm_3x4(m in matrix_strategy::<3, 4, _>(prop::num::f64::ANY)) {
+        check_matrix_frobenius_norm(m);
+    }
+
+    #[test]
+    fn matrix_frobenius_norm_4x4(m in matrix_strategy::<4, 4, _>(prop::num::f64::ANY)) {
+        check_matrix_frobenius_norm(m);
     }
 
     // Note: using `prop::num::f64::NORMAL` as opposed to `prop::num::f64::ANY` because

--- a/crates/multicalc/tests/suite/linear_algebra/matrix.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/matrix.rs
@@ -26,6 +26,7 @@ fn matrix_arithmetic() {
     assert_eq!(right - left, Matrix::new([[4.0, 4.0], [4.0, 4.0]]));
     assert_eq!(-left, Matrix::new([[-1.0, -2.0], [-3.0, -4.0]]));
     assert_eq!(left * 2.0, left.scale(2.0));
+    assert_eq!(left / 2.0, left.scale(0.5));
 
     let mut accumulated = left;
     accumulated += right;

--- a/crates/multicalc/tests/suite/linear_algebra/vector.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/vector.rs
@@ -143,6 +143,38 @@ fn vector_arithmetic() {
     assert_eq!(accumulated, left + right);
     accumulated -= right;
     assert_eq!(accumulated, left);
+
+    // Check division by zero behavior
+    let a = Vector::new([
+        1.0,
+        -1.0,
+        0.0,
+        -0.0,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+        f64::NAN,
+    ]);
+    let div_zero = a / 0.0;
+    let expected = Vector::new([
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+        f64::NAN,
+        f64::NAN,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+        f64::NAN,
+    ]);
+    div_zero
+        .into_array()
+        .into_iter()
+        .zip(expected.as_array())
+        .for_each(|(got, want)| {
+            assert_eq!(
+                got.total_cmp(want),
+                core::cmp::Ordering::Equal,
+                "{got} != {want}"
+            );
+        })
 }
 
 #[test]
@@ -190,6 +222,30 @@ fn check_vector_normalized<const N: usize>(mut v: Vector<N>) -> Result<(), TestC
     assert_scalar_close(v.norm(), 1.0, tol);
 
     Ok(())
+}
+
+#[test]
+fn zero_vector_normalize() {
+    // A vector with any finite non-zero entry (even EPSILON) can still be normalized
+    let mut near_zero = Vector::new([<f64 as multicalc::Numeric>::EPSILON, 0.0, 0.0]);
+    assert_eq!(near_zero.normalized(), Vector::new([1.0f64, 0.0, 0.0]));
+    near_zero.normalize();
+    assert_eq!(near_zero, Vector::new([1.0f64, 0.0, 0.0]));
+
+    // The zero vector will normalize to NAN
+    let mut zero = Vector::new([0.0f64, 0.0, 0.0]);
+    assert!(
+        zero.normalized()
+            .into_array()
+            .into_iter()
+            .all(|x| x.total_cmp(&f64::NAN).is_eq())
+    );
+    zero.normalize();
+    assert!(
+        zero.into_array()
+            .into_iter()
+            .all(|x| x.total_cmp(&f64::NAN).is_eq())
+    );
 }
 
 proptest! {

--- a/crates/multicalc/tests/suite/linear_algebra/vector.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/vector.rs
@@ -1,4 +1,15 @@
 use multicalc::linear_algebra::{Matrix, Vector};
+use multicalc_testkit::tol::{Tol, assert_scalar_close};
+use proptest::prelude::*;
+use proptest::test_runner::TestCaseError;
+
+// A strategy for producing vectors in property-based tests.
+fn vector_strategy<const N: usize, S>(num_strategy: S) -> impl Strategy<Value = Vector<N>>
+where
+    S: Strategy<Value = f64>,
+{
+    prop::array::uniform::<_, N>(num_strategy).prop_map(Vector::new)
+}
 
 // ----- construction & access -----
 
@@ -129,6 +140,48 @@ fn vector_is_finite() {
     assert!(!Vector::new([1.0, f64::NAN]).is_finite());
     assert!(!Vector::new([f64::INFINITY, 0.0]).is_finite());
     assert!(!Vector::new([0.0, f64::NEG_INFINITY]).is_finite());
+}
+
+fn check_vector_normalized<const N: usize>(mut v: Vector<N>) -> Result<(), TestCaseError> {
+    prop_assume!(v.norm().is_finite());
+    prop_assume!(v.norm() > 1e-16);
+
+    let tol = Tol {
+        abs: 0.0,
+        rel: 1e-8,
+    };
+
+    let normalized = v.normalized();
+    assert_scalar_close(normalized.norm(), 1.0, tol);
+
+    v.normalize();
+    assert_scalar_close(v.norm(), 1.0, tol);
+
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn vector_normalize_1(v in vector_strategy::<1, _>(prop::num::f64::NORMAL)) {
+        check_vector_normalized(v)?;
+    }
+
+    #[test]
+    fn vector_normalize_2(v in vector_strategy::<2, _>(prop::num::f64::NORMAL)) {
+        check_vector_normalized(v)?;
+    }
+
+    #[test]
+    fn vector_normalize_3(v in vector_strategy::<3, _>(prop::num::f64::NORMAL)) {
+        check_vector_normalized(v)?;
+    }
+
+    #[test]
+    fn vector_normalize_4(v in vector_strategy::<4, _>(prop::num::f64::NORMAL)) {
+        check_vector_normalized(v)?;
+    }
 }
 
 // ----- cross products & scalar triple -----

--- a/crates/multicalc/tests/suite/linear_algebra/vector.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/vector.rs
@@ -231,7 +231,7 @@ fn check_vector_normalized<const N: usize>(mut v: Vector<N>) -> Result<(), TestC
     assert_eq!(v, normalized);
 
     // Fallible in-place normalization also agrees;
-    assert!(v_copy.try_normalize().is_ok());
+    assert!(v_copy.try_normalize().is_some());
     assert_eq!(v_copy, normalized);
 
     Ok(())
@@ -249,7 +249,7 @@ fn zero_vector_normalize() {
 
     // Fallible normalization rejects the zero vector
     assert_eq!(zero.try_normalized(), None);
-    assert!(zero.try_normalize().is_err());
+    assert!(zero.try_normalize().is_none());
     assert_eq!(zero, Vector::new([0.0f64, 0.0, 0.0]));
 
     // The zero vector will normalize to NAN via the unchecked functions

--- a/crates/multicalc/tests/suite/linear_algebra/vector.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/vector.rs
@@ -218,8 +218,19 @@ fn check_vector_normalized<const N: usize>(mut v: Vector<N>) -> Result<(), TestC
     let normalized = v.normalized();
     assert_scalar_close(normalized.norm(), 1.0, tol);
 
+    // The normalized and try_normalized operations are identical when normalization is possible.
+    assert_eq!(Some(normalized), v.try_normalized());
+
+    // Create a copy of the vector to test both mutable operations.
+    let mut v_copy = v;
+
+    // In-place normalization gives the same result as returning a copy.
     v.normalize();
-    assert_scalar_close(v.norm(), 1.0, tol);
+    assert_eq!(v, normalized);
+
+    // Fallible in-place normalization also agrees;
+    assert!(v_copy.try_normalize().is_ok());
+    assert_eq!(v_copy, normalized);
 
     Ok(())
 }
@@ -232,8 +243,14 @@ fn zero_vector_normalize() {
     near_zero.normalize();
     assert_eq!(near_zero, Vector::new([1.0f64, 0.0, 0.0]));
 
-    // The zero vector will normalize to NAN
     let mut zero = Vector::new([0.0f64, 0.0, 0.0]);
+
+    // Fallible normalization rejects the zero vector
+    assert_eq!(zero.try_normalized(), None);
+    assert!(zero.try_normalize().is_err());
+    assert_eq!(zero, Vector::new([0.0f64, 0.0, 0.0]));
+
+    // The zero vector will normalize to NAN via the unchecked functions
     assert!(
         zero.normalized()
             .into_array()

--- a/crates/multicalc/tests/suite/linear_algebra/vector.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/vector.rs
@@ -1,3 +1,4 @@
+use core::f64::consts::{E, PI};
 use multicalc::linear_algebra::{Matrix, Vector};
 use multicalc_testkit::tol::{Tol, assert_scalar_close};
 use proptest::prelude::*;
@@ -90,6 +91,37 @@ fn get_checked_access() {
 
     matrix.as_mut_slice_rows()[1][1] = 8.0;
     assert_eq!(matrix.get(1, 1), Some(&8.0));
+}
+
+fn check_vector_map<const N: usize, F: Fn(f64) -> f64>(v: Vector<N>, f: F) {
+    let u = v.map(&f);
+    for (a, b) in u.as_slice().iter().zip(v.as_slice()) {
+        assert_eq!(*a, f(*b));
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn vector_map_1(v in vector_strategy::<1, _>(prop::num::f64::NORMAL)) {
+        check_vector_map(v, |x| x + PI);
+    }
+
+    #[test]
+    fn vector_map_2(v in vector_strategy::<2, _>(prop::num::f64::NORMAL)) {
+        check_vector_map(v, |x| 2.0 * x);
+    }
+
+    #[test]
+    fn vector_map_3(v in vector_strategy::<3, _>(prop::num::f64::NORMAL)) {
+        check_vector_map(v, |x| x - E);
+    }
+
+    #[test]
+    fn vector_map_4(v in vector_strategy::<4, _>(prop::num::f64::NORMAL)) {
+        check_vector_map(v, |x| x * x);
+    }
 }
 
 // ----- vector arithmetic -----

--- a/crates/multicalc/tests/suite/linear_algebra/vector.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/vector.rs
@@ -93,6 +93,7 @@ fn vector_arithmetic() {
     assert_eq!(-left, Vector::new([-1.0, -2.0, -3.0]));
     assert_eq!(left * 2.0, left.scale(2.0));
     assert_eq!(left.scale(2.0), Vector::new([2.0, 4.0, 6.0]));
+    assert_eq!(left / 2.0, left.scale(0.5));
 
     let mut accumulated = left;
     accumulated += right;

--- a/crates/multicalc/tests/suite/linear_algebra/vector.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/vector.rs
@@ -1,6 +1,6 @@
 use core::f64::consts::{E, PI};
 use multicalc::linear_algebra::{Matrix, Vector};
-use multicalc_testkit::tol::{Tol, assert_scalar_close};
+use multicalc_testkit::tol::{Tol, assert_scalar_close, assert_vector_close};
 use proptest::prelude::*;
 use proptest::test_runner::TestCaseError;
 
@@ -207,16 +207,18 @@ fn vector_is_finite() {
 }
 
 fn check_vector_normalized<const N: usize>(mut v: Vector<N>) -> Result<(), TestCaseError> {
-    prop_assume!(v.norm().is_finite());
-    prop_assume!(v.norm() > 1e-16);
+    let norm = v.norm();
+    prop_assume!(norm.is_finite());
+    prop_assume!(norm > 1e-16);
 
     let tol = Tol {
-        abs: 0.0,
+        abs: <f64 as multicalc::Numeric>::EPSILON_X30,
         rel: 1e-8,
     };
 
     let normalized = v.normalized();
     assert_scalar_close(normalized.norm(), 1.0, tol);
+    assert_vector_close(&v, &normalized.scale(norm), tol);
 
     // The normalized and try_normalized operations are identical when normalization is possible.
     assert_eq!(Some(normalized), v.try_normalized());

--- a/tools/testkit/src/tol.rs
+++ b/tools/testkit/src/tol.rs
@@ -20,6 +20,11 @@ pub fn close(got: f64, want: f64, t: Tol) -> bool {
     (got - want).abs() <= t.abs + t.rel * got.abs().max(want.abs())
 }
 
+/// Asserts a scalar matches the expected value within `t`.
+pub fn assert_scalar_close(got: f64, want: f64, t: Tol) {
+    assert!(close(got, want, t), "got {got}, want {want}, tol {t:?}");
+}
+
 /// Asserts every component of a vector matches within `t`.
 pub fn assert_vector_close<const N: usize>(got: &Vector<N>, want: &Vector<N>, t: Tol) {
     for i in 0..N {


### PR DESCRIPTION
Closes #163 

New `Matrix` methods:

- Frobenius norm
- Trace
- from_diagonal
- Division by scalars

New `Vector` methods:

- map
- Normalize
- Division by scalars

Tests and documentation for all new methods.

@kmolan commented on the issue that other methods are likely useful. This PR seems large enough for now though. I propose adding other methods in a follow-up PR.

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
