### PR TITLE
prelude and convenience free functions

### DIFF
--- a/crates/multicalc/GUIDE.md
+++ b/crates/multicalc/GUIDE.md
@@ -768,8 +768,11 @@ state forward through a matrix model and grows the covariance by the process noi
 a measurement and shrinks it. Fixed-size, no allocation, and generic over the `Numeric` scalar, so a
 `Dual` state differentiates the whole filter.
 
-- `KalmanFilter<STATE_DIMENSION, MEASUREMENT_DIMENSION, T>`: built from an initial estimate and the
-  four model matrices — transition, measurement model, process noise, measurement noise.
+- `KalmanFilter<STATE_DIMENSION, MEASUREMENT_DIMENSION, T>`: built from an initial estimate and a
+  `KalmanModel`.
+- `KalmanModel<STATE_DIMENSION, MEASUREMENT_DIMENSION, T>`: the four matrices that describe what the
+  filter is tracking — transition, measurement model, process noise, measurement noise. Three of
+  them are the same shape, so naming each field is what stops a swapped pair compiling.
 - `predict` / `predict_with_control`: the time step, undriven or with a `control_model ·
   control_input` term. `CONTROL_DIMENSION` lives on the method, so undriven users never meet it.
 - `update`: the measurement step. The only fallible operation in the module.
@@ -779,17 +782,19 @@ a measurement and shrinks it. Fixed-size, no allocation, and generic over the `N
   changing timestep changes the model between steps.
 
 ```rust
-use multicalc::estimation::KalmanFilter;
+use multicalc::estimation::{KalmanFilter, KalmanModel};
 use multicalc::linear_algebra::{Matrix, Vector};
 
 // Constant velocity: position integrates velocity over a 1 s step; position is measured.
 let mut filter = KalmanFilter::new(
     Vector::new([0.0, 0.0]),                    // initial state [position, velocity]
     Matrix::new([[1.0, 0.0], [0.0, 1.0]]),      // initial covariance
-    Matrix::new([[1.0, 1.0], [0.0, 1.0]]),      // state transition
-    Matrix::new([[1.0, 0.0]]),                  // measurement model
-    Matrix::new([[0.01, 0.0], [0.0, 0.01]]),    // process noise
-    Matrix::new([[0.1]]),                       // measurement noise
+    KalmanModel {
+        state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
+        measurement_model: Matrix::new([[1.0, 0.0]]),   // position only
+        process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
+        measurement_noise: Matrix::new([[0.1]]),
+    },
 );
 
 filter.predict();

