### PR TITLE
polish docs, fix a nit on readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,4 +68,12 @@ Releases are automated from `main`:
 2. When that PR merges, the release workflow publishes to crates.io and creates a `vX.Y.Z` tag and GitHub release whose notes come from the matching changelog section.
 3. The `Cargo.toml` version and the top dated changelog heading must match; a bump with no changelog entry fails the release.
 
+Before step 1, build the docs the way docs.rs will and skim the result — docs.rs only rebuilds on a publish, so a broken page stays broken until the next release:
+
+```sh
+RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc -p multicalc --no-deps --all-features
+```
+
+The `--cfg docsrs` flag is nightly-only and turns on the "Available on crate feature `alloc` only" badges. Check that the `alloc`-gated items (`ParticleFilter`, `Jacobian::get_on_heap`) are present and badged.
+
 Thank you for all the contributions!

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Docs](https://docs.rs/multicalc/badge.svg)](https://docs.rs/multicalc)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**Math for real-time embedded systems, in `no_std` stable Rust with nero-zero dependencies: state
+**Scientific math for real-time embedded systems, in `no_std` stable Rust with near-zero dependencies: state
 estimation, control, kinematics, and Lie groups on a calculus, autodiff, and linear-algebra core in one integrated package.
 No heap, no panics, no `unsafe` - from a 64-bit server down to a bare-metal microcontroller.**
 

--- a/crates/multicalc/Cargo.toml
+++ b/crates/multicalc/Cargo.toml
@@ -26,3 +26,7 @@ alloc = []
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/multicalc/README.md
+++ b/crates/multicalc/README.md
@@ -6,7 +6,7 @@
 [![Docs](https://docs.rs/multicalc/badge.svg)](https://docs.rs/multicalc)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
-**Math for real-time embedded systems, in `no_std` stable Rust with nero-zero dependencies: state
+**Scientific math for real-time embedded systems, in `no_std` stable Rust with near-zero dependencies: state
 estimation, control, kinematics, and Lie groups on a calculus, autodiff, and linear-algebra core in one integrated package.
 No heap, no panics, no `unsafe` - from a 64-bit server down to a bare-metal microcontroller.**
 
@@ -235,9 +235,8 @@ Refer to the [guide](https://github.com/kmolan/multicalc-rust/blob/main/crates/m
 
 ## Error handling
 
-Where a sensible default exists, a "safe" wrapper (such as `get_single` or `get_double`) returns
-the answer directly. Otherwise the call returns a `Result` whose error is the module family's own
-enum (`LinalgError`, `DiffError`, `IntegrateError`, `SolveError`, `KinematicsError`,
+Every fallible call returns a `Result` whose error is the module family's own enum
+(`LinalgError`, `DiffError`, `IntegrateError`, `SolveError`, `KinematicsError`,
 `EstimationError`, `ControlError`, or `MotionError`), each convertible into the `CalcError`
 umbrella. All variants are listed in
 [error.rs](https://github.com/kmolan/multicalc-rust/blob/main/crates/multicalc/src/error.rs).
@@ -266,6 +265,28 @@ with:
 cargo run -p multicalc-demos --example <name>
 ```
 
+## Feature flags
+
+- `alloc` (off by default): enables the heap-based methods for inputs too large for the stack.
+  See [Heap allocation](#heap-allocation).
+
+## Heap allocation
+
+The library allocates nothing by default: every type is fixed-size and lives on the stack. Turning
+on `alloc` pulls in `extern crate alloc` and unlocks exactly two things:
+
+- `estimation::ParticleFilter`, whose cloud of samples is sized at runtime and so cannot be a
+  fixed-size stack type.
+- `numerical_derivative::jacobian::Jacobian::get_on_heap`, which returns a `Vec<Vec<_>>` for
+  Jacobians too large to sit on the stack. The stack-allocated `get` is always available.
+
+Nothing else changes: `no_std`, `forbid(unsafe_code)`, and the no-panic rules hold either way, and
+the feature never pulls in `std`.
+
+## MSRV and edition
+
+Edition 2024, minimum supported Rust version **1.85**.
+
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/kmolan/multicalc-rust/blob/main/CONTRIBUTING.md).
@@ -280,28 +301,6 @@ Optimization* (chapters 4 and 10).
 ## License
 
 multicalc is licensed under the MIT license.
-
-### Feature flags
-
-- `alloc` (off by default): enables the heap-based methods for inputs too large for the stack.
-  See [Heap allocation](#heap-allocation).
-
-### Heap allocation
-
-The library allocates nothing by default: every type is fixed-size and lives on the stack. Turning
-on `alloc` pulls in `extern crate alloc` and unlocks exactly two things:
-
-- `estimation::ParticleFilter`, whose cloud of samples is sized at runtime and so cannot be a
-  fixed-size stack type.
-- `numerical_derivative::jacobian::Jacobian::get_on_heap`, which returns a `Vec<Vec<_>>` for
-  Jacobians too large to sit on the stack. The stack-allocated `get` is always available.
-
-Nothing else changes: `no_std`, `forbid(unsafe_code)`, and the no-panic rules hold either way, and
-the feature never pulls in `std`.
-
-### MSRV and edition
-
-Edition 2024, minimum supported Rust version **1.85**.
 
 ## Contact
 

--- a/crates/multicalc/src/estimation/mod.rs
+++ b/crates/multicalc/src/estimation/mod.rs
@@ -10,10 +10,12 @@ mod extended_kalman_filter;
 mod kalman_filter;
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 mod particle_filter;
 
 pub use extended_kalman_filter::ExtendedKalmanFilter;
 pub use kalman_filter::{CovarianceUpdate, KalmanFilter};
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use particle_filter::{GaussianLikelihood, Likelihood, ParticleFilter, ResamplingScheme};

--- a/crates/multicalc/src/lib.rs
+++ b/crates/multicalc/src/lib.rs
@@ -1,7 +1,9 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 extern crate alloc;
 
 /// Re-export of [`libm`], so `no_std` users can reach transcendental functions
@@ -50,6 +52,7 @@ pub use estimation::{ExtendedKalmanFilter, KalmanFilter};
 
 /// Particle filter (bootstrap/SIR) with pluggable resampling and measurement likelihood.
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use estimation::{GaussianLikelihood, Likelihood, ParticleFilter, ResamplingScheme};
 
 /// Seedable pseudo-random generator and the trait its uniform and normal draws come from.

--- a/crates/multicalc/src/numerical_derivative/jacobian.rs
+++ b/crates/multicalc/src/numerical_derivative/jacobian.rs
@@ -93,6 +93,7 @@ impl<D: DerivatorMultiVariable> Jacobian<D> {
     /// [`DiffError::EmptyFunctionSet`] if `function` has no outputs, or
     /// [`DiffError::StepSizeZero`] if the derivator's step size is zero.
     #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn get_on_heap<
         F: VectorFn<NUM_VARS, NUM_FUNCS>,
         const NUM_FUNCS: usize,


### PR DESCRIPTION
## What & why

Closes https://github.com/kmolan/multicalc-rust/issues/193

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