--- a/crates/multicalc/README.md
+++ b/crates/multicalc/README.md
@@ -173,17 +173,19 @@ re-linearizes them each step, with the Jacobians coming from autodiff, so a nonl
 hand-derived matrices:
 
 ```rust
-use multicalc::estimation::KalmanFilter;
+use multicalc::estimation::{KalmanFilter, KalmanModel};
 use multicalc::linear_algebra::{Matrix, Vector};
 
 // Constant velocity: position integrates velocity over a 1 s step, and only position is measured.
 let mut filter = KalmanFilter::new(
     Vector::new([0.0, 0.0]),                    // initial state [position, velocity]
     Matrix::new([[1.0, 0.0], [0.0, 1.0]]),      // initial covariance
-    Matrix::new([[1.0, 1.0], [0.0, 1.0]]),      // state transition
-    Matrix::new([[1.0, 0.0]]),                  // measurement model: position only
-    Matrix::new([[0.01, 0.0], [0.0, 0.01]]),    // process noise
-    Matrix::new([[0.1]]),                       // measurement noise
+    KalmanModel {
+        state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
+        measurement_model: Matrix::new([[1.0, 0.0]]),   // position only
+        process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
+        measurement_noise: Matrix::new([[0.1]]),
+    },
 );
 
 filter.predict();

--- a/crates/multicalc/src/approximation/linear_approximation.rs
+++ b/crates/multicalc/src/approximation/linear_approximation.rs
@@ -105,9 +105,23 @@ impl<D: DerivatorMultiVariable + Default> Default for LinearApproximator<D> {
     }
 }
 
+impl LinearApproximator<AutoDiffMulti> {
+    /// An approximator using exact autodiff derivatives.
+    ///
+    /// ```
+    /// use multicalc::approximation::linear_approximation::LinearApproximator;
+    ///
+    /// const APPROXIMATOR: LinearApproximator = LinearApproximator::new();
+    /// ```
+    #[inline]
+    pub const fn new() -> Self {
+        Self::from_derivator(AutoDiffMulti::new())
+    }
+}
+
 impl<D: DerivatorMultiVariable> LinearApproximator<D> {
     /// Builds an approximator from an explicit derivator.
-    pub fn from_derivator(derivator: D) -> Self {
+    pub const fn from_derivator(derivator: D) -> Self {
         LinearApproximator {
             derivator,
             summation: SummationMethod::Pairwise,

--- a/crates/multicalc/src/approximation/mod.rs
+++ b/crates/multicalc/src/approximation/mod.rs
@@ -10,6 +10,13 @@ pub use crate::utils::summation::SummationMethod;
 pub mod linear_approximation;
 pub mod quadratic_approximation;
 
+pub use linear_approximation::{
+    LinearApproximation, LinearApproximationPredictionMetrics, LinearApproximator,
+};
+pub use quadratic_approximation::{
+    QuadraticApproximation, QuadraticApproximationPredictionMetrics, QuadraticApproximator,
+};
+
 /// Goodness-of-fit metrics shared by the linear and quadratic approximators.
 ///
 /// Returns `(mae, mse, rmse, r_squared, adjusted_r_squared)`. `num_predictors` is the

--- a/crates/multicalc/src/approximation/quadratic_approximation.rs
+++ b/crates/multicalc/src/approximation/quadratic_approximation.rs
@@ -104,9 +104,23 @@ impl<D: DerivatorMultiVariable + Default> Default for QuadraticApproximator<D> {
     }
 }
 
+impl QuadraticApproximator<AutoDiffMulti> {
+    /// An approximator using exact autodiff derivatives.
+    ///
+    /// ```
+    /// use multicalc::approximation::quadratic_approximation::QuadraticApproximator;
+    ///
+    /// const APPROXIMATOR: QuadraticApproximator = QuadraticApproximator::new();
+    /// ```
+    #[inline]
+    pub const fn new() -> Self {
+        Self::from_derivator(AutoDiffMulti::new())
+    }
+}
+
 impl<D: DerivatorMultiVariable> QuadraticApproximator<D> {
     /// Builds an approximator from an explicit derivator.
-    pub fn from_derivator(derivator: D) -> Self {
+    pub const fn from_derivator(derivator: D) -> Self {
         QuadraticApproximator {
             derivator,
             summation: SummationMethod::Pairwise,

--- a/crates/multicalc/src/control/derivative_filter.rs
+++ b/crates/multicalc/src/control/derivative_filter.rs
@@ -26,7 +26,7 @@ use crate::scalar::Numeric;
 /// assert!((smoother.value() - 10.0).abs() < 1e-9);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct OnePoleLowPass<T: Numeric> {
+pub struct OnePoleLowPass<T: Numeric = f64> {
     smoothing: T,
     state: T,
     initialized: bool,

--- a/crates/multicalc/src/control/follow_the_gap.rs
+++ b/crates/multicalc/src/control/follow_the_gap.rs
@@ -25,7 +25,7 @@ use crate::scalar::Numeric;
 /// When nothing is wide enough, the result is a full stop with [`FollowTheGapOutput::is_blocked`] set — the
 /// follower never spins in place. What to do then, such as reversing, is left to the caller.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct FollowTheGap<const BEAMS: usize, T: Numeric> {
+pub struct FollowTheGap<const BEAMS: usize, T: Numeric = f64> {
     /// How wide an angle the scan covers, in radians.
     field_of_view: T,
     /// How far the sensor can see, in metres.
@@ -50,7 +50,7 @@ pub struct FollowTheGap<const BEAMS: usize, T: Numeric> {
 
 /// The result of one reactive step: the motion command plus context.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct FollowTheGapOutput<T: Numeric> {
+pub struct FollowTheGapOutput<T: Numeric = f64> {
     body_twist: BodyTwist<T>,
     heading: T,
     gap_start_index: usize,

--- a/crates/multicalc/src/control/pid.rs
+++ b/crates/multicalc/src/control/pid.rs
@@ -30,7 +30,7 @@ use crate::scalar::Numeric;
 /// assert!((measurement - setpoint).abs() < 1e-3);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Pid<T: Numeric> {
+pub struct Pid<T: Numeric = f64> {
     proportional_gain: T,
     integral_gain: T,
     derivative_gain: T,

--- a/crates/multicalc/src/control/pure_pursuit.rs
+++ b/crates/multicalc/src/control/pure_pursuit.rs
@@ -8,7 +8,7 @@ use crate::spatial::SE2;
 
 /// A path curvature, the reciprocal of the turning radius, in units of 1/m. Positive curves left.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Curvature<T: Numeric> {
+pub struct Curvature<T: Numeric = f64> {
     value: T,
 }
 

--- a/crates/multicalc/src/estimation/kalman_filter.rs
+++ b/crates/multicalc/src/estimation/kalman_filter.rs
@@ -28,6 +28,33 @@ pub enum CovarianceUpdate {
     Naive,
 }
 
+/// The four matrices that describe what a linear Kalman filter is tracking.
+///
+/// # Examples
+/// ```
+/// use multicalc::estimation::KalmanModel;
+/// use multicalc::linear_algebra::Matrix;
+///
+/// // Constant velocity: position integrates velocity over a 1 s step; position is measured.
+/// let model = KalmanModel {
+///     state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
+///     measurement_model: Matrix::new([[1.0, 0.0]]),
+///     process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
+///     measurement_noise: Matrix::new([[0.1]]),
+/// };
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct KalmanModel<const STATE_DIMENSION: usize, const MEASUREMENT_DIMENSION: usize, T = f64> {
+    /// How the state moves forward one step on its own.
+    pub state_transition: Matrix<STATE_DIMENSION, STATE_DIMENSION, T>,
+    /// How a measurement is produced from the state.
+    pub measurement_model: Matrix<MEASUREMENT_DIMENSION, STATE_DIMENSION, T>,
+    /// How much uncertainty each step adds.
+    pub process_noise: Matrix<STATE_DIMENSION, STATE_DIMENSION, T>,
+    /// How noisy the measurements are.
+    pub measurement_noise: Matrix<MEASUREMENT_DIMENSION, MEASUREMENT_DIMENSION, T>,
+}
+
 /// A linear Kalman filter over a `STATE_DIMENSION`-state model with `MEASUREMENT_DIMENSION`
 /// measurements.
 ///
@@ -49,17 +76,19 @@ pub enum CovarianceUpdate {
 ///
 /// # Examples
 /// ```
-/// use multicalc::estimation::KalmanFilter;
+/// use multicalc::estimation::{KalmanFilter, KalmanModel};
 /// use multicalc::linear_algebra::{Matrix, Vector};
 /// # fn main() -> Result<(), multicalc::error::EstimationError> {
 /// // Constant velocity: position integrates velocity over a 1 s step; position is measured.
 /// let mut filter = KalmanFilter::new(
-///     Vector::new([0.0, 0.0]),                        // initial state
-///     Matrix::new([[1.0, 0.0], [0.0, 1.0]]),          // initial covariance
-///     Matrix::new([[1.0, 1.0], [0.0, 1.0]]),          // state transition
-///     Matrix::new([[1.0, 0.0]]),                      // measurement model
-///     Matrix::new([[0.01, 0.0], [0.0, 0.01]]),        // process noise
-///     Matrix::new([[0.1]]),                           // measurement noise
+///     Vector::new([0.0, 0.0]),                // initial state
+///     Matrix::new([[1.0, 0.0], [0.0, 1.0]]),  // initial covariance
+///     KalmanModel {
+///         state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
+///         measurement_model: Matrix::new([[1.0, 0.0]]),
+///         process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
+///         measurement_noise: Matrix::new([[0.1]]),
+///     },
 /// );
 /// filter.predict();
 /// filter.update(Vector::new([1.0]))?;
@@ -83,17 +112,14 @@ pub struct KalmanFilter<const STATE_DIMENSION: usize, const MEASUREMENT_DIMENSIO
 impl<const STATE_DIMENSION: usize, const MEASUREMENT_DIMENSION: usize, T: Numeric>
     KalmanFilter<STATE_DIMENSION, MEASUREMENT_DIMENSION, T>
 {
-    /// Builds a filter from an initial estimate and the four model matrices.
+    /// Builds a filter from an initial estimate and the model it is tracking.
     ///
     /// The covariance update starts at [`Joseph`](CovarianceUpdate::Joseph); change it with
     /// [`with_covariance_update`](Self::with_covariance_update).
     pub fn new(
         initial_state: Vector<STATE_DIMENSION, T>,
         initial_covariance: Matrix<STATE_DIMENSION, STATE_DIMENSION, T>,
-        state_transition: Matrix<STATE_DIMENSION, STATE_DIMENSION, T>,
-        measurement_model: Matrix<MEASUREMENT_DIMENSION, STATE_DIMENSION, T>,
-        process_noise: Matrix<STATE_DIMENSION, STATE_DIMENSION, T>,
-        measurement_noise: Matrix<MEASUREMENT_DIMENSION, MEASUREMENT_DIMENSION, T>,
+        model: KalmanModel<STATE_DIMENSION, MEASUREMENT_DIMENSION, T>,
     ) -> Self {
         const {
             assert!(
@@ -110,10 +136,10 @@ impl<const STATE_DIMENSION: usize, const MEASUREMENT_DIMENSION: usize, T: Numeri
         KalmanFilter {
             state: initial_state,
             covariance: initial_covariance,
-            state_transition,
-            measurement_model,
-            process_noise,
-            measurement_noise,
+            state_transition: model.state_transition,
+            measurement_model: model.measurement_model,
+            process_noise: model.process_noise,
+            measurement_noise: model.measurement_noise,
             innovation: Vector::zeros(),
             innovation_covariance: Matrix::zeros(),
             covariance_update: CovarianceUpdate::Joseph,
@@ -123,16 +149,18 @@ impl<const STATE_DIMENSION: usize, const MEASUREMENT_DIMENSION: usize, T: Numeri
     /// Selects how [`update`](Self::update) recomputes the covariance.
     ///
     /// ```
-    /// use multicalc::estimation::{CovarianceUpdate, KalmanFilter};
+    /// use multicalc::estimation::{CovarianceUpdate, KalmanFilter, KalmanModel};
     /// use multicalc::linear_algebra::{Matrix, Vector};
     /// # fn main() -> Result<(), multicalc::error::EstimationError> {
     /// let mut filter = KalmanFilter::new(
     ///     Vector::new([0.0, 0.0]),
     ///     Matrix::new([[1.0, 0.0], [0.0, 1.0]]),
-    ///     Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
-    ///     Matrix::new([[1.0, 0.0]]),
-    ///     Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
-    ///     Matrix::new([[0.1]]),
+    ///     KalmanModel {
+    ///         state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
+    ///         measurement_model: Matrix::new([[1.0, 0.0]]),
+    ///         process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
+    ///         measurement_noise: Matrix::new([[0.1]]),
+    ///     },
     /// )
     /// .with_covariance_update(CovarianceUpdate::Naive);
     /// filter.predict();

--- a/crates/multicalc/src/estimation/mod.rs
+++ b/crates/multicalc/src/estimation/mod.rs
@@ -1,6 +1,6 @@
 //! State estimation from noisy measurements.
 //!
-//! - [`KalmanFilter`] — the linear filter, a single Gaussian belief.
+//! - [`KalmanFilter`] — the linear filter, a single Gaussian belief, over a [`KalmanModel`].
 //! - [`ExtendedKalmanFilter`] — nonlinear models, differentiated for their Jacobians each step.
 //! - [`ParticleFilter`] — a cloud of weighted samples, for non-Gaussian or multi-peaked beliefs
 //!   (`alloc` only).
@@ -14,7 +14,7 @@ mod kalman_filter;
 mod particle_filter;
 
 pub use extended_kalman_filter::ExtendedKalmanFilter;
-pub use kalman_filter::{CovarianceUpdate, KalmanFilter};
+pub use kalman_filter::{CovarianceUpdate, KalmanFilter, KalmanModel};
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]

--- a/crates/multicalc/src/kinematics/differential_drive.rs
+++ b/crates/multicalc/src/kinematics/differential_drive.rs
@@ -21,14 +21,14 @@ fn to_wheels<T: Numeric>(r: T, b: T, linear: T, angular: T) -> (T, T) {
 
 /// Wheel angular velocities [rad/s]. Positive drives the body forward.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct WheelVelocities<T: Numeric> {
+pub struct WheelVelocities<T: Numeric = f64> {
     left: T,
     right: T,
 }
 
 /// Wheel angular displacements over one tick `[rad]` — what an encoder reports.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct WheelRotations<T: Numeric> {
+pub struct WheelRotations<T: Numeric = f64> {
     left: T,
     right: T,
 }
@@ -38,7 +38,7 @@ pub struct WheelRotations<T: Numeric> {
 /// The se(2) twist restricted to two degrees of freedom. There is no lateral field: a
 /// differential-drive body cannot slide sideways.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct BodyTwist<T: Numeric> {
+pub struct BodyTwist<T: Numeric = f64> {
     linear: T,
     angular: T,
 }
@@ -48,7 +48,7 @@ pub struct BodyTwist<T: Numeric> {
 /// Arc length, not displacement — the straight-line distance covered is the chord, which is shorter
 /// whenever the heading changes. These are the exponential coordinates of the relative pose.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct BodyArc<T: Numeric> {
+pub struct BodyArc<T: Numeric = f64> {
     linear: T,
     angular: T,
 }
@@ -209,7 +209,7 @@ impl<T: Numeric> BodyArc<T> {
 /// `wheelbase` is the track width: the lateral distance between the two wheel contact points, not a
 /// front-to-rear axle distance.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct DifferentialDrive<T: Numeric> {
+pub struct DifferentialDrive<T: Numeric = f64> {
     wheel_radius: T,
     wheelbase: T,
 }

--- a/crates/multicalc/src/kinematics/unicycle.rs
+++ b/crates/multicalc/src/kinematics/unicycle.rs
@@ -18,7 +18,7 @@ use crate::scalar::Numeric;
 /// assert!((state[0] - 0.1).abs() < 1e-12);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Unicycle<T: Numeric> {
+pub struct Unicycle<T: Numeric = f64> {
     twist: BodyTwist<T>,
 }
 

--- a/crates/multicalc/src/lib.rs
+++ b/crates/multicalc/src/lib.rs
@@ -26,6 +26,36 @@ pub use scalar::Jet;
 /// finite differences and autodiff.
 pub use scalar::{ScalarFn, ScalarFnN, VectorFn};
 
+/// The plain scalar wrapper, and the marker for numeric constants inside a `scalar_fn!` body.
+pub use scalar::{Primal, c};
+
+/// Differentiation: the autodiff and finite-difference backends, their shared traits, and the
+/// derivative-matrix types.
+pub use numerical_derivative::{
+    AutoDiffMulti, AutoDiffSingle, DerivatorMultiVariable, DerivatorSingleVariable,
+    FiniteDifferenceConfig, FiniteDifferenceMode, FiniteDifferenceMulti, FiniteDifferenceSingle,
+    Hessian, Jacobian,
+};
+
+/// One-call derivatives, needing no imported trait and no configured backend.
+pub use numerical_derivative::{derivative, partial, second_derivative};
+
+/// Integration: the iterative and Gaussian-quadrature backends and their shared traits.
+pub use numerical_integration::{
+    GaussianConfig, GaussianMulti, GaussianQuadratureMethod, GaussianSingle,
+    IntegratorMultiVariable, IntegratorSingleVariable, IterativeConfig, IterativeMethod,
+    IterativeMulti, IterativeSingle, SummationMethod,
+};
+
+/// One-call integration over an interval, on the same terms.
+pub use numerical_integration::integral;
+
+/// Linear and quadratic Taylor models with goodness-of-fit metrics.
+pub use approximation::{
+    LinearApproximation, LinearApproximationPredictionMetrics, LinearApproximator,
+    QuadraticApproximation, QuadraticApproximationPredictionMetrics, QuadraticApproximator,
+};
+
 /// Fixed-size, stack-allocated vector and matrix types.
 pub use linear_algebra::{Matrix, Vector};
 
@@ -48,7 +78,7 @@ pub use spatial::{Twist, Wrench};
 pub use kinematics::{BodyArc, BodyTwist, DifferentialDrive, WheelRotations, WheelVelocities};
 
 /// Linear Kalman filter and Extended Kalman filter
-pub use estimation::{ExtendedKalmanFilter, KalmanFilter};
+pub use estimation::{CovarianceUpdate, ExtendedKalmanFilter, KalmanFilter, KalmanModel};
 
 /// Particle filter (bootstrap/SIR) with pluggable resampling and measurement likelihood.
 #[cfg(feature = "alloc")]
@@ -92,6 +122,7 @@ pub mod numerical_derivative;
 pub mod numerical_integration;
 pub mod ode;
 pub mod optimization;
+pub mod prelude;
 pub mod random;
 pub mod root_finding;
 pub mod scalar;

--- a/crates/multicalc/src/motion/polyline_path.rs
+++ b/crates/multicalc/src/motion/polyline_path.rs
@@ -16,7 +16,7 @@ pub enum EndOfPath {
 
 /// The result of projecting a query point onto a path.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct PathProjection<const DIMENSION: usize, T: Numeric> {
+pub struct PathProjection<const DIMENSION: usize, T: Numeric = f64> {
     point: Vector<DIMENSION, T>,
     segment_index: usize,
     arc_length: T,
@@ -76,7 +76,7 @@ impl<const DIMENSION: usize, T: Numeric> PathProjection<DIMENSION, T> {
 /// assert!((x - 2.0).abs() < 1e-12 && y.abs() < 1e-12);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct PolylinePath<const MAX_POINTS: usize, const DIMENSION: usize, T: Numeric> {
+pub struct PolylinePath<const MAX_POINTS: usize, const DIMENSION: usize, T: Numeric = f64> {
     points: [Vector<DIMENSION, T>; MAX_POINTS],
     length: usize,
     end_of_path: EndOfPath,

--- a/crates/multicalc/src/numerical_derivative/hessian.rs
+++ b/crates/multicalc/src/numerical_derivative/hessian.rs
@@ -19,10 +19,24 @@ impl<D: DerivatorMultiVariable + Default> Default for Hessian<D> {
     }
 }
 
+impl Hessian<AutoDiffMulti> {
+    /// A Hessian using exact autodiff derivatives.
+    ///
+    /// ```
+    /// use multicalc::numerical_derivative::hessian::Hessian;
+    ///
+    /// const H: Hessian = Hessian::new();
+    /// ```
+    #[inline]
+    pub const fn new() -> Self {
+        Self::from_derivator(AutoDiffMulti::new())
+    }
+}
+
 impl<D: DerivatorMultiVariable> Hessian<D> {
     /// Builds a Hessian from an explicit derivator. Use this to supply a custom derivator,
     /// either one from this crate or your own implementation of [`DerivatorMultiVariable`].
-    pub fn from_derivator(derivator: D) -> Self {
+    pub const fn from_derivator(derivator: D) -> Self {
         Hessian { derivator }
     }
 

--- a/crates/multicalc/src/numerical_derivative/jacobian.rs
+++ b/crates/multicalc/src/numerical_derivative/jacobian.rs
@@ -22,10 +22,24 @@ impl<D: DerivatorMultiVariable + Default> Default for Jacobian<D> {
     }
 }
 
+impl Jacobian<AutoDiffMulti> {
+    /// A Jacobian using exact autodiff derivatives.
+    ///
+    /// ```
+    /// use multicalc::numerical_derivative::jacobian::Jacobian;
+    ///
+    /// const J: Jacobian = Jacobian::new();
+    /// ```
+    #[inline]
+    pub const fn new() -> Self {
+        Self::from_derivator(AutoDiffMulti::new())
+    }
+}
+
 impl<D: DerivatorMultiVariable> Jacobian<D> {
     /// Builds a Jacobian from an explicit derivator. Use this to supply a custom derivator,
     /// either one from this crate or your own implementation of [`DerivatorMultiVariable`].
-    pub fn from_derivator(derivator: D) -> Self {
+    pub const fn from_derivator(derivator: D) -> Self {
         Jacobian { derivator }
     }
 

--- a/crates/multicalc/src/numerical_derivative/mod.rs
+++ b/crates/multicalc/src/numerical_derivative/mod.rs
@@ -1,5 +1,6 @@
 //! Differentiation: exact automatic differentiation and finite differences.
 //!
+//! - [`derivative`] / [`second_derivative`] / [`partial`] — the short way to take one derivative.
 //! - [`autodiff`] / [`finite_difference`] — the two [`derivator`] backends (autodiff is exact).
 //! - [`jacobian`] / [`hessian`] — derivative matrices of vector- and scalar-valued functions.
 
@@ -9,3 +10,80 @@ pub mod finite_difference;
 pub mod hessian;
 pub mod jacobian;
 pub mod mode;
+
+pub use autodiff::{AutoDiffMulti, AutoDiffSingle};
+pub use derivator::{DerivatorMultiVariable, DerivatorSingleVariable};
+pub use finite_difference::{
+    FiniteDifferenceConfig, FiniteDifferenceMulti, FiniteDifferenceSingle,
+};
+pub use hessian::Hessian;
+pub use jacobian::Jacobian;
+pub use mode::{DEFAULT_STEP_SIZE, DEFAULT_STEP_SIZE_MULTIPLIER, FiniteDifferenceMode};
+
+use crate::error::DiffError;
+use crate::scalar::{Dual, HyperDual, Numeric, ScalarFn, ScalarFnN};
+
+/// The derivative of a single-variable function at a point.
+///
+/// For a third or higher derivative, or to choose finite differences instead, 
+/// use [`AutoDiffSingle`] or [`FiniteDifferenceSingle`].
+///
+/// # Examples
+/// ```
+/// use multicalc::numerical_derivative::derivative;
+/// use multicalc::scalar_fn;
+///
+/// // f(x) = x^3, so f'(2) = 12
+/// let f = scalar_fn!(|x| x * x * x);
+/// assert!((derivative(&f, 2.0_f64) - 12.0).abs() < 1e-12);
+/// ```
+#[must_use]
+#[inline]
+pub fn derivative<T: Numeric, F: ScalarFn>(function: &F, point: T) -> T {
+    function.eval(Dual::variable(point)).deriv
+}
+
+/// The second derivative of a single-variable function at a point.
+///
+/// # Examples
+/// ```
+/// use multicalc::numerical_derivative::second_derivative;
+/// use multicalc::scalar_fn;
+///
+/// // f(x) = x^3, so f''(2) = 12; f32 works the same way
+/// let f = scalar_fn!(|x| x * x * x);
+/// assert!((second_derivative(&f, 2.0_f32) - 12.0).abs() < 1e-4);
+/// ```
+#[must_use]
+#[inline]
+pub fn second_derivative<T: Numeric, F: ScalarFn>(function: &F, point: T) -> T {
+    function.eval(HyperDual::variable(point)).eps1eps2
+}
+
+/// One partial derivative of a multi-variable function, picked by variable index.
+///
+/// For a mixed or higher-order partial, use [`AutoDiffMulti`].
+///
+/// # Errors
+/// [`DiffError::IndexOutOfRange`] if `variable_index` is not a variable of `function`. The index is
+/// an ordinary number rather than part of the type, so it is checked when the code runs.
+///
+/// # Examples
+/// ```
+/// use multicalc::numerical_derivative::partial;
+/// use multicalc::scalar_fn;
+/// # fn main() -> Result<(), multicalc::error::DiffError> {
+/// // g(x, y) = x^2 * y, so dg/dx at (3, 4) is 2xy = 24
+/// let g = scalar_fn!(|v: &[f64; 2]| v[0] * v[0] * v[1]);
+/// assert!((partial(&g, 0, &[3.0_f64, 4.0])? - 24.0).abs() < 1e-12);
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn partial<T: Numeric, F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize>(
+    function: &F,
+    variable_index: usize,
+    point: &[T; NUM_VARS],
+) -> Result<T, DiffError> {
+    AutoDiffMulti::<T>::new().get_single_partial(function, variable_index, point)
+}

--- a/crates/multicalc/src/numerical_derivative/mod.rs
+++ b/crates/multicalc/src/numerical_derivative/mod.rs
@@ -25,7 +25,7 @@ use crate::scalar::{Dual, HyperDual, Numeric, ScalarFn, ScalarFnN};
 
 /// The derivative of a single-variable function at a point.
 ///
-/// For a third or higher derivative, or to choose finite differences instead, 
+/// For a third or higher derivative, or to choose finite differences instead,
 /// use [`AutoDiffSingle`] or [`FiniteDifferenceSingle`].
 ///
 /// # Examples

--- a/crates/multicalc/src/numerical_integration/mod.rs
+++ b/crates/multicalc/src/numerical_integration/mod.rs
@@ -1,5 +1,6 @@
 //! Numerical integration.
 //!
+//! - [`integral`] — the short way to integrate one function over one interval.
 //! - [`gaussian_integration`] — Gaussian quadrature (nodes from
 //!   [`gaussian_tables`](crate::gaussian_tables)).
 //! - [`iterative_integration`] — iterative refinement of a running estimate.
@@ -11,3 +12,46 @@ pub mod iterative_integration;
 pub mod mode;
 
 pub use crate::utils::summation::SummationMethod;
+
+pub use gaussian_integration::{
+    DEFAULT_QUADRATURE_ORDERS, GaussianConfig, GaussianMulti, GaussianSingle,
+};
+pub use integrator::{IntegratorMultiVariable, IntegratorSingleVariable};
+pub use iterative_integration::{
+    DEFAULT_TOTAL_ITERATIONS, IterativeConfig, IterativeMulti, IterativeSingle,
+};
+pub use mode::{GaussianQuadratureMethod, IterativeMethod};
+
+use crate::error::IntegrateError;
+use crate::scalar::Numeric;
+
+/// The integral of a single-variable function over an interval.
+///
+/// This picks a method on your behalf: it walks the interval in [`DEFAULT_TOTAL_ITERATIONS`] steps
+/// using Boole's rule, which is the strongest all-round choice for a smooth integrand. Reach for
+/// [`IterativeSingle`] to change the rule or the step count, or [`GaussianSingle`] for quadrature.
+/// Either limit may be infinite.
+///
+/// # Errors
+/// [`IntegrateError::LimitsIllDefined`] if the limits are reversed, equal, `NaN`, or point the
+/// wrong way at an infinity, or [`IntegrateError::NonFinite`] if the integrand blows up on the way.
+///
+/// # Examples
+/// ```
+/// use multicalc::numerical_integration::integral;
+/// # fn main() -> Result<(), multicalc::error::IntegrateError> {
+/// // 2x over [0, 2] is 4
+/// assert!((integral(&|x: f64| 2.0 * x, [0.0, 2.0])? - 4.0).abs() < 1e-9);
+///
+/// // a decaying integrand may run to infinity: e^-x over [0, inf) is 1
+/// assert!((integral(&|x: f64| (-x).exp(), [0.0, f64::INFINITY])? - 1.0).abs() < 1e-6);
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn integral<T: Numeric, F: Fn(T) -> T>(
+    function: &F,
+    limits: [T; 2],
+) -> Result<T, IntegrateError> {
+    IterativeSingle::<T>::default().get_single(function, &limits)
+}

--- a/crates/multicalc/src/ode/rk45.rs
+++ b/crates/multicalc/src/ode/rk45.rs
@@ -7,7 +7,7 @@ use crate::scalar::Numeric;
 
 /// One accepted RK45 step, carrying the data for cubic-Hermite interpolation inside `[t0, t1]`.
 #[derive(Debug, Clone, Copy)]
-pub struct Step<const N: usize, T: Numeric> {
+pub struct Step<const N: usize, T: Numeric = f64> {
     /// Step start time.
     pub t0: T,
     /// Step end time.

--- a/crates/multicalc/src/optimization/gauss_newton.rs
+++ b/crates/multicalc/src/optimization/gauss_newton.rs
@@ -51,6 +51,20 @@ impl<D: DerivatorMultiVariable + Default> Default for GaussNewton<D> {
     }
 }
 
+impl GaussNewton<AutoDiffMulti> {
+    /// A solver using exact autodiff derivatives.
+    ///
+    /// ```
+    /// use multicalc::optimization::GaussNewton;
+    ///
+    /// const SOLVER: GaussNewton = GaussNewton::new();
+    /// ```
+    #[inline]
+    pub const fn new() -> Self {
+        Self::from_derivator(AutoDiffMulti::new())
+    }
+}
+
 impl<D: DerivatorMultiVariable> GaussNewton<D> {
     /// Builds a solver with a specific differentiation backend and default settings:
     /// tolerances of `30·EPSILON`, patience `100`, backtracking off.

--- a/crates/multicalc/src/optimization/levenberg_marquardt.rs
+++ b/crates/multicalc/src/optimization/levenberg_marquardt.rs
@@ -48,6 +48,20 @@ impl<D: DerivatorMultiVariable + Default> Default for LevenbergMarquardt<D> {
     }
 }
 
+impl LevenbergMarquardt<AutoDiffMulti> {
+    /// A solver using exact autodiff derivatives.
+    ///
+    /// ```
+    /// use multicalc::optimization::LevenbergMarquardt;
+    ///
+    /// const SOLVER: LevenbergMarquardt = LevenbergMarquardt::new();
+    /// ```
+    #[inline]
+    pub const fn new() -> Self {
+        Self::from_derivator(AutoDiffMulti::new())
+    }
+}
+
 impl<D: DerivatorMultiVariable> LevenbergMarquardt<D> {
     /// Builds a solver with a specific differentiation backend and default settings:
     /// tolerances of `30·EPSILON`, step bound `100`, patience `100`, column scaling on.

--- a/crates/multicalc/src/prelude.rs
+++ b/crates/multicalc/src/prelude.rs
@@ -1,0 +1,26 @@
+//! The traits and one-call functions worth importing together.
+//!
+//! Glob-import this, then name the types you need from the crate root:
+//!
+//! ```
+//! use multicalc::prelude::*;
+//! use multicalc::scalar_fn;
+//!
+//! // f(x) = x^2, so f'(3) = 6
+//! let square = scalar_fn!(|x| x * x);
+//! assert!((derivative(&square, 3.0_f64) - 6.0).abs() < 1e-12);
+//! ```
+//!
+//! Only traits and functions live here; types stay at the crate root, so there is one place to
+//! look for them. `SummationMethod` is the one name with two paths, since both
+//! `numerical_integration` and `approximation` take it as a parameter.
+
+pub use crate::error::CalcError;
+pub use crate::numerical_derivative::{
+    DerivatorMultiVariable, DerivatorSingleVariable, derivative, partial, second_derivative,
+};
+pub use crate::numerical_integration::{
+    IntegratorMultiVariable, IntegratorSingleVariable, integral,
+};
+pub use crate::random::RandomSource;
+pub use crate::scalar::{Numeric, Primal, ScalarFn, ScalarFnN, VectorFn};

--- a/crates/multicalc/src/root_finding/newton.rs
+++ b/crates/multicalc/src/root_finding/newton.rs
@@ -48,6 +48,20 @@ impl<D: DerivatorSingleVariable + Default> Default for Newton<D> {
     }
 }
 
+impl Newton<AutoDiffSingle> {
+    /// A solver using exact autodiff derivatives.
+    ///
+    /// ```
+    /// use multicalc::root_finding::Newton;
+    ///
+    /// const SOLVER: Newton = Newton::new();
+    /// ```
+    #[inline]
+    pub const fn new() -> Self {
+        Self::from_derivator(AutoDiffSingle::new())
+    }
+}
+
 impl<D: DerivatorSingleVariable> Newton<D> {
     /// Builds a solver with the given derivator and default settings:
     /// tolerances of `30 × EPSILON`, budget of 100 iterations, backtracking off.

--- a/crates/multicalc/src/root_finding/newton_system.rs
+++ b/crates/multicalc/src/root_finding/newton_system.rs
@@ -55,6 +55,20 @@ impl<D: DerivatorMultiVariable + Default> Default for NewtonSystem<D> {
     }
 }
 
+impl NewtonSystem<AutoDiffMulti> {
+    /// A solver using exact autodiff derivatives.
+    ///
+    /// ```
+    /// use multicalc::root_finding::NewtonSystem;
+    ///
+    /// const SOLVER: NewtonSystem = NewtonSystem::new();
+    /// ```
+    #[inline]
+    pub const fn new() -> Self {
+        Self::from_derivator(AutoDiffMulti::new())
+    }
+}
+
 impl<D: DerivatorMultiVariable> NewtonSystem<D> {
     /// Builds a solver with the given derivator and default settings:
     /// tolerances of `30 × EPSILON`, budget of 100 iterations, backtracking off.

--- a/crates/multicalc/src/scalar/dual.rs
+++ b/crates/multicalc/src/scalar/dual.rs
@@ -15,7 +15,7 @@ use crate::scalar::Numeric;
 /// The arithmetic and [`Numeric`] methods propagate the derivative by the chain rule, so
 /// `deriv` tracks the first derivative of whatever expression built the value.
 #[derive(Debug, Clone, Copy)]
-pub struct Dual<T: Numeric> {
+pub struct Dual<T: Numeric = f64> {
     /// The value, `f(x)`.
     pub value: T,
     /// The first derivative, `f'(x)`.

--- a/crates/multicalc/src/scalar/hyper_dual.rs
+++ b/crates/multicalc/src/scalar/hyper_dual.rs
@@ -17,7 +17,7 @@ use crate::scalar::Numeric;
 /// After evaluating a function, `real` holds the value, `eps1`/`eps2` hold the first
 /// derivatives along each seeded direction, and `eps1eps2` holds the second (mixed) derivative.
 #[derive(Debug, Clone, Copy)]
-pub struct HyperDual<T: Numeric> {
+pub struct HyperDual<T: Numeric = f64> {
     /// The value, `f`.
     pub real: T,
     /// First derivative along direction 1.

--- a/crates/multicalc/src/spatial/lie/se2.rs
+++ b/crates/multicalc/src/spatial/lie/se2.rs
@@ -10,7 +10,7 @@ use crate::spatial::small_angle_sq;
 /// A 2D rigid-body transform: a rotation and a translation. The tangent is `[vx, vy, ω]`.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[allow(clippy::upper_case_acronyms)]
-pub struct SE2<T: Numeric> {
+pub struct SE2<T: Numeric = f64> {
     rotation: SO2<T>,
     translation: Vector<2, T>,
 }

--- a/crates/multicalc/src/spatial/lie/se3.rs
+++ b/crates/multicalc/src/spatial/lie/se3.rs
@@ -12,7 +12,7 @@ use crate::spatial::lie::{
 /// A 3D rigid-body transform: a rotation and a translation. The tangent is `[vx, vy, vz, ωx, ωy, ωz]`.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[allow(clippy::upper_case_acronyms)]
-pub struct SE3<T: Numeric> {
+pub struct SE3<T: Numeric = f64> {
     rotation: SO3<T>,
     translation: Vector<3, T>,
 }

--- a/crates/multicalc/src/spatial/lie/so2.rs
+++ b/crates/multicalc/src/spatial/lie/so2.rs
@@ -9,7 +9,7 @@ use crate::scalar::Numeric;
 /// so it takes no trigonometry. The group is abelian; `exp`/`log` are exact and need no fallback.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[allow(clippy::upper_case_acronyms)]
-pub struct SO2<T: Numeric> {
+pub struct SO2<T: Numeric = f64> {
     c: T,
     s: T,
 }

--- a/crates/multicalc/src/spatial/lie/so3.rs
+++ b/crates/multicalc/src/spatial/lie/so3.rs
@@ -21,7 +21,7 @@ use crate::spatial::lie::{inverse_left_jacobian_so3, left_jacobian_so3, skew3};
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[allow(clippy::upper_case_acronyms)]
-pub struct SO3<T: Numeric> {
+pub struct SO3<T: Numeric = f64> {
     q: Quaternion<T>,
 }
 

--- a/crates/multicalc/src/spatial/quaternion.rs
+++ b/crates/multicalc/src/spatial/quaternion.rs
@@ -29,7 +29,7 @@ use crate::spatial::{small_angle, small_angle_sq};
 
 /// A quaternion `w + x·i + y·j + z·k`, stored scalar-first.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Quaternion<T: Numeric> {
+pub struct Quaternion<T: Numeric = f64> {
     w: T,
     x: T,
     y: T,

--- a/crates/multicalc/src/spatial/twist.rs
+++ b/crates/multicalc/src/spatial/twist.rs
@@ -25,7 +25,7 @@ use crate::scalar::Numeric;
 /// let _: Vector<6, f64> = a.into();
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Twist<T: Numeric> {
+pub struct Twist<T: Numeric = f64> {
     linear: Vector<3, T>,
     angular: Vector<3, T>,
 }

--- a/crates/multicalc/src/spatial/wrench.rs
+++ b/crates/multicalc/src/spatial/wrench.rs
@@ -23,7 +23,7 @@ use crate::scalar::Numeric;
 /// assert_eq!(a.scale(2.0).as_array(), [2.0, 4.0, 6.0, 8.0, 10.0, 12.0]);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Wrench<T: Numeric> {
+pub struct Wrench<T: Numeric = f64> {
     force: Vector<3, T>,
     torque: Vector<3, T>,
 }

--- a/crates/multicalc/tests/suite/estimation/extended_kalman_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/extended_kalman_filter.rs
@@ -1,7 +1,7 @@
 //! Extended Kalman filter goldens, invariants, and error paths.
 
 use multicalc::error::{DiffError, EstimationError};
-use multicalc::estimation::{CovarianceUpdate, ExtendedKalmanFilter, KalmanFilter};
+use multicalc::estimation::{CovarianceUpdate, ExtendedKalmanFilter, KalmanFilter, KalmanModel};
 use multicalc::linear_algebra::{Matrix, Vector};
 use multicalc::numerical_derivative::finite_difference::FiniteDifferenceMulti;
 use multicalc::numerical_derivative::mode::FiniteDifferenceMode;
@@ -102,10 +102,12 @@ fn extended_filter_with_linear_models_matches_linear_filter() {
     let mut linear = KalmanFilter::<2, 1>::new(
         Vector::new([0.0, 0.0]),
         initial_covariance,
-        Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
-        Matrix::new([[1.0, 0.0]]),
-        process_noise,
-        measurement_noise,
+        KalmanModel {
+            state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
+            measurement_model: Matrix::new([[1.0, 0.0]]),
+            process_noise,
+            measurement_noise,
+        },
     );
 
     for step in 0..8 {

--- a/crates/multicalc/tests/suite/estimation/kalman_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/kalman_filter.rs
@@ -1,7 +1,7 @@
 //! Linear Kalman filter goldens, invariants, and error paths.
 
 use multicalc::error::EstimationError;
-use multicalc::estimation::{CovarianceUpdate, KalmanFilter};
+use multicalc::estimation::{CovarianceUpdate, KalmanFilter, KalmanModel};
 use multicalc::linear_algebra::{Matrix, Vector};
 use multicalc::scalar::{Dual, Numeric};
 use multicalc_testkit::tol::{Tol, assert_matrix_close, assert_vector_close};
@@ -16,10 +16,12 @@ fn constant_velocity_filter<T: Numeric>(
     KalmanFilter::new(
         Vector::new([T::ZERO, T::ZERO]),
         initial_covariance,
-        Matrix::new([[T::ONE, T::ONE], [T::ZERO, T::ONE]]),
-        Matrix::new([[T::ONE, T::ZERO]]),
-        process_noise,
-        measurement_noise,
+        KalmanModel {
+            state_transition: Matrix::new([[T::ONE, T::ONE], [T::ZERO, T::ONE]]),
+            measurement_model: Matrix::new([[T::ONE, T::ZERO]]),
+            process_noise,
+            measurement_noise,
+        },
     )
 }
 
@@ -183,10 +185,12 @@ proptest! {
         let mut filter = KalmanFilter::<2, 1>::new(
             Vector::new([state[0], state[1]]),
             initial_covariance,
-            Matrix::identity(),
-            Matrix::new([[1.0, 0.0]]),
-            Matrix::zeros(),
-            Matrix::new([[1.0]]),
+            KalmanModel {
+                state_transition: Matrix::identity(),
+                measurement_model: Matrix::new([[1.0, 0.0]]),
+                process_noise: Matrix::zeros(),
+                measurement_noise: Matrix::new([[1.0]]),
+            },
         );
         filter.predict();
 

--- a/crates/multicalc/tests/suite/estimation/particle_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/particle_filter.rs
@@ -1,5 +1,7 @@
 use multicalc::error::EstimationError;
-use multicalc::estimation::{GaussianLikelihood, KalmanFilter, ParticleFilter, ResamplingScheme};
+use multicalc::estimation::{
+    GaussianLikelihood, KalmanFilter, KalmanModel, ParticleFilter, ResamplingScheme,
+};
 use multicalc::linear_algebra::{Matrix, Vector};
 use multicalc::random::{Pcg32, RandomSource};
 use multicalc::scalar::{Numeric, VectorFn};
@@ -227,10 +229,12 @@ fn converges_to_kalman_on_linear_gaussian_model() {
     let mut kalman = KalmanFilter::new(
         Vector::new([0.0, 0.0]),
         identity_covariance(),
-        Matrix::new([[1.0, dt], [0.0, 1.0]]),
-        Matrix::new([[1.0, 0.0]]),
-        process_noise,
-        measurement_noise,
+        KalmanModel {
+            state_transition: Matrix::new([[1.0, dt], [0.0, 1.0]]),
+            measurement_model: Matrix::new([[1.0, 0.0]]),
+            process_noise,
+            measurement_noise,
+        },
     );
     let mut particle = ParticleFilter::<2, 1>::new(
         20_000,

--- a/demos/examples/basics/estimation.rs
+++ b/demos/examples/basics/estimation.rs
@@ -11,7 +11,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use multicalc::discretization::q_discrete_white_noise;
-use multicalc::estimation::{CovarianceUpdate, ExtendedKalmanFilter, KalmanFilter};
+use multicalc::estimation::{CovarianceUpdate, ExtendedKalmanFilter, KalmanFilter, KalmanModel};
 use multicalc::linear_algebra::{Matrix, Vector};
 use multicalc::scalar::{Dual, Numeric, VectorFn};
 
@@ -32,10 +32,12 @@ fn tracker<T: Numeric>(
     KalmanFilter::new(
         Vector::new([T::ZERO, T::ZERO]),
         initial_covariance,
-        Matrix::new([[T::ONE, T::ONE], [T::ZERO, T::ONE]]),
-        Matrix::new([[T::ONE, T::ZERO]]),
-        process_noise,
-        measurement_noise,
+        KalmanModel {
+            state_transition: Matrix::new([[T::ONE, T::ONE], [T::ZERO, T::ONE]]),
+            measurement_model: Matrix::new([[T::ONE, T::ZERO]]),
+            process_noise,
+            measurement_noise,
+        },
     )
 }
 

--- a/tools/embedded-smoke/src/checks.rs
+++ b/tools/embedded-smoke/src/checks.rs
@@ -15,7 +15,7 @@ use core::hint::black_box;
 use multicalc::LevenbergMarquardt;
 use multicalc::control::{FollowTheGap, Pid, pure_pursuit_curvature};
 use multicalc::error::LinalgError;
-use multicalc::estimation::{ExtendedKalmanFilter, KalmanFilter};
+use multicalc::estimation::{ExtendedKalmanFilter, KalmanFilter, KalmanModel};
 use multicalc::linear_algebra::{Matrix, Vector};
 use multicalc::numerical_derivative::autodiff::{AutoDiffMulti, AutoDiffSingle};
 use multicalc::numerical_derivative::derivator::DerivatorSingleVariable;
@@ -313,10 +313,12 @@ pub fn kalman_filter_golden() -> f64 {
     let mut filter = KalmanFilter::<2, 1>::new(
         black_box(Vector::new(fixtures::KALMAN_INITIAL_STATE)),
         Matrix::new(fixtures::KALMAN_INITIAL_COVARIANCE),
-        Matrix::new(fixtures::KALMAN_STATE_TRANSITION),
-        Matrix::new(fixtures::KALMAN_MEASUREMENT_MODEL),
-        Matrix::new(fixtures::KALMAN_PROCESS_NOISE),
-        Matrix::new(fixtures::KALMAN_MEASUREMENT_NOISE),
+        KalmanModel {
+            state_transition: Matrix::new(fixtures::KALMAN_STATE_TRANSITION),
+            measurement_model: Matrix::new(fixtures::KALMAN_MEASUREMENT_MODEL),
+            process_noise: Matrix::new(fixtures::KALMAN_PROCESS_NOISE),
+            measurement_noise: Matrix::new(fixtures::KALMAN_MEASUREMENT_NOISE),
+        },
     );
     for row in fixtures::KALMAN_MEASUREMENTS {
         filter.predict();
@@ -446,10 +448,12 @@ pub fn kalman_filter_identity_f32() -> f32 {
     let mut filter = KalmanFilter::<2, 1, f32>::new(
         black_box(Vector::new([0.0_f32, 0.0])),
         Matrix::identity(),
-        Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
-        Matrix::new([[1.0, 0.0]]),
-        Matrix::zeros(),
-        Matrix::new([[1.0]]),
+        KalmanModel {
+            state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
+            measurement_model: Matrix::new([[1.0, 0.0]]),
+            process_noise: Matrix::zeros(),
+            measurement_noise: Matrix::new([[1.0]]),
+        },
     );
     for measurement in [1.0_f32, 2.0] {
         filter.predict();

--- a/tools/qa/benches/latency.rs
+++ b/tools/qa/benches/latency.rs
@@ -267,14 +267,16 @@ impl VectorFn<5, 2> for GlobalPosition {
 
 fn bench_kalman_filter_step(c: &mut Criterion) {
     // One predict + update of a constant-velocity tracker: position measured, velocity inferred.
-    use multicalc::estimation::KalmanFilter;
+    use multicalc::estimation::{KalmanFilter, KalmanModel};
     let mut filter = KalmanFilter::<2, 1>::new(
         Vector::new([0.0, 1.0]),
         Matrix::identity(),
-        Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
-        Matrix::new([[1.0, 0.0]]),
-        Matrix::new([[0.05, 0.0], [0.0, 0.05]]),
-        Matrix::new([[0.5]]),
+        KalmanModel {
+            state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
+            measurement_model: Matrix::new([[1.0, 0.0]]),
+            process_noise: Matrix::new([[0.05, 0.0], [0.0, 0.05]]),
+            measurement_noise: Matrix::new([[0.5]]),
+        },
     );
     let measurement = Vector::new([1.0]);
     c.bench_function("kalman_filter_step", |b| {

--- a/tools/qa/tests/estimation.rs
+++ b/tools/qa/tests/estimation.rs
@@ -2,7 +2,7 @@
 
 //! Checks the linear Kalman filter against filterpy goldens.
 
-use multicalc::estimation::{ExtendedKalmanFilter, KalmanFilter};
+use multicalc::estimation::{ExtendedKalmanFilter, KalmanFilter, KalmanModel};
 use multicalc::linear_algebra::Vector;
 use multicalc::scalar::{Numeric, VectorFn};
 use multicalc_qa::load::*;
@@ -14,10 +14,20 @@ fn build_filter<const STATE_DIMENSION: usize, const MEASUREMENT_DIMENSION: usize
     KalmanFilter::new(
         to_vector::<STATE_DIMENSION>(&fx.inputs["initial_state"]),
         to_matrix::<STATE_DIMENSION, STATE_DIMENSION>(&fx.inputs["initial_covariance"]),
-        to_matrix::<STATE_DIMENSION, STATE_DIMENSION>(&fx.inputs["state_transition"]),
-        to_matrix::<MEASUREMENT_DIMENSION, STATE_DIMENSION>(&fx.inputs["measurement_model"]),
-        to_matrix::<STATE_DIMENSION, STATE_DIMENSION>(&fx.inputs["process_noise"]),
-        to_matrix::<MEASUREMENT_DIMENSION, MEASUREMENT_DIMENSION>(&fx.inputs["measurement_noise"]),
+        KalmanModel {
+            state_transition: to_matrix::<STATE_DIMENSION, STATE_DIMENSION>(
+                &fx.inputs["state_transition"],
+            ),
+            measurement_model: to_matrix::<MEASUREMENT_DIMENSION, STATE_DIMENSION>(
+                &fx.inputs["measurement_model"],
+            ),
+            process_noise: to_matrix::<STATE_DIMENSION, STATE_DIMENSION>(
+                &fx.inputs["process_noise"],
+            ),
+            measurement_noise: to_matrix::<MEASUREMENT_DIMENSION, MEASUREMENT_DIMENSION>(
+                &fx.inputs["measurement_noise"],
+            ),
+        },
     )
 }
 


### PR DESCRIPTION
add prelude, re-export every public type at the crate root, and convenience free functions

## What & why

Closes https://github.com/kmolan/multicalc-rust/issues/194

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
