### PR TITLE
Easier include paths and getter names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,10 @@ jobs:
         run: cargo test -p multicalc
       - name: Test (alloc feature)
         run: cargo test -p multicalc --features alloc
+      # All features on: the README and guide examples are compiled here too, and some of
+      # them use the alloc-only types.
       - name: Doctests
-        run: cargo test -p multicalc --doc
+        run: cargo test -p multicalc --all-features --doc
 
   qa:
     name: qa fixtures (host-only)

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -60,8 +60,10 @@ jobs:
         run: cargo test -p multicalc
       - name: Test (alloc feature)
         run: cargo test -p multicalc --features alloc
+      # All features on: the README and guide examples are compiled here too, and some of
+      # them use the alloc-only types.
       - name: Doctests
-        run: cargo test -p multicalc --doc
+        run: cargo test -p multicalc --all-features --doc
 
   qa:
     name: qa fixtures (host-only)

--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@
 [![Docs](https://docs.rs/multicalc/badge.svg)](https://docs.rs/multicalc)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**Scientific math for real-time embedded systems, in `no_std` stable Rust with near-zero dependencies: state
-estimation, control, kinematics, and Lie groups on a calculus, autodiff, and linear-algebra core in one integrated package.
-No heap, no panics, no `unsafe` - from a 64-bit server down to a bare-metal microcontroller.**
+**Scientific computing that fits on a microcontroller, built and tested from scratch in one integrated package. Estimation, control, kinematics, Lie groups, calculus, autodiff and linear algebra in stable no_std Rust with
+no heap, no panics and no unsafe. Run the same code on your laptop and your Cortex-M0.**
 
 https://github.com/user-attachments/assets/93dee114-67f6-4124-a20d-88a8be50da6f
 
@@ -17,10 +16,7 @@ screen is measured live, inside a 1 ms tick.*
 
 ## Highlights
 
-- **1 kHz loop rate.** The lead showcase localizes a differential-drive
-  robot against a known map with a 2,000-particle filter over 61 noisy lidar beams, then runs a
-  5-state extended Kalman filter fusing 100 Hz wheel odometry, a 200 Hz IMU, and 20 Hz GPS while a
-  Follow-the-Gap controller laps a course of obstacles — predict, fuse, and plan every millisecond.
+- **1 kHz loop rates:** No heap, fixed-size types, bounded work per call. Results in a full robotics control loop at 1 kHz.
 - **Exercise the same math from a server to a microcontroller.** Every commit is built and tested on **six targets**:
   the `x86_64` and `aarch64` Linux hosts and on four bare-metal ABIs (`thumbv7em` soft-float,
   `thumbv7em` hardware-FPU, `thumbv6m`, and `riscv32imc`), running the real math under QEMU.
@@ -78,46 +74,58 @@ fn main() -> Result<(), CalcError> {
     let g = scalar_fn!(|v: &[f64; 2]| v[0] * v[0] * v[1] + v[0].sin()); // g(x, y) = x²y + sin x
 
     // Derivatives — exact, by forward-mode autodiff. No step size, no truncation error.
-    let slope = derivative(&f, 2.0_f64);                     // f'(2)  = 10
-    let bend = second_derivative(&f, 2.0_f64);               // f''(2) = 12
-    let dg_dx = partial(&g, 0, &[1.0_f64, 2.0])?;            // ∂g/∂x at (1, 2)
+    let single_point = 2.0_f64;
+    let slope = derivative(&f, single_point);                // f'(2)  = 10
+    let bend = second_derivative(&f, single_point);          // f''(2) = 12
+
+    let point = [1.0_f64, 2.0];
+    let x_index = 0;
+    let dg_dx = partial(&g, x_index, &point)?;
 
     // The derivative matrices of those same two formulas.
-    let hessian = Hessian::new().evaluate(&g, &[1.0, 2.0])?;            // 2x2 second derivatives
+    let hessian = Hessian::new().evaluate(&g, &point)?;      // 2x2 second derivatives
     let both = scalar_fn_vec!(|v: &[f64; 2]| [
         v[0] * v[0] * v[1] + v[0].sin(),
         v[0] * v[0] * v[0] - c(2.0) * v[0],
     ]);
-    let jacobian = Jacobian::new().evaluate(&both, &[1.0, 2.0])?;       // 2x2 first derivatives
+    let jacobian = Jacobian::new().evaluate(&both, &point)?; // 2x2 first derivatives
 
     // Integration — f again, this time over an interval.
-    let area = integral(&|x: f64| f.eval(x), [0.0, 2.0])?;   // ∫₀² f = 0
+    let limits = [0.0, 2.0];
+    let area = integral(&|x: f64| f.eval(x), limits)?;       // ∫₀² f = 0
 
     // Linear algebra — solve H·x = b with the Hessian computed three lines up.
-    let x = hessian.solve(Vector::new([1.0, 2.0]))?;
+    let b = Vector::new([1.0, 2.0]);
+    let x = hessian.solve(b)?;
 
     // Root finding — Newton on the same f, its derivative supplied by autodiff.
-    let root = Newton::new().solve(&f, 2.0)?.root;           // √2 ≈ 1.41421356
+    let initial_guess = 2.0;
+    let root = Newton::new().solve(&f, initial_guess)?.root; // √2 ≈ 1.41421356
 
     // Rigid-body motion — SO(3)/SE(3), generic over the scalar like everything above.
-    let turn = SO3::exp(Vector::new([0.0, 0.0, core::f64::consts::FRAC_PI_2]));  // 90° about z
-    let pose = SE3::from_parts(turn, Vector::new([1.0, 2.0, 3.0]));
-    let moved = pose.act(Vector::new([1.0, 0.0, 0.0]));      // rotate, then translate → (1, 3, 3)
+    let quarter_turn_about_z = Vector::new([0.0, 0.0, core::f64::consts::FRAC_PI_2]);
+    let translation = Vector::new([1.0, 2.0, 3.0]);
+    let start = Vector::new([1.0, 0.0, 0.0]);
+
+    let pose = SE3::from_parts(SO3::exp(quarter_turn_about_z), translation);
+    let moved = pose.act(start);                  // rotate, then translate → (1, 3, 3)
 
     // Estimation — a Kalman filter recovering the velocity it never measures.
-    let mut filter = KalmanFilter::new(
-        Vector::new([0.0, 0.0]),                 // initial state [position, velocity]
-        Matrix::new([[1.0, 0.0], [0.0, 1.0]]),   // initial covariance
-        KalmanModel {
-            state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
-            measurement_model: Matrix::new([[1.0, 0.0]]),    // position only
-            process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
-            measurement_noise: Matrix::new([[0.1]]),
-        },
-    );
+    let initial_state = Vector::new([0.0, 0.0]);  // [position, velocity]
+    let initial_covariance = Matrix::new([[1.0, 0.0], [0.0, 1.0]]);
+    let model = KalmanModel {
+        state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
+        measurement_model: Matrix::new([[1.0, 0.0]]),        // position only
+        process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
+        measurement_noise: Matrix::new([[0.1]]),
+    };
+
+    let mut filter = KalmanFilter::new(initial_state, initial_covariance, model);
     filter.predict();
-    filter.update(Vector::new([1.0]))?;          // the target moved about 1 m
-    let velocity = filter.state()[1];            // recovered, though never measured
+
+    let measurement = Vector::new([1.0]);         // the target moved about 1 m
+    filter.update(measurement)?;
+    let velocity = filter.state()[1];             // recovered, though never measured
 
     Ok(())
 }
@@ -126,14 +134,34 @@ fn main() -> Result<(), CalcError> {
 Every fallible call propagates with `?`: each module has its own error enum, and all of them
 convert into the `CalcError` umbrella, so one return type covers a program that mixes modules.
 
-Import with `use multicalc::prelude::*;` for the traits and one-call functions, plus the types you
-need from the crate root. The one-call functions (`derivative`, `partial`, `integral`) cover the
-common case; the strategy objects behind them are how you pick a different method or step size.
+## Full tutorial
 
-## Tutorial
-
-The [guide](https://github.com/kmolan/multicalc-rust/blob/main/crates/multicalc/GUIDE.md) is a comprehensive tutorial for each module. It shows the full imports,
+Refer to the [guide](https://github.com/kmolan/multicalc-rust/blob/main/crates/multicalc/GUIDE.md) for a comprehensive tutorial for each module. It shows the full imports,
 expected outputs in comments, error-path notes, and pointers to runnable demos. Start there when you need the complete picture of a feature.
+
+## Accuracy
+
+Verified against external-library fixtures (`mpmath`, `numpy`, `scipy`, `filterpy`) in
+the `multicalc-qa` crate, with per-module tables generated from those fixtures. See
+[benchmarks/README.md](https://github.com/kmolan/multicalc-rust/tree/main/benchmarks/README.md)
+for the index, or go straight to
+[calculus](https://github.com/kmolan/multicalc-rust/tree/main/benchmarks/calculus.md),
+[linear_algebra](https://github.com/kmolan/multicalc-rust/tree/main/benchmarks/linear_algebra.md),
+[optimization](https://github.com/kmolan/multicalc-rust/tree/main/benchmarks/optimization.md),
+[ode](https://github.com/kmolan/multicalc-rust/tree/main/benchmarks/ode.md),
+[estimation](https://github.com/kmolan/multicalc-rust/tree/main/benchmarks/estimation.md),
+or [root_finding](https://github.com/kmolan/multicalc-rust/tree/main/benchmarks/root_finding.md).
+
+## Runnable demos
+
+Runnable, self-contained programs for each module live in the
+[`demos/`](https://github.com/kmolan/multicalc-rust/tree/main/demos) crate. See
+[demos/README.md](https://github.com/kmolan/multicalc-rust/blob/main/demos/README.md). Run one
+with:
+
+```sh
+cargo run -p multicalc-demos --example <name>
+```
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -62,11 +62,73 @@ screen is measured live, inside a 1 ms tick.*
 - [Approximation](https://github.com/kmolan/multicalc-rust/blob/main/crates/multicalc/GUIDE.md#taylor-approximation): linear and quadratic Taylor models with goodness-of-fit metrics.
 - [Random](https://github.com/kmolan/multicalc-rust/blob/main/crates/multicalc/GUIDE.md#random): `Pcg32` and the `RandomSource` trait, a seedable `no_std` generator for the particle filter and for stochastic models.
 
-## Install
+## Quick start
 
-```sh
-cargo add multicalc
+Two formulas, written once, carried through six modules — each step feeding the next:
+
+```rust
+use multicalc::prelude::*;
+use multicalc::{Hessian, Jacobian, KalmanFilter, KalmanModel, Matrix, Newton, SE3, SO3, Vector, c};
+use multicalc::{scalar_fn, scalar_fn_vec};
+
+fn main() -> Result<(), CalcError> {
+    // Written once, evaluated at f64 here and at an autodiff number wherever a derivative is asked
+    // for — the formula text never changes.
+    let f = scalar_fn!(|x| x * x * x - c(2.0) * x);                     // f(x)    = x³ - 2x
+    let g = scalar_fn!(|v: &[f64; 2]| v[0] * v[0] * v[1] + v[0].sin()); // g(x, y) = x²y + sin x
+
+    // Derivatives — exact, by forward-mode autodiff. No step size, no truncation error.
+    let slope = derivative(&f, 2.0_f64);                     // f'(2)  = 10
+    let bend = second_derivative(&f, 2.0_f64);               // f''(2) = 12
+    let dg_dx = partial(&g, 0, &[1.0_f64, 2.0])?;            // ∂g/∂x at (1, 2)
+
+    // The derivative matrices of those same two formulas.
+    let hessian = Hessian::new().evaluate(&g, &[1.0, 2.0])?;            // 2x2 second derivatives
+    let both = scalar_fn_vec!(|v: &[f64; 2]| [
+        v[0] * v[0] * v[1] + v[0].sin(),
+        v[0] * v[0] * v[0] - c(2.0) * v[0],
+    ]);
+    let jacobian = Jacobian::new().evaluate(&both, &[1.0, 2.0])?;       // 2x2 first derivatives
+
+    // Integration — f again, this time over an interval.
+    let area = integral(&|x: f64| f.eval(x), [0.0, 2.0])?;   // ∫₀² f = 0
+
+    // Linear algebra — solve H·x = b with the Hessian computed three lines up.
+    let x = hessian.solve(Vector::new([1.0, 2.0]))?;
+
+    // Root finding — Newton on the same f, its derivative supplied by autodiff.
+    let root = Newton::new().solve(&f, 2.0)?.root;           // √2 ≈ 1.41421356
+
+    // Rigid-body motion — SO(3)/SE(3), generic over the scalar like everything above.
+    let turn = SO3::exp(Vector::new([0.0, 0.0, core::f64::consts::FRAC_PI_2]));  // 90° about z
+    let pose = SE3::from_parts(turn, Vector::new([1.0, 2.0, 3.0]));
+    let moved = pose.act(Vector::new([1.0, 0.0, 0.0]));      // rotate, then translate → (1, 3, 3)
+
+    // Estimation — a Kalman filter recovering the velocity it never measures.
+    let mut filter = KalmanFilter::new(
+        Vector::new([0.0, 0.0]),                 // initial state [position, velocity]
+        Matrix::new([[1.0, 0.0], [0.0, 1.0]]),   // initial covariance
+        KalmanModel {
+            state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
+            measurement_model: Matrix::new([[1.0, 0.0]]),    // position only
+            process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
+            measurement_noise: Matrix::new([[0.1]]),
+        },
+    );
+    filter.predict();
+    filter.update(Vector::new([1.0]))?;          // the target moved about 1 m
+    let velocity = filter.state()[1];            // recovered, though never measured
+
+    Ok(())
+}
 ```
+
+Every fallible call propagates with `?`: each module has its own error enum, and all of them
+convert into the `CalcError` umbrella, so one return type covers a program that mixes modules.
+
+Import with `use multicalc::prelude::*;` for the traits and one-call functions, plus the types you
+need from the crate root. The one-call functions (`derivative`, `partial`, `integral`) cover the
+common case; the strategy objects behind them are how you pick a different method or step size.
 
 ## Tutorial
 

--- a/crates/multicalc/GUIDE.md
+++ b/crates/multicalc/GUIDE.md
@@ -87,11 +87,12 @@ use multicalc::AutoDiffSingle;
 use multicalc::DerivatorSingleVariable;
 use multicalc::scalar_fn;
 
-let f = scalar_fn!(|x| x * x * x);           // f(x) = x^3, evaluable at any Numeric
-let d = AutoDiffSingle::default();           // forward-mode autodiff, exact
+let function = scalar_fn!(|x| x * x * x);    // f(x) = x^3, evaluable at any Numeric
+let derivator = AutoDiffSingle::default();   // forward-mode autodiff, exact
+let point = 2.0;
 
-let first = d.differentiate(1, &f, 2.0).unwrap();      // 12.0
-let third = d.differentiate(3, &f, 2.0).unwrap();      //  6.0
+let first = derivator.differentiate(1, &function, point).unwrap();   // 12.0
+let third = derivator.differentiate(3, &function, point).unwrap();   //  6.0
 ```
 
 Errors: differentiation calls return [`DiffError`](#error-handling) (for example `OrderZero`).
@@ -125,9 +126,14 @@ let g = scalar_fn!(|v: &[f64; 3]| v[1] * v[0].sin() + v[0] * v[1].cos() + v[0] *
 let d = AutoDiffMulti::default();
 let point = [1.0, 2.0, 3.0];
 
-let dx    = d.first_partial_derivative(&g, 0, &point).unwrap();  // dg/dx
-let mixed = d.differentiate(&g, &[0, 1], &point).unwrap();           // d(dg/dx)/dy
-let third = d.differentiate(&g, &[0, 0, 1], &point).unwrap();        // d^3 g / dx^2 dy
+let x_index = 0;
+let dx = d.first_partial_derivative(&g, x_index, &point).unwrap();
+
+let then_by_y = [0, 1];
+let mixed = d.differentiate(&g, &then_by_y, &point).unwrap();      // d(dg/dx)/dy
+
+let twice_by_x_then_y = [0, 0, 1];
+let third = d.differentiate(&g, &twice_by_x_then_y, &point).unwrap();
 ```
 
 Pass a finite-difference derivator (`FiniteDifferenceSingle` / `FiniteDifferenceMulti`) instead
@@ -144,13 +150,15 @@ use multicalc::{scalar_fn, scalar_fn_vec};
 
 // the vector function (x*y*z, x^2 + y^2)
 let f = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
+let jacobian_point = [1.0, 2.0, 3.0];
 let jacobian: Jacobian = Jacobian::default();
-let j = jacobian.evaluate(&f, &[1.0, 2.0, 3.0]).unwrap();   // [[6, 3, 2], [2, 4, 0]]
+let j = jacobian.evaluate(&f, &jacobian_point).unwrap();   // [[6, 3, 2], [2, 4, 0]]
 
 // g(x, y) = y*sin(x) + 2*x*e^y
 let g = scalar_fn!(|v: &[f64; 2]| v[1] * v[0].sin() + c(2.0) * v[0] * v[1].exp());
+let hessian_point = [1.0, 2.0];
 let hessian: Hessian = Hessian::default();
-let h = hessian.evaluate(&g, &[1.0, 2.0]).unwrap();
+let h = hessian.evaluate(&g, &hessian_point).unwrap();
 ```
 
 With the `alloc` feature, `Jacobian::evaluate_on_heap` returns a `Vec<Vec<T>>` for inputs too large
@@ -183,20 +191,26 @@ Iterative rules over finite and infinite limits:
 use multicalc::IntegratorSingleVariable;
 use multicalc::IterativeSingle;
 
-let integrator = IterativeSingle::default();                 // Boole's rule, 120 intervals
-let area = integrator.single_integral(&|x: f64| 2.0 * x, &[0.0, 2.0]).unwrap();   // 4.0
+let integrator = IterativeSingle::default();     // Boole's rule, 120 intervals
+
+let line = |x: f64| 2.0 * x;
+let limits = [0.0, 2.0];
+let area = integrator.single_integral(&line, &limits).unwrap();   // 4.0
 
 // infinite / semi-infinite limits are supported for decaying integrands
-let bell = integrator
-    .single_integral(&|x| (-x * x).exp(), &[f64::NEG_INFINITY, f64::INFINITY])
-    .unwrap();                                               // sqrt(pi)
+let bell_curve = |x: f64| (-x * x).exp();
+let real_line = [f64::NEG_INFINITY, f64::INFINITY];
+let bell = integrator.single_integral(&bell_curve, &real_line).unwrap();   // sqrt(pi)
 ```
 
 Choose the rule and interval count with `from_parameters`:
 
 ```rust
 use multicalc::{IterativeMethod, IterativeSingle};
-let integrator: IterativeSingle = IterativeSingle::from_parameters(120, IterativeMethod::Simpsons);
+
+let interval_count = 120;
+let integrator: IterativeSingle =
+    IterativeSingle::from_parameters(interval_count, IterativeMethod::Simpsons);
 ```
 
 Each Gaussian rule integrates over a fixed domain. Pass the bare integrand `f(x)`; the weights
@@ -208,10 +222,12 @@ use multicalc::GaussianSingle;
 use multicalc::GaussianQuadratureMethod;
 
 // Gauss-Hermite integrates f(x) * e^(-x^2) over the whole real line.
-let hermite = GaussianSingle::from_parameters(5, GaussianQuadratureMethod::GaussHermite);
-let val = hermite
-    .single_integral(&|x| x * x, &[f64::NEG_INFINITY, f64::INFINITY])
-    .unwrap();                                                // sqrt(pi)/2
+let node_count = 5;
+let hermite = GaussianSingle::from_parameters(node_count, GaussianQuadratureMethod::GaussHermite);
+
+let square = |x: f64| x * x;
+let real_line = [f64::NEG_INFINITY, f64::INFINITY];
+let val = hermite.single_integral(&square, &real_line).unwrap();   // sqrt(pi)/2
 ```
 
 | Rule           | Computes                                              |
@@ -242,7 +258,8 @@ users reach them through `GaussianSingle` rather than directly.
 use multicalc::gaussian_tables;
 use multicalc::GaussianQuadratureMethod;
 
-let pairs = gaussian_tables::nodes(GaussianQuadratureMethod::GaussHermite, 5).unwrap();
+let order = 5;
+let pairs = gaussian_tables::nodes(GaussianQuadratureMethod::GaussHermite, order).unwrap();
 for (weight, abscissa) in pairs {
     // weight * f(abscissa) is one term of the 5-point Gauss-Hermite sum
 }
@@ -268,10 +285,12 @@ use multicalc::LinearApproximator;
 use multicalc::scalar_fn;
 
 let f = scalar_fn!(|v: &[f64; 3]| v[0] + v[1] * v[1] + v[2] * v[2] * v[2]);
+let base_point = [1.0, 2.0, 3.0];        // where the model is anchored
 let linear: LinearApproximator = LinearApproximator::default();
-let model = linear.approximate(&f, &[1.0, 2.0, 3.0]).unwrap();
+let model = linear.approximate(&f, &base_point).unwrap();
 
-let y = model.predict(&[1.1, 2.1, 3.1]);
+let nearby = [1.1, 2.1, 3.1];
+let y = model.predict(&nearby);
 // model.prediction_metrics(&samples, &f) returns RMSE, R^2, and more
 ```
 
@@ -496,10 +515,13 @@ use multicalc::Vector;
 let f = |_t: f64, y: &Vector<2, f64>| Vector::new([y[1], -y[0]]);
 let y0 = Vector::new([1.0, 0.0]);
 
-let y1 = Rk4::step(&f, 0.0, &y0, 0.1);                                  // one fixed step of size 0.1
+let start_time = 0.0;
+let timestep = 0.1;
+let y1 = Rk4::step(&f, start_time, &y0, timestep);      // one fixed step
 
 // Adaptive solve over one full period returns to the start [1, 0].
-let yf = Rk45::default().solve(&f, 0.0, &y0, core::f64::consts::TAU).unwrap();
+let one_period = core::f64::consts::TAU;
+let yf = Rk45::default().solve(&f, start_time, &y0, one_period).unwrap();
 assert!((yf[0] - 1.0).abs() < 1e-6 && yf[1].abs() < 1e-6);
 ```
 
@@ -512,11 +534,16 @@ use multicalc::Vector;
 
 let f = |_t: f64, y: &Vector<2, f64>| Vector::new([y[1], -y[0]]);
 let y0 = Vector::new([1.0, 0.0]);
-let solver = Rk45::default().with_rtol(1e-9).with_atol(1e-12);
+let relative_tolerance = 1e-9;
+let absolute_tolerance = 1e-12;
+let solver = Rk45::default()
+    .with_rtol(relative_tolerance)
+    .with_atol(absolute_tolerance);
 
+let start_time = 0.0;
 let times = [0.5, 1.0, 2.0, 3.0];
 let mut out = [Vector::<2, f64>::zeros(); 4];
-solver.solve_on_grid(&f, 0.0, &y0, &times, &mut out).unwrap();
+solver.solve_on_grid(&f, start_time, &y0, &times, &mut out).unwrap();
 ```
 
 Errors: the adaptive solver returns [`IntegrateError`](#error-handling): `StepSizeTooSmall`,
@@ -591,12 +618,16 @@ use multicalc::{SE3, SO3};
 use multicalc::Vector;
 
 // A 90° rotation about z, applied to a point.
-let r = SO3::<f64>::exp(Vector::new([0.0, 0.0, core::f64::consts::FRAC_PI_2]));
-let p = r.act(Vector::new([1.0, 0.0, 0.0]));         // ≈ (0, 1, 0)
+let quarter_turn_about_z = Vector::new([0.0, 0.0, core::f64::consts::FRAC_PI_2]);
+let r = SO3::<f64>::exp(quarter_turn_about_z);
+
+let point = Vector::new([1.0, 0.0, 0.0]);
+let p = r.act(point);                                // ≈ (0, 1, 0)
 
 // A rigid transform: rotate, then translate.
-let g = SE3::from_parts(r, Vector::new([1.0, 2.0, 3.0]));
-let q = g.act(Vector::new([1.0, 0.0, 0.0]));         // ≈ (1, 3, 3)
+let translation = Vector::new([1.0, 2.0, 3.0]);
+let g = SE3::from_parts(r, translation);
+let q = g.act(point);                                // ≈ (1, 3, 3)
 
 // exp/log round trip on the tangent twist [v; ω].
 let xi = g.log();
@@ -636,21 +667,33 @@ use multicalc::{BodyTwist, DifferentialDrive, WheelVelocities};
 use multicalc::Dual;
 use multicalc::SE2;
 
-// Geometry: a 36 mm wheel radius and a 235 mm track width.
-let dd = DifferentialDrive::new(0.036_f64, 0.235).unwrap();
+let wheel_radius = 0.036_f64;   // 36 mm
+let track_width = 0.235;        // 235 mm between the wheels
+let drive = DifferentialDrive::new(wheel_radius, track_width).unwrap();
 
 // Wheel velocities to a body twist, and back exactly.
-let twist = dd.forward(WheelVelocities::new(10.0, 10.0));   // v = 0.36 m/s, ω = 0
-let wheels = dd.inverse(BodyTwist::new(0.36, 0.0));         // back to (10, 10)
+let wheel_speeds = WheelVelocities::new(10.0, 10.0);        // rad/s on each wheel
+let twist = drive.forward(wheel_speeds);                    // v = 0.36 m/s, ω = 0
+
+let body_motion = BodyTwist::new(0.36, 0.0);                // m/s forward, rad/s turn
+let wheels = drive.inverse(body_motion);                    // back to (10, 10)
 
 // The encoder path: distance travelled -> wheel rotation -> body arc -> pose.
-let rotations = dd.wheel_rotations_from_travel(0.01, 0.012);
-let pose = integrate(SE2::identity(), dd.forward_arc(rotations));
+let left_travel = 0.01;    // metres rolled by each wheel
+let right_travel = 0.012;
+let rotations = drive.wheel_rotations_from_travel(left_travel, right_travel);
+
+let start = SE2::identity();
+let pose = integrate(start, drive.forward_arc(rotations));
 
 // Autodiff straight through an odometry step: d(pose)/d(arc length).
+let arc_length = Dual::variable(0.4);   // the quantity being differentiated
+let turn_rate = Dual::constant(0.3);
+let duration = Dual::constant(1.0);
+
 let step = integrate(
     SE2::<Dual<f64>>::identity(),
-    BodyTwist::new(Dual::variable(0.4), Dual::constant(0.3)).integrate_over(Dual::constant(1.0)),
+    BodyTwist::new(arc_length, turn_rate).integrate_over(duration),
 );
 let dx_ds = step.translation()[0].deriv;
 ```
@@ -691,29 +734,53 @@ use multicalc::Vector;
 use multicalc::SE2;
 
 // A speed loop: PID on the forward speed, output limited, derivative filtered.
-let mut speed_loop = Pid::new(2.0_f64, 1.0, 0.05, 0.01)
+let proportional_gain = 2.0_f64;
+let integral_gain = 1.0;
+let derivative_gain = 0.05;
+let timestep = 0.01;
+let lowest_output = -1.0;
+let highest_output = 1.0;
+let derivative_filter_weight = 0.2;
+
+let mut speed_loop = Pid::new(proportional_gain, integral_gain, derivative_gain, timestep)
     .unwrap()
-    .with_output_limits(-1.0, 1.0)
+    .with_output_limits(lowest_output, highest_output)
     .unwrap()
-    .with_derivative_filter(0.2)
+    .with_derivative_filter(derivative_filter_weight)
     .unwrap();
-let command = speed_loop.update(0.4, 0.35); // setpoint 0.4 m/s, measured 0.35 m/s
+
+let setpoint = 0.4;      // m/s we want
+let measurement = 0.35;  // m/s we have
+let command = speed_loop.update(setpoint, measurement);
 
 // Steering toward a point 2 m ahead and 1 m to the left: a left turn, so positive curvature.
-let curvature = pure_pursuit_curvature(SE2::identity(), Vector::new([2.0, 1.0]), 2.0).unwrap();
-let twist = curvature.to_body_twist(0.4);
+let pose = SE2::identity();
+let target = Vector::new([2.0, 1.0]);
+let lookahead_distance = 2.0;
+let curvature = pure_pursuit_curvature(pose, target, lookahead_distance).unwrap();
 
-// Reactive avoidance: 31 beams over 120°, 4 m range, a 0.5 m chassis, a 0.5 m free-range threshold,
-// 0.4 m/s cruise.
+let forward_speed = 0.4;
+let twist = curvature.to_body_twist(forward_speed);
+
+// Reactive avoidance over a 31-beam scan.
+let field_of_view = 2.0 * core::f64::consts::PI / 3.0;   // 120°
+let max_range = 4.0;
+let robot_radius = 0.5;
+let clearance = 0.5;     // a gap must beat this to count as free
+let cruise_speed = 0.4;
+
 let follower: FollowTheGap<31, f64> =
-    FollowTheGap::try_new(2.0 * core::f64::consts::PI / 3.0, 4.0, 0.5, 0.5, 0.4).unwrap();
+    FollowTheGap::try_new(field_of_view, max_range, robot_radius, clearance, cruise_speed).unwrap();
 
 // A clear scan drives straight ahead at cruise speed.
-let output = follower.compute(&[4.0; 31], 0.0).unwrap();
+let goal_angle = 0.0;
+let clear_scan = [4.0; 31];
+let output = follower.compute(&clear_scan, goal_angle).unwrap();
 assert!(output.heading().abs() < 1e-12);
 
 // A wall all round stops, and says why.
-let blocked = follower.compute(&[0.2; 31], 0.0).unwrap();
+let walled_in = [0.2; 31];
+let blocked = follower.compute(&walled_in, goal_angle).unwrap();
 assert!(blocked.is_blocked());
 assert_eq!(blocked.body_twist().linear(), 0.0);
 ```
@@ -780,13 +847,15 @@ let path: PolylinePath<3, 2, f64> = PolylinePath::try_from_points(&[
 let total = path.total_arc_length();                        // 7.0
 
 // Where is a robot sitting off to the side of the first leg?
-let here = path.closest_point(Vector::new([2.0, 0.5])).unwrap();
+let robot_position = Vector::new([2.0, 0.5]);
+let here = path.closest_point(robot_position).unwrap();
 let on_path = here.point();                                 // (2.0, 0.0)
 let travelled = here.arc_length();                          // 2.0
 let cross_track = here.distance();                          // 0.5
 
 // Aim one unit further along than that.
-let aim = path.lookahead_point(travelled, 1.0).unwrap();    // (3.0, 0.0)
+let lookahead_distance = 1.0;
+let aim = path.lookahead_point(travelled, lookahead_distance).unwrap();   // (3.0, 0.0)
 ```
 
 `try_from_points` and `push` return [`MotionError::CapacityExceeded`] if there is no room for the
@@ -820,24 +889,26 @@ use multicalc::{KalmanFilter, KalmanModel};
 use multicalc::{Matrix, Vector};
 
 // Constant velocity: position integrates velocity over a 1 s step; position is measured.
-let mut filter = KalmanFilter::new(
-    Vector::new([0.0, 0.0]),                    // initial state [position, velocity]
-    Matrix::new([[1.0, 0.0], [0.0, 1.0]]),      // initial covariance
-    KalmanModel {
-        state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
-        measurement_model: Matrix::new([[1.0, 0.0]]),   // position only
-        process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
-        measurement_noise: Matrix::new([[0.1]]),
-    },
-);
+let initial_state = Vector::new([0.0, 0.0]);   // [position, velocity]
+let initial_covariance = Matrix::new([[1.0, 0.0], [0.0, 1.0]]);
+let model = KalmanModel {
+    state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
+    measurement_model: Matrix::new([[1.0, 0.0]]),   // position only
+    process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
+    measurement_noise: Matrix::new([[0.1]]),
+};
+
+let mut filter = KalmanFilter::new(initial_state, initial_covariance, model);
 
 filter.predict();
-filter.update(Vector::new([1.0])).unwrap();
+let measurement = Vector::new([1.0]);
+filter.update(measurement).unwrap();
 let position = filter.state()[0];
 
 // Gate an outlier before folding it in.
 filter.predict();
-filter.update(Vector::new([1.9])).unwrap();
+let outlier = Vector::new([1.9]);
+filter.update(outlier).unwrap();
 let gate = filter.normalized_innovation_squared().unwrap();
 ```
 
@@ -938,18 +1009,28 @@ impl VectorFn<2, 2> for Stationary {
     }
 }
 
+let particle_count = 1000;
+let initial_mean = Vector::new([0.0, 0.0]);
+let initial_covariance = Matrix::new([[1.0, 0.0], [0.0, 1.0]]);
+let process_noise = Matrix::new([[0.01, 0.0], [0.0, 0.01]]);
+let seed = 7;
+
 let mut filter = ParticleFilter::<2, 2>::new(
-    1000,
-    Vector::new([0.0, 0.0]),                  // initial mean
-    Matrix::new([[1.0, 0.0], [0.0, 1.0]]),    // initial covariance
-    Matrix::new([[0.01, 0.0], [0.0, 0.01]]),  // process noise
-    7,                                        // seed
-).unwrap();
-let sensor = GaussianLikelihood::new(Matrix::new([[0.05, 0.0], [0.0, 0.05]])).unwrap();
+    particle_count,
+    initial_mean,
+    initial_covariance,
+    process_noise,
+    seed,
+)
+.unwrap();
+
+let measurement_noise = Matrix::new([[0.05, 0.0], [0.0, 0.05]]);
+let sensor = GaussianLikelihood::new(measurement_noise).unwrap();
+let measurement = Vector::new([1.0, 2.0]);
 
 for _ in 0..20 {
     filter.predict(&Stationary).unwrap();
-    filter.update(&Stationary, &sensor, Vector::new([1.0, 2.0])).unwrap();
+    filter.update(&Stationary, &sensor, measurement).unwrap();
 }
 assert!((filter.mean()[0] - 1.0).abs() < 0.2);
 ```
@@ -979,17 +1060,19 @@ sensor models, and Monte-Carlo checks need the same thing.
 ```rust
 use multicalc::{Pcg32, RandomSource};
 
-let mut generator = Pcg32::new(20260722);
+let seed = 20260722;
+let mut generator = Pcg32::new(seed);
 
 let uniform = generator.next_unit_f64();     // in [0, 1)
 let noise = generator.standard_normal();     // mean 0, standard deviation 1
 
 // The same seed replays the same sequence.
-let mut replay = Pcg32::new(20260722);
+let mut replay = Pcg32::new(seed);
 assert_eq!(replay.next_unit_f64(), uniform);
 
 // A second stream from the same seed draws an independent sequence.
-let mut other = Pcg32::with_stream(20260722, 1);
+let stream = 1;
+let mut other = Pcg32::with_stream(seed, stream);
 let independent = other.standard_normal();
 ```
 

--- a/crates/multicalc/GUIDE.md
+++ b/crates/multicalc/GUIDE.md
@@ -12,12 +12,12 @@ from `libm`, so the crate works without `std`. Methods like `f64::sin` need `std
 `no_std` crate, call the `libm` version instead (`libm::sin(x)` in place of `x.sin()`). The
 crate re-exports `libm` as `multicalc::libm`.
 
-Where a sensible default exists, a convenience method such as `get_single` returns the answer
-directly. Otherwise a call returns a `Result`, and the error is the module family's own enum;
-see [Error handling](#error-handling).
+Every fallible call returns a `Result`, and the error is the module family's own enum; see
+[Error handling](#error-handling).
 
 ## Contents
 
+- [Importing](#importing)
 - [Scalars and automatic differentiation](#scalars-and-automatic-differentiation)
 - [Derivatives, Jacobians, and Hessians](#derivatives-jacobians-and-hessians)
 - [Integration](#integration)
@@ -38,6 +38,35 @@ see [Error handling](#error-handling).
 - [Error handling](#error-handling)
 - [Internals](#internals)
 
+## Importing
+
+There is one answer: glob the prelude for the traits and one-call functions, then name the types
+you need from the crate root. Every public type lives at `multicalc::Type`, so you never have to
+know which file it is declared in. The examples below spell out their imports in full, but
+`use multicalc::prelude::*;` covers the traits in all of them.
+
+```rust
+use multicalc::prelude::*;
+use multicalc::{KalmanFilter, Matrix, Vector};
+```
+
+The one exception is a handful of free functions that stay on their own module, because their
+names only make sense next to each other — `multicalc::vector_field::curl_3d` reads better than
+`multicalc::curl_3d`.
+
+### The easy path and the configurable one
+
+Most calculus work has two ways in, and the guide uses both:
+
+- **The one-call functions** — `derivative`, `second_derivative`, `partial`, `integral`. They need
+  no imported trait and no configuration, and they use exact automatic differentiation. Reach for
+  these first.
+- **The strategy objects** — `AutoDiffSingle`, `FiniteDifferenceSingle`, `IterativeSingle`,
+  `GaussianSingle` and their multi-variable siblings. These are how you choose a different method,
+  a step size, an iteration count, or a derivative order above the second.
+
+Both compute the same answers; the objects just expose the knobs.
+
 ## Scalars and automatic differentiation
 
 The scalar number system that every calculus module is generic over: the `Numeric` trait, plus
@@ -54,15 +83,15 @@ the forward-mode automatic-differentiation numbers that also implement it.
 One formula, differentiated exactly to any order:
 
 ```rust
-use multicalc::numerical_derivative::autodiff::AutoDiffSingle;
-use multicalc::numerical_derivative::derivator::DerivatorSingleVariable;
+use multicalc::AutoDiffSingle;
+use multicalc::DerivatorSingleVariable;
 use multicalc::scalar_fn;
 
 let f = scalar_fn!(|x| x * x * x);           // f(x) = x^3, evaluable at any Numeric
 let d = AutoDiffSingle::default();           // forward-mode autodiff, exact
 
-let first = d.get(1, &f, 2.0).unwrap();      // 12.0
-let third = d.get(3, &f, 2.0).unwrap();      //  6.0
+let first = d.differentiate(1, &f, 2.0).unwrap();      // 12.0
+let third = d.differentiate(3, &f, 2.0).unwrap();      //  6.0
 ```
 
 Errors: differentiation calls return [`DiffError`](#error-handling) (for example `OrderZero`).
@@ -75,18 +104,20 @@ Credits: standard forward-mode dual numbers. Full demo:
 Derivatives of any order, total and partial — exact through forward-mode autodiff, or by finite
 differences for black-box functions — plus Jacobian and Hessian matrices.
 
-- `autodiff::{AutoDiffSingle, AutoDiffMulti}`: exact derivatives.
-- `finite_difference::{FiniteDifferenceSingle, FiniteDifferenceMulti}`: for functions you
-  cannot author with `scalar_fn!`.
-- Both implement the `derivator::DerivatorSingleVariable` / `DerivatorMultiVariable` traits
-  (`get`, `get_single`, `get_double`, `get_single_partial`).
-- `jacobian::Jacobian` and `hessian::Hessian` build the matrices.
+- `derivative`, `second_derivative`, `partial`: one-call functions covering the common case. See
+  [the note on the two paths](#the-easy-path-and-the-configurable-one).
+- `AutoDiffSingle` / `AutoDiffMulti`: exact derivatives, to any order.
+- `FiniteDifferenceSingle` / `FiniteDifferenceMulti`: for functions you cannot author with
+  `scalar_fn!`.
+- Both implement the `DerivatorSingleVariable` / `DerivatorMultiVariable` traits
+  (`differentiate`, `first_derivative`, `second_derivative`, `first_partial_derivative`).
+- `Jacobian` and `Hessian` build the matrices.
 
 For several variables, the derivative order is just the number of indices you pass:
 
 ```rust
-use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
-use multicalc::numerical_derivative::derivator::DerivatorMultiVariable;
+use multicalc::AutoDiffMulti;
+use multicalc::DerivatorMultiVariable;
 use multicalc::scalar_fn;
 
 // g(x, y, z) = y*sin(x) + x*cos(y) + x*y*e^z; order = number of indices passed
@@ -94,9 +125,9 @@ let g = scalar_fn!(|v: &[f64; 3]| v[1] * v[0].sin() + v[0] * v[1].cos() + v[0] *
 let d = AutoDiffMulti::default();
 let point = [1.0, 2.0, 3.0];
 
-let dx    = d.get_single_partial(&g, 0, &point).unwrap();  // dg/dx
-let mixed = d.get(&g, &[0, 1], &point).unwrap();           // d(dg/dx)/dy
-let third = d.get(&g, &[0, 0, 1], &point).unwrap();        // d^3 g / dx^2 dy
+let dx    = d.first_partial_derivative(&g, 0, &point).unwrap();  // dg/dx
+let mixed = d.differentiate(&g, &[0, 1], &point).unwrap();           // d(dg/dx)/dy
+let third = d.differentiate(&g, &[0, 0, 1], &point).unwrap();        // d^3 g / dx^2 dy
 ```
 
 Pass a finite-difference derivator (`FiniteDifferenceSingle` / `FiniteDifferenceMulti`) instead
@@ -106,23 +137,23 @@ Write a vector-valued function with `scalar_fn_vec!` and its rows differentiate 
 to give the Jacobian; a scalar field gives the Hessian:
 
 ```rust
-use multicalc::numerical_derivative::jacobian::Jacobian;
-use multicalc::numerical_derivative::hessian::Hessian;
-use multicalc::scalar::c;
+use multicalc::Jacobian;
+use multicalc::Hessian;
+use multicalc::c;
 use multicalc::{scalar_fn, scalar_fn_vec};
 
 // the vector function (x*y*z, x^2 + y^2)
 let f = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
 let jacobian: Jacobian = Jacobian::default();
-let j = jacobian.get(&f, &[1.0, 2.0, 3.0]).unwrap();   // [[6, 3, 2], [2, 4, 0]]
+let j = jacobian.evaluate(&f, &[1.0, 2.0, 3.0]).unwrap();   // [[6, 3, 2], [2, 4, 0]]
 
 // g(x, y) = y*sin(x) + 2*x*e^y
 let g = scalar_fn!(|v: &[f64; 2]| v[1] * v[0].sin() + c(2.0) * v[0] * v[1].exp());
 let hessian: Hessian = Hessian::default();
-let h = hessian.get(&g, &[1.0, 2.0]).unwrap();
+let h = hessian.evaluate(&g, &[1.0, 2.0]).unwrap();
 ```
 
-With the `alloc` feature, `Jacobian::get_on_heap` returns a `Vec<Vec<T>>` for inputs too large
+With the `alloc` feature, `Jacobian::evaluate_on_heap` returns a `Vec<Vec<T>>` for inputs too large
 for the stack.
 
 Errors: these calls return [`DiffError`](#error-handling): `OrderZero`, `OrderUnsupported`,
@@ -136,49 +167,50 @@ and
 Definite integration of any order: iterative Newton-Cotes rules and Gaussian quadrature, over
 finite, semi-infinite, and infinite limits.
 
-- `iterative_integration::IterativeSingle`: Boole (default), Simpson, and Trapezoidal rules;
-  pick the rule and interval count with `from_parameters`.
+- `integral`: a one-call function covering the common case. See
+  [the note on the two paths](#the-easy-path-and-the-configurable-one).
+- `IterativeSingle`: Boole (default), Simpson, and Trapezoidal rules; pick the rule and interval
+  count with `from_parameters`.
 - Pairwise summation is the default; chain `.with_kahan_summation()` to opt into Kahan.
-- `gaussian_integration::GaussianSingle`: Gauss-Legendre, Gauss-Hermite, and Gauss-Laguerre.
-  Pass the **bare** integrand; the weights already carry the weighting factor.
-- Both implement the `integrator::IntegratorSingleVariable` / `MultiVariable` traits
-  (`get_single`, `get_double`, …); the rules live in `mode`.
+- `GaussianSingle`: Gauss-Legendre, Gauss-Hermite, and Gauss-Laguerre. Pass the **bare**
+  integrand; the weights already carry the weighting factor.
+- Both implement the `IntegratorSingleVariable` / `IntegratorMultiVariable` traits
+  (`integrate`, `single_integral`, `double_integral`, …).
 
 Iterative rules over finite and infinite limits:
 
 ```rust
-use multicalc::numerical_integration::integrator::IntegratorSingleVariable;
-use multicalc::numerical_integration::iterative_integration::IterativeSingle;
+use multicalc::IntegratorSingleVariable;
+use multicalc::IterativeSingle;
 
 let integrator = IterativeSingle::default();                 // Boole's rule, 120 intervals
-let area = integrator.get_single(&|x: f64| 2.0 * x, &[0.0, 2.0]).unwrap();   // 4.0
+let area = integrator.single_integral(&|x: f64| 2.0 * x, &[0.0, 2.0]).unwrap();   // 4.0
 
 // infinite / semi-infinite limits are supported for decaying integrands
 let bell = integrator
-    .get_single(&|x| (-x * x).exp(), &[f64::NEG_INFINITY, f64::INFINITY])
+    .single_integral(&|x| (-x * x).exp(), &[f64::NEG_INFINITY, f64::INFINITY])
     .unwrap();                                               // sqrt(pi)
 ```
 
 Choose the rule and interval count with `from_parameters`:
 
 ```rust
-use multicalc::numerical_integration::iterative_integration::IterativeSingle;
-use multicalc::numerical_integration::mode::IterativeMethod;
-let integrator = IterativeSingle::from_parameters(120, IterativeMethod::Simpsons);
+use multicalc::{IterativeMethod, IterativeSingle};
+let integrator: IterativeSingle = IterativeSingle::from_parameters(120, IterativeMethod::Simpsons);
 ```
 
 Each Gaussian rule integrates over a fixed domain. Pass the bare integrand `f(x)`; the weights
 already carry the weighting factor:
 
 ```rust
-use multicalc::numerical_integration::integrator::IntegratorSingleVariable;
-use multicalc::numerical_integration::gaussian_integration::GaussianSingle;
-use multicalc::numerical_integration::mode::GaussianQuadratureMethod;
+use multicalc::IntegratorSingleVariable;
+use multicalc::GaussianSingle;
+use multicalc::GaussianQuadratureMethod;
 
 // Gauss-Hermite integrates f(x) * e^(-x^2) over the whole real line.
 let hermite = GaussianSingle::from_parameters(5, GaussianQuadratureMethod::GaussHermite);
 let val = hermite
-    .get_single(&|x| x * x, &[f64::NEG_INFINITY, f64::INFINITY])
+    .single_integral(&|x| x * x, &[f64::NEG_INFINITY, f64::INFINITY])
     .unwrap();                                                // sqrt(pi)/2
 ```
 
@@ -208,7 +240,7 @@ users reach them through `GaussianSingle` rather than directly.
 
 ```rust
 use multicalc::gaussian_tables;
-use multicalc::numerical_integration::mode::GaussianQuadratureMethod;
+use multicalc::GaussianQuadratureMethod;
 
 let pairs = gaussian_tables::nodes(GaussianQuadratureMethod::GaussHermite, 5).unwrap();
 for (weight, abscissa) in pairs {
@@ -225,22 +257,22 @@ Errors: an out-of-range order returns `IntegrateError::QuadratureOrderOutOfRange
 Local Taylor models of a function around a point (linear and quadratic) with goodness-of-fit
 metrics.
 
-- `linear_approximation::LinearApproximator`: first-order model.
-- `quadratic_approximation::QuadraticApproximator`: same API, also captures curvature.
-- `get` builds the model; `predict` evaluates it; `get_prediction_metrics` returns MAE, MSE,
+- `LinearApproximator`: first-order model.
+- `QuadraticApproximator`: same API, also captures curvature.
+- `approximate` builds the model; `predict` evaluates it; `prediction_metrics` returns MAE, MSE,
   RMSE, R², and adjusted R² against sample points.
 - Metrics use pairwise summation by default; chain `.with_kahan_summation()` to opt into Kahan.
 
 ```rust
-use multicalc::approximation::linear_approximation::LinearApproximator;
+use multicalc::LinearApproximator;
 use multicalc::scalar_fn;
 
 let f = scalar_fn!(|v: &[f64; 3]| v[0] + v[1] * v[1] + v[2] * v[2] * v[2]);
 let linear: LinearApproximator = LinearApproximator::default();
-let model = linear.get(&f, &[1.0, 2.0, 3.0]).unwrap();
+let model = linear.approximate(&f, &[1.0, 2.0, 3.0]).unwrap();
 
 let y = model.predict(&[1.1, 2.1, 3.1]);
-// model.get_prediction_metrics(&samples, &f) returns RMSE, R^2, and more
+// model.prediction_metrics(&samples, &f) returns RMSE, R^2, and more
 ```
 
 `QuadraticApproximator` works the same way and captures curvature as well.
@@ -262,7 +294,7 @@ mismatch is a compile error, nothing is heap-allocated, and the math never panic
 Direct linear solves via LU and Cholesky:
 
 ```rust
-use multicalc::linear_algebra::{Matrix, Vector};
+use multicalc::{Matrix, Vector};
 
 // Solve A·x = b.
 let a = Matrix::<3, 3>::new([[2.0, 1.0, 1.0], [4.0, 3.0, 3.0], [8.0, 7.0, 9.0]]);
@@ -282,7 +314,7 @@ The singular value decomposition (one-sided Jacobi) gives the pseudo-inverse, mi
 least-squares solve, rank, and condition number for any shape:
 
 ```rust
-use multicalc::linear_algebra::{Matrix, Vector};
+use multicalc::{Matrix, Vector};
 
 // Thin SVD of a tall matrix: A = U · diag(σ) · Vᵀ.
 let a = Matrix::<3, 2>::new([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]);
@@ -300,7 +332,8 @@ let x = svd.solve(Vector::new([1.0, 2.0, 3.0]));
 For an overdetermined linear least-squares fit, use the column-pivoted QR directly:
 
 ```rust
-use multicalc::linear_algebra::{Matrix, PivotedQr, Vector};
+use multicalc::linear_algebra::PivotedQr;
+use multicalc::{Matrix, Vector};
 
 // Least-squares fit of y = a + b*t through (0, 1), (1, 3), (2, 5): a = 1, b = 2.
 let a = Matrix::<3, 2>::new([[1.0, 0.0], [1.0, 1.0], [1.0, 2.0]]);
@@ -333,9 +366,9 @@ Write the residuals `model - data` with `scalar_fn_vec!` and the solver differen
 under autodiff:
 
 ```rust
-use multicalc::optimization::LevenbergMarquardt;
-use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
-use multicalc::scalar::c;
+use multicalc::LevenbergMarquardt;
+use multicalc::AutoDiffMulti;
+use multicalc::c;
 use multicalc::scalar_fn_vec;
 
 // Fit a*e^(b*t) to (0, 100), (1, 50), (2, 25): the minimum is a = 100, b = -ln 2.
@@ -380,9 +413,9 @@ budget and reports why it stopped as a `RootTermination`.
 - The scalar solvers return a `RootReport`; the system solver returns a `RootReportN`.
 
 ```rust
-use multicalc::root_finding::{Bisection, Newton, NewtonSystem};
-use multicalc::numerical_derivative::autodiff::{AutoDiffMulti, AutoDiffSingle};
-use multicalc::scalar::c;
+use multicalc::{Bisection, Newton, NewtonSystem};
+use multicalc::{AutoDiffMulti, AutoDiffSingle};
+use multicalc::c;
 use multicalc::{scalar_fn, scalar_fn_vec};
 
 // Bracket a scalar root: f(x) = x^2 - 2 on [0, 2].
@@ -414,28 +447,28 @@ solve and overflow-safe `enorm` from [Linear algebra](#linear-algebra). Full dem
 
 Curl and divergence via autodiff, plus line and flux integrals sampled along a curve.
 
-- `curl::{get_2d, get_3d}` and `divergence::{get_2d, get_3d}` take an explicit derivator (pass
+- `curl_2d` / `curl_3d` and `divergence_2d` / `divergence_3d` take an explicit derivator (pass
   `AutoDiffMulti::default()` for exact results) and a `scalar_fn_vec!` field.
-- `line_integral` and `flux_integral` sample the field, so they take plain closures for the
-  field and the parametric curve.
+- `line_integral_2d` and `flux_integral_2d`, with their 3D and `_custom` forms, sample the field,
+  so they take plain closures for the field and the parametric curve.
 
 ```rust
-use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
-use multicalc::scalar::c;
+use multicalc::AutoDiffMulti;
+use multicalc::c;
 use multicalc::scalar_fn_vec;
-use multicalc::vector_field::{curl, divergence, line_integral, flux_integral};
+use multicalc::vector_field::{curl_2d, divergence_2d, flux_integral_2d, line_integral_2d};
 
 // field (2xy, 3cos y)
 let field = scalar_fn_vec!(|v: &[f64; 2]| [c(2.0) * v[0] * v[1], c(3.0) * v[1].cos()]);
-let curl_2d = curl::get_2d(AutoDiffMulti::default(), &field, &[1.0, 3.14]).unwrap();
-let div_2d = divergence::get_2d(AutoDiffMulti::default(), &field, &[1.0, 3.14]).unwrap();
+let curl = curl_2d(AutoDiffMulti::default(), &field, &[1.0, 3.14]).unwrap();
+let divergence = divergence_2d(AutoDiffMulti::default(), &field, &[1.0, 3.14]).unwrap();
 
 // field (y, -x) along the unit circle (cos t, sin t)
 let g: [&dyn Fn(&[f64; 2]) -> f64; 2] = [&(|v: &[f64; 2]| v[1]), &(|v: &[f64; 2]| -v[0])];
 let curve: [&dyn Fn(f64) -> f64; 2] = [&(|t: f64| t.cos()), &(|t: f64| t.sin())];
 let limit = [0.0, 2.0 * std::f64::consts::PI];
-let line = line_integral::get_2d(&g, &curve, &limit).unwrap();   // -2*pi
-let flux = flux_integral::get_2d(&g, &curve, &limit).unwrap();   //  0
+let line = line_integral_2d(&g, &curve, &limit).unwrap();   // -2*pi
+let flux = flux_integral_2d(&g, &curve, &limit).unwrap();   //  0
 ```
 
 The 3D curl is `(dVz/dy - dVy/dz, dVx/dz - dVz/dx, dVy/dx - dVx/dy)`.
@@ -456,8 +489,8 @@ Initial-value solvers for `y' = f(t, y)` systems, generic over the state dimensi
   and `with_atol`.
 
 ```rust
-use multicalc::ode::{Rk4, Rk45};
-use multicalc::linear_algebra::Vector;
+use multicalc::{Rk4, Rk45};
+use multicalc::Vector;
 
 // Harmonic oscillator y'' = -y as the first-order system [position, velocity].
 let f = |_t: f64, y: &Vector<2, f64>| Vector::new([y[1], -y[0]]);
@@ -474,8 +507,8 @@ Dense output samples a whole grid in one pass, and `for_each_step` lets you trac
 quantity as the solver runs:
 
 ```rust
-use multicalc::ode::Rk45;
-use multicalc::linear_algebra::Vector;
+use multicalc::Rk45;
+use multicalc::Vector;
 
 let f = |_t: f64, y: &Vector<2, f64>| Vector::new([y[1], -y[0]]);
 let y0 = Vector::new([1.0, 0.0]);
@@ -504,9 +537,9 @@ Because the routines run through the matrix exponential, an autodiff scalar flow
 through them: a single `Dual` recovers a derivative with respect to a parameter.
 
 ```rust
-use multicalc::discretization::{q_discrete_white_noise, van_loan, zoh};
-use multicalc::linear_algebra::Matrix;
-use multicalc::scalar::Dual;
+use multicalc::{q_discrete_white_noise, van_loan, zoh};
+use multicalc::Matrix;
+use multicalc::Dual;
 
 let dt = 0.1;
 
@@ -554,8 +587,8 @@ ordering is `[v; ω]` (linear part first) for `SE2`/`SE3`; the retract is right-
 finite at rest.
 
 ```rust
-use multicalc::spatial::{SE3, SO3};
-use multicalc::linear_algebra::Vector;
+use multicalc::{SE3, SO3};
+use multicalc::Vector;
 
 // A 90° rotation about z, applied to a point.
 let r = SO3::<f64>::exp(Vector::new([0.0, 0.0, core::f64::consts::FRAC_PI_2]));
@@ -598,9 +631,10 @@ are exact identities. There is no lateral term to silently drop.
 - `OdometryStep`: the process model as a `VectorFn`, for autodiff Jacobians.
 
 ```rust
-use multicalc::kinematics::{BodyTwist, DifferentialDrive, WheelVelocities, integrate};
-use multicalc::scalar::Dual;
-use multicalc::spatial::SE2;
+use multicalc::kinematics::integrate;
+use multicalc::{BodyTwist, DifferentialDrive, WheelVelocities};
+use multicalc::Dual;
+use multicalc::SE2;
 
 // Geometry: a 36 mm wheel radius and a 235 mm track width.
 let dd = DifferentialDrive::new(0.036_f64, 0.235).unwrap();
@@ -652,9 +686,9 @@ and every call after that is total.
   so the working buffer is stack-allocated and the beam geometry is fixed at compile time.
 
 ```rust
-use multicalc::control::{FollowTheGap, Pid, pure_pursuit_curvature};
-use multicalc::linear_algebra::Vector;
-use multicalc::spatial::SE2;
+use multicalc::{FollowTheGap, Pid, pure_pursuit_curvature};
+use multicalc::Vector;
+use multicalc::SE2;
 
 // A speed loop: PID on the forward speed, output limited, derivative filtered.
 let mut speed_loop = Pid::new(2.0_f64, 1.0, 0.05, 0.01)
@@ -731,8 +765,8 @@ the path, and what point should I aim at.
   the default) or `Loop` (wrap to the start). Set it with `with_end_of_path`.
 
 ```rust
-use multicalc::motion::{EndOfPath, PolylinePath};
-use multicalc::linear_algebra::Vector;
+use multicalc::{EndOfPath, PolylinePath};
+use multicalc::Vector;
 
 // An L-shaped path: three units east, then four units north.
 let path: PolylinePath<3, 2, f64> = PolylinePath::try_from_points(&[
@@ -782,8 +816,8 @@ a measurement and shrinks it. Fixed-size, no allocation, and generic over the `N
   changing timestep changes the model between steps.
 
 ```rust
-use multicalc::estimation::{KalmanFilter, KalmanModel};
-use multicalc::linear_algebra::{Matrix, Vector};
+use multicalc::{KalmanFilter, KalmanModel};
+use multicalc::{Matrix, Vector};
 
 // Constant velocity: position integrates velocity over a 1 s step; position is measured.
 let mut filter = KalmanFilter::new(
@@ -837,9 +871,9 @@ of silent estimator bugs.
   reachable only with a finite-difference backend, as the autodiff default cannot.
 
 ```rust
-use multicalc::estimation::ExtendedKalmanFilter;
-use multicalc::linear_algebra::{Matrix, Vector};
-use multicalc::scalar::{Numeric, VectorFn};
+use multicalc::ExtendedKalmanFilter;
+use multicalc::{Matrix, Vector};
+use multicalc::{Numeric, VectorFn};
 
 // Range to a landmark at (3, 4): nonlinear in the pose, so the linear filter cannot take it.
 struct RangeToLandmark;
@@ -893,9 +927,9 @@ the price is running hundreds to thousands of samples every step.
   and `weights`.
 
 ```rust
-# use multicalc::estimation::{GaussianLikelihood, ParticleFilter};
-# use multicalc::linear_algebra::{Matrix, Vector};
-# use multicalc::scalar::{Numeric, VectorFn};
+# use multicalc::{GaussianLikelihood, ParticleFilter};
+# use multicalc::{Matrix, Vector};
+# use multicalc::{Numeric, VectorFn};
 // A stationary 2-D point, measured directly with a little noise.
 struct Stationary;
 impl VectorFn<2, 2> for Stationary {
@@ -943,7 +977,7 @@ sensor models, and Monte-Carlo checks need the same thing.
   a seeded simulation repeatable. Not for cryptography.
 
 ```rust
-use multicalc::random::{Pcg32, RandomSource};
+use multicalc::{Pcg32, RandomSource};
 
 let mut generator = Pcg32::new(20260722);
 
@@ -983,14 +1017,32 @@ are reachable through `core::error::Error::source`. Convert up to the umbrella w
 `.into()`:
 
 ```rust
-use multicalc::error::{CalcError, LinalgError};
+use multicalc::{CalcError, Matrix, Vector};
 
+// One return type covers a function that mixes modules: each `?` converts the module's own
+// error into the umbrella on its way out.
 fn solve() -> Result<(), CalcError> {
-    let err: Result<(), LinalgError> = Err(LinalgError::Singular);
-    err?;            // LinalgError -> CalcError via From
+    let a = Matrix::new([[2.0, 1.0, 1.0], [4.0, 3.0, 3.0], [8.0, 7.0, 9.0]]);
+    let b = Vector::new([7.0, 19.0, 49.0]);
+
+    let x = a.lu()?.solve(b);          // LinalgError -> CalcError
+    assert!((a * x - b).norm() < 1e-9);
+
+    // A singular matrix returns `LinalgError::Singular` here rather than panicking.
+    let singular = Matrix::<3, 3>::zeros();
+    assert!(singular.lu().is_err());
+
     Ok(())
 }
+# solve().unwrap();
 ```
+
+This is the shape the converted demos use — see
+[linear_algebra.rs](https://github.com/kmolan/multicalc-rust/blob/main/demos/examples/basics/linear_algebra.rs),
+[root_finding.rs](https://github.com/kmolan/multicalc-rust/blob/main/demos/examples/basics/root_finding.rs),
+and
+[estimation.rs](https://github.com/kmolan/multicalc-rust/blob/main/demos/examples/basics/estimation.rs),
+each of which returns `Result<(), CalcError>` from `main` and propagates with `?`.
 
 ## Internals
 

--- a/crates/multicalc/README.md
+++ b/crates/multicalc/README.md
@@ -69,20 +69,20 @@ expected outputs in comments, error-path notes, and pointers to runnable demos. 
 One formula, differentiated to any order by forward-mode autodiff:
 
 ```rust
-use multicalc::numerical_derivative::autodiff::{AutoDiffSingle, AutoDiffMulti};
-use multicalc::numerical_derivative::derivator::{DerivatorSingleVariable, DerivatorMultiVariable};
+use multicalc::numerical_derivative::{AutoDiffSingle, AutoDiffMulti};
+use multicalc::numerical_derivative::{DerivatorSingleVariable, DerivatorMultiVariable};
 use multicalc::scalar_fn;
 
 let f = scalar_fn!(|x| x * x * x);           // f(x) = x^3
 let d = AutoDiffSingle::default();           // forward-mode autodiff, exact
-let first = d.get(1, &f, 2.0).unwrap();      // 12.0
-let third = d.get(3, &f, 2.0).unwrap();      //  6.0
+let first = d.differentiate(1, &f, 2.0).unwrap();      // 12.0
+let third = d.differentiate(3, &f, 2.0).unwrap();      //  6.0
 
 // Partial derivatives of a multivariable function; order = number of indices.
 let g = scalar_fn!(|v: &[f64; 2]| v[0] * v[0] * v[1]);          // g(x, y) = x^2 * y
 let dm = AutoDiffMulti::default();
-let dx    = dm.get_single_partial(&g, 0, &[3.0, 4.0]).unwrap(); // dg/dx = 2xy   = 24.0
-let mixed = dm.get(&g, &[0, 1], &[3.0, 4.0]).unwrap();          // d^2g/dxdy = 2x =  6.0
+let dx    = dm.first_partial_derivative(&g, 0, &[3.0, 4.0]).unwrap(); // dg/dx = 2xy   = 24.0
+let mixed = dm.differentiate(&g, &[0, 1], &[3.0, 4.0]).unwrap();          // d^2g/dxdy = 2x =  6.0
 ```
 
 ### Integration
@@ -90,23 +90,23 @@ let mixed = dm.get(&g, &[0, 1], &[3.0, 4.0]).unwrap();          // d^2g/dxdy = 2
 Newton-Cotes and Gaussian rules over finite, semi-infinite, and infinite limits:
 
 ```rust
-use multicalc::numerical_integration::integrator::IntegratorSingleVariable;
-use multicalc::numerical_integration::iterative_integration::IterativeSingle;
-use multicalc::numerical_integration::gaussian_integration::GaussianSingle;
-use multicalc::numerical_integration::mode::GaussianQuadratureMethod;
+use multicalc::numerical_integration::IntegratorSingleVariable;
+use multicalc::numerical_integration::IterativeSingle;
+use multicalc::numerical_integration::GaussianSingle;
+use multicalc::numerical_integration::GaussianQuadratureMethod;
 
 let integrator = IterativeSingle::default();     // Boole's rule, 120 intervals
 
-let area = integrator.get_single(&|x: f64| 2.0 * x, &[0.0, 2.0]).unwrap();       // 2x on [0, 2]        -> 4.0
+let area = integrator.single_integral(&|x: f64| 2.0 * x, &[0.0, 2.0]).unwrap();       // 2x on [0, 2]        -> 4.0
 // decaying integrands may run to a semi-infinite or infinite limit
-let tail = integrator.get_single(&|x: f64| (-x).exp(), &[0.0, f64::INFINITY]).unwrap();  // e^-x on [0, inf)  -> 1.0
+let tail = integrator.single_integral(&|x: f64| (-x).exp(), &[0.0, f64::INFINITY]).unwrap();  // e^-x on [0, inf)  -> 1.0
 let bell = integrator
-    .get_single(&|x: f64| (-x * x).exp(), &[f64::NEG_INFINITY, f64::INFINITY])
+    .single_integral(&|x: f64| (-x * x).exp(), &[f64::NEG_INFINITY, f64::INFINITY])
     .unwrap();                                                                   // e^(-x^2) on R       -> sqrt(pi)
 
 // Gauss-Hermite already carries the e^(-x^2) weight, so pass the bare integrand.
 let gh = GaussianSingle::from_parameters(5, GaussianQuadratureMethod::GaussHermite);
-let moment = gh.get_single(&|x: f64| x * x, &[f64::NEG_INFINITY, f64::INFINITY]).unwrap();  // x^2, weight e^(-x^2) -> sqrt(pi)/2
+let moment = gh.single_integral(&|x: f64| x * x, &[f64::NEG_INFINITY, f64::INFINITY]).unwrap();  // x^2, weight e^(-x^2) -> sqrt(pi)/2
 ```
 
 ### Nonlinear curve fitting
@@ -116,7 +116,7 @@ them under autodiff and drives the fit:
 
 ```rust
 use multicalc::optimization::LevenbergMarquardt;
-use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+use multicalc::numerical_derivative::AutoDiffMulti;
 use multicalc::scalar::c;
 use multicalc::scalar_fn_vec;
 
@@ -202,7 +202,7 @@ Scalar equations and square systems `F(x) = 0`, with exact autodiff derivatives:
 
 ```rust
 use multicalc::root_finding::{Bisection, Newton, NewtonSystem};
-use multicalc::numerical_derivative::autodiff::{AutoDiffMulti, AutoDiffSingle};
+use multicalc::numerical_derivative::{AutoDiffMulti, AutoDiffSingle};
 use multicalc::scalar::c;
 use multicalc::{scalar_fn, scalar_fn_vec};
 

--- a/crates/multicalc/README.md
+++ b/crates/multicalc/README.md
@@ -62,15 +62,104 @@ No heap, no panics, no `unsafe` - from a 64-bit server down to a bare-metal micr
 The [guide](https://github.com/kmolan/multicalc-rust/blob/main/crates/multicalc/GUIDE.md) is a comprehensive tutorial for each module. It shows the full imports,
 expected outputs in comments, error-path notes, and pointers to runnable demos. Start there when you need the complete picture of a feature.
 
+## Quick start
+
+Two formulas, written once, carried through six modules — each step feeding the next:
+
+```rust
+use multicalc::prelude::*;
+use multicalc::{Hessian, Jacobian, KalmanFilter, KalmanModel, Matrix, Newton, SE3, SO3, Vector, c};
+use multicalc::{scalar_fn, scalar_fn_vec};
+
+fn main() -> Result<(), CalcError> {
+    // Written once, evaluated at f64 here and at an autodiff number wherever a derivative is asked
+    // for — the formula text never changes.
+    let f = scalar_fn!(|x| x * x * x - c(2.0) * x);                     // f(x)    = x³ - 2x
+    let g = scalar_fn!(|v: &[f64; 2]| v[0] * v[0] * v[1] + v[0].sin()); // g(x, y) = x²y + sin x
+
+    // Derivatives — exact, by forward-mode autodiff. No step size, no truncation error.
+    let slope = derivative(&f, 2.0_f64);                     // f'(2)  = 10
+    let bend = second_derivative(&f, 2.0_f64);               // f''(2) = 12
+    let dg_dx = partial(&g, 0, &[1.0_f64, 2.0])?;            // ∂g/∂x at (1, 2)
+
+    // The derivative matrices of those same two formulas.
+    let hessian = Hessian::new().evaluate(&g, &[1.0, 2.0])?;            // 2x2 second derivatives
+    let both = scalar_fn_vec!(|v: &[f64; 2]| [
+        v[0] * v[0] * v[1] + v[0].sin(),
+        v[0] * v[0] * v[0] - c(2.0) * v[0],
+    ]);
+    let jacobian = Jacobian::new().evaluate(&both, &[1.0, 2.0])?;       // 2x2 first derivatives
+
+    // Integration — f again, this time over an interval.
+    let area = integral(&|x: f64| f.eval(x), [0.0, 2.0])?;   // ∫₀² f = 0
+
+    // Linear algebra — solve H·x = b with the Hessian computed three lines up.
+    let x = hessian.solve(Vector::new([1.0, 2.0]))?;
+
+    // Root finding — Newton on the same f, its derivative supplied by autodiff.
+    let root = Newton::new().solve(&f, 2.0)?.root;           // √2 ≈ 1.41421356
+
+    // Rigid-body motion — SO(3)/SE(3), generic over the scalar like everything above.
+    let turn = SO3::exp(Vector::new([0.0, 0.0, core::f64::consts::FRAC_PI_2]));  // 90° about z
+    let pose = SE3::from_parts(turn, Vector::new([1.0, 2.0, 3.0]));
+    let moved = pose.act(Vector::new([1.0, 0.0, 0.0]));      // rotate, then translate → (1, 3, 3)
+
+    // Estimation — a Kalman filter recovering the velocity it never measures.
+    let mut filter = KalmanFilter::new(
+        Vector::new([0.0, 0.0]),                 // initial state [position, velocity]
+        Matrix::new([[1.0, 0.0], [0.0, 1.0]]),   // initial covariance
+        KalmanModel {
+            state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
+            measurement_model: Matrix::new([[1.0, 0.0]]),    // position only
+            process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
+            measurement_noise: Matrix::new([[0.1]]),
+        },
+    );
+    filter.predict();
+    filter.update(Vector::new([1.0]))?;          // the target moved about 1 m
+    let velocity = filter.state()[1];            // recovered, though never measured
+
+    Ok(())
+}
+```
+
+Every fallible call propagates with `?`: each module has its own error enum, and all of them
+convert into the `CalcError` umbrella, so one return type covers a program that mixes modules.
+
+Import with `use multicalc::prelude::*;` for the traits and one-call functions, plus the types you
+need from the crate root.
+
+**Two ways in, throughout the crate.** The one-call functions — `derivative`, `second_derivative`,
+`partial`, `integral` — need no imported trait and no configuration, and use exact automatic
+differentiation. The strategy objects — `AutoDiffSingle`, `FiniteDifferenceSingle`,
+`IterativeSingle`, `GaussianSingle` — are how you choose a different method, a step size, an
+iteration count, or a derivative order above the second. Both compute the same answers.
+
 ## Example snippets
 
 ### Exact derivatives
 
-One formula, differentiated to any order by forward-mode autodiff:
+The short way, and the configurable way when you need a third derivative:
 
 ```rust
-use multicalc::numerical_derivative::{AutoDiffSingle, AutoDiffMulti};
-use multicalc::numerical_derivative::{DerivatorSingleVariable, DerivatorMultiVariable};
+use multicalc::{derivative, second_derivative, partial};
+use multicalc::scalar_fn;
+
+let f = scalar_fn!(|x| x * x * x);                       // f(x) = x^3
+let first = derivative(&f, 2.0_f64);                     // 12.0
+let second = second_derivative(&f, 2.0_f64);             // 12.0
+
+// One partial of a multivariable function, by variable index.
+let g = scalar_fn!(|v: &[f64; 2]| v[0] * v[0] * v[1]);   // g(x, y) = x^2 * y
+let dx = partial(&g, 0, &[3.0_f64, 4.0])?;               // dg/dx = 2xy = 24.0
+# Ok::<(), multicalc::DiffError>(())
+```
+
+Any order, and mixed partials, through the autodiff objects:
+
+```rust
+use multicalc::{AutoDiffSingle, AutoDiffMulti};
+use multicalc::{DerivatorSingleVariable, DerivatorMultiVariable};
 use multicalc::scalar_fn;
 
 let f = scalar_fn!(|x| x * x * x);           // f(x) = x^3
@@ -90,10 +179,10 @@ let mixed = dm.differentiate(&g, &[0, 1], &[3.0, 4.0]).unwrap();          // d^2
 Newton-Cotes and Gaussian rules over finite, semi-infinite, and infinite limits:
 
 ```rust
-use multicalc::numerical_integration::IntegratorSingleVariable;
-use multicalc::numerical_integration::IterativeSingle;
-use multicalc::numerical_integration::GaussianSingle;
-use multicalc::numerical_integration::GaussianQuadratureMethod;
+use multicalc::IntegratorSingleVariable;
+use multicalc::IterativeSingle;
+use multicalc::GaussianSingle;
+use multicalc::GaussianQuadratureMethod;
 
 let integrator = IterativeSingle::default();     // Boole's rule, 120 intervals
 
@@ -115,9 +204,9 @@ Author the residuals `model - data` with `scalar_fn_vec!`; `LevenbergMarquardt` 
 them under autodiff and drives the fit:
 
 ```rust
-use multicalc::optimization::LevenbergMarquardt;
-use multicalc::numerical_derivative::AutoDiffMulti;
-use multicalc::scalar::c;
+use multicalc::LevenbergMarquardt;
+use multicalc::AutoDiffMulti;
+use multicalc::c;
 use multicalc::scalar_fn_vec;
 
 // Fit a*e^(b*t) to (0, 100), (1, 50), (2, 25): the minimum is a = 100, b = -ln 2.
@@ -138,7 +227,7 @@ Fixed-size `Matrix` and `Vector` with dimensions as const generics (shape mismat
 compile errors):
 
 ```rust
-use multicalc::linear_algebra::{Matrix, Vector};
+use multicalc::{Matrix, Vector};
 
 // Solve A·x = b.
 let a = Matrix::<3, 3>::new([[2.0, 1.0, 1.0], [4.0, 3.0, 3.0], [8.0, 7.0, 9.0]]);
@@ -156,8 +245,8 @@ let s_inv = s.cholesky().unwrap().inverse();
 flows straight through:
 
 ```rust
-use multicalc::spatial::{SE3, SO3};
-use multicalc::linear_algebra::Vector;
+use multicalc::{SE3, SO3};
+use multicalc::Vector;
 
 let r = SO3::<f64>::exp(Vector::new([0.0, 0.0, core::f64::consts::FRAC_PI_2])); // 90° about z
 let g = SE3::from_parts(r, Vector::new([1.0, 2.0, 3.0]));
@@ -167,33 +256,32 @@ let xi = g.log();                              // 6-vector twist [v; ω]
 
 ### Tracking a robot's state
 
-A Kalman filter recovers what you never measure directly — here velocity, from position alone.
 `ExtendedKalmanFilter` takes its process and measurement models as functions instead of matrices and
 re-linearizes them each step, with the Jacobians coming from autodiff, so a nonlinear model needs no
-hand-derived matrices:
+hand-derived matrices. The linear filter from [Quick start](#quick-start) also reports how
+surprising each measurement was, which is how you reject an outlier before folding it in:
 
 ```rust
-use multicalc::estimation::{KalmanFilter, KalmanModel};
-use multicalc::linear_algebra::{Matrix, Vector};
+use multicalc::{CovarianceUpdate, KalmanFilter, KalmanModel, Matrix, Vector};
 
-// Constant velocity: position integrates velocity over a 1 s step, and only position is measured.
 let mut filter = KalmanFilter::new(
-    Vector::new([0.0, 0.0]),                    // initial state [position, velocity]
-    Matrix::new([[1.0, 0.0], [0.0, 1.0]]),      // initial covariance
+    Vector::new([0.0, 0.0]),
+    Matrix::new([[1.0, 0.0], [0.0, 1.0]]),
     KalmanModel {
         state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
-        measurement_model: Matrix::new([[1.0, 0.0]]),   // position only
+        measurement_model: Matrix::new([[1.0, 0.0]]),
         process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
         measurement_noise: Matrix::new([[0.1]]),
     },
-);
+)
+.with_covariance_update(CovarianceUpdate::Joseph);   // the default; symmetric by construction
 
 filter.predict();
-filter.update(Vector::new([1.0])).unwrap();     // the target moved about 1 m
-let velocity = filter.state()[1];               // recovered, though never measured
+filter.update(Vector::new([1.0]))?;
 
-// Gate an outlier before folding it in.
-let gate = filter.normalized_innovation_squared().unwrap();
+// How far the measurement fell from the prediction, in units of its own uncertainty.
+let gate = filter.normalized_innovation_squared()?;
+# Ok::<(), multicalc::EstimationError>(())
 ```
 
 ### Root finding
@@ -201,9 +289,9 @@ let gate = filter.normalized_innovation_squared().unwrap();
 Scalar equations and square systems `F(x) = 0`, with exact autodiff derivatives:
 
 ```rust
-use multicalc::root_finding::{Bisection, Newton, NewtonSystem};
-use multicalc::numerical_derivative::{AutoDiffMulti, AutoDiffSingle};
-use multicalc::scalar::c;
+use multicalc::{Bisection, Newton, NewtonSystem};
+use multicalc::{AutoDiffMulti, AutoDiffSingle};
+use multicalc::c;
 use multicalc::{scalar_fn, scalar_fn_vec};
 
 let f = scalar_fn!(|x| c(-2.0) + x * x);       // f(x) = x^2 - 2, root at sqrt(2)
@@ -221,8 +309,8 @@ let solved = NewtonSystem::<AutoDiffMulti>::default().solve(&system, &[1.5, 0.8]
 Initial-value solvers for `y' = f(t, y)` systems, generic over the state dimension:
 
 ```rust
-use multicalc::ode::{Rk4, Rk45};
-use multicalc::linear_algebra::Vector;
+use multicalc::{Rk4, Rk45};
+use multicalc::Vector;
 
 // Harmonic oscillator y'' = -y as the first-order system [position, velocity].
 let f = |_t: f64, y: &Vector<2, f64>| Vector::new([y[1], -y[0]]);

--- a/crates/multicalc/README.md
+++ b/crates/multicalc/README.md
@@ -6,16 +6,12 @@
 [![Docs](https://docs.rs/multicalc/badge.svg)](https://docs.rs/multicalc)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
-**Scientific math for real-time embedded systems, in `no_std` stable Rust with near-zero dependencies: state
-estimation, control, kinematics, and Lie groups on a calculus, autodiff, and linear-algebra core in one integrated package.
-No heap, no panics, no `unsafe` - from a 64-bit server down to a bare-metal microcontroller.**
+**Scientific computing that fits on a microcontroller, built and tested from scratch in one integrated package. Estimation, control, kinematics, Lie groups, calculus, autodiff and linear algebra in stable no_std Rust with
+no heap, no panics and no unsafe. Run the same code on your laptop and your Cortex-M0.**
 
 ## Why use it
 
-- **1 kHz loop rate.** The lead showcase localizes a differential-drive
-  robot against a known map with a 2,000-particle filter over 61 noisy lidar beams, then runs a
-  5-state extended Kalman filter fusing 100 Hz wheel odometry, a 200 Hz IMU, and 20 Hz GPS while a
-  Follow-the-Gap controller laps a course of obstacles — predict, fuse, and plan every millisecond.
+- **1 kHz loop rates:** No heap, fixed-size types, bounded work per call. Results in a full robotics control loop at 1 kHz.
 - **Exercise the same math from a server to a microcontroller.** Every commit is built and tested on **six targets**:
   the `x86_64` and `aarch64` Linux hosts and on four bare-metal ABIs (`thumbv7em` soft-float,
   `thumbv7em` hardware-FPU, `thumbv6m`, and `riscv32imc`), running the real math under QEMU.
@@ -57,11 +53,6 @@ No heap, no panics, no `unsafe` - from a 64-bit server down to a bare-metal micr
 - [Approximation](https://github.com/kmolan/multicalc-rust/blob/main/crates/multicalc/GUIDE.md#taylor-approximation): linear and quadratic Taylor models with goodness-of-fit metrics.
 - [Random](https://github.com/kmolan/multicalc-rust/blob/main/crates/multicalc/GUIDE.md#random): `Pcg32` and the `RandomSource` trait, a seedable `no_std` generator for the particle filter and for stochastic models.
 
-## Tutorial
-
-The [guide](https://github.com/kmolan/multicalc-rust/blob/main/crates/multicalc/GUIDE.md) is a comprehensive tutorial for each module. It shows the full imports,
-expected outputs in comments, error-path notes, and pointers to runnable demos. Start there when you need the complete picture of a feature.
-
 ## Quick start
 
 Two formulas, written once, carried through six modules — each step feeding the next:
@@ -78,46 +69,58 @@ fn main() -> Result<(), CalcError> {
     let g = scalar_fn!(|v: &[f64; 2]| v[0] * v[0] * v[1] + v[0].sin()); // g(x, y) = x²y + sin x
 
     // Derivatives — exact, by forward-mode autodiff. No step size, no truncation error.
-    let slope = derivative(&f, 2.0_f64);                     // f'(2)  = 10
-    let bend = second_derivative(&f, 2.0_f64);               // f''(2) = 12
-    let dg_dx = partial(&g, 0, &[1.0_f64, 2.0])?;            // ∂g/∂x at (1, 2)
+    let single_point = 2.0_f64;
+    let slope = derivative(&f, single_point);                // f'(2)  = 10
+    let bend = second_derivative(&f, single_point);          // f''(2) = 12
+
+    let point = [1.0_f64, 2.0];
+    let x_index = 0;
+    let dg_dx = partial(&g, x_index, &point)?;
 
     // The derivative matrices of those same two formulas.
-    let hessian = Hessian::new().evaluate(&g, &[1.0, 2.0])?;            // 2x2 second derivatives
+    let hessian = Hessian::new().evaluate(&g, &point)?;      // 2x2 second derivatives
     let both = scalar_fn_vec!(|v: &[f64; 2]| [
         v[0] * v[0] * v[1] + v[0].sin(),
         v[0] * v[0] * v[0] - c(2.0) * v[0],
     ]);
-    let jacobian = Jacobian::new().evaluate(&both, &[1.0, 2.0])?;       // 2x2 first derivatives
+    let jacobian = Jacobian::new().evaluate(&both, &point)?; // 2x2 first derivatives
 
     // Integration — f again, this time over an interval.
-    let area = integral(&|x: f64| f.eval(x), [0.0, 2.0])?;   // ∫₀² f = 0
+    let limits = [0.0, 2.0];
+    let area = integral(&|x: f64| f.eval(x), limits)?;       // ∫₀² f = 0
 
     // Linear algebra — solve H·x = b with the Hessian computed three lines up.
-    let x = hessian.solve(Vector::new([1.0, 2.0]))?;
+    let b = Vector::new([1.0, 2.0]);
+    let x = hessian.solve(b)?;
 
     // Root finding — Newton on the same f, its derivative supplied by autodiff.
-    let root = Newton::new().solve(&f, 2.0)?.root;           // √2 ≈ 1.41421356
+    let initial_guess = 2.0;
+    let root = Newton::new().solve(&f, initial_guess)?.root; // √2 ≈ 1.41421356
 
     // Rigid-body motion — SO(3)/SE(3), generic over the scalar like everything above.
-    let turn = SO3::exp(Vector::new([0.0, 0.0, core::f64::consts::FRAC_PI_2]));  // 90° about z
-    let pose = SE3::from_parts(turn, Vector::new([1.0, 2.0, 3.0]));
-    let moved = pose.act(Vector::new([1.0, 0.0, 0.0]));      // rotate, then translate → (1, 3, 3)
+    let quarter_turn_about_z = Vector::new([0.0, 0.0, core::f64::consts::FRAC_PI_2]);
+    let translation = Vector::new([1.0, 2.0, 3.0]);
+    let start = Vector::new([1.0, 0.0, 0.0]);
+
+    let pose = SE3::from_parts(SO3::exp(quarter_turn_about_z), translation);
+    let moved = pose.act(start);                  // rotate, then translate → (1, 3, 3)
 
     // Estimation — a Kalman filter recovering the velocity it never measures.
-    let mut filter = KalmanFilter::new(
-        Vector::new([0.0, 0.0]),                 // initial state [position, velocity]
-        Matrix::new([[1.0, 0.0], [0.0, 1.0]]),   // initial covariance
-        KalmanModel {
-            state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
-            measurement_model: Matrix::new([[1.0, 0.0]]),    // position only
-            process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
-            measurement_noise: Matrix::new([[0.1]]),
-        },
-    );
+    let initial_state = Vector::new([0.0, 0.0]);  // [position, velocity]
+    let initial_covariance = Matrix::new([[1.0, 0.0], [0.0, 1.0]]);
+    let model = KalmanModel {
+        state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
+        measurement_model: Matrix::new([[1.0, 0.0]]),        // position only
+        process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
+        measurement_noise: Matrix::new([[0.1]]),
+    };
+
+    let mut filter = KalmanFilter::new(initial_state, initial_covariance, model);
     filter.predict();
-    filter.update(Vector::new([1.0]))?;          // the target moved about 1 m
-    let velocity = filter.state()[1];            // recovered, though never measured
+
+    let measurement = Vector::new([1.0]);         // the target moved about 1 m
+    filter.update(measurement)?;
+    let velocity = filter.state()[1];             // recovered, though never measured
 
     Ok(())
 }
@@ -126,214 +129,14 @@ fn main() -> Result<(), CalcError> {
 Every fallible call propagates with `?`: each module has its own error enum, and all of them
 convert into the `CalcError` umbrella, so one return type covers a program that mixes modules.
 
-Import with `use multicalc::prelude::*;` for the traits and one-call functions, plus the types you
-need from the crate root.
+## Full tutorial
 
-**Two ways in, throughout the crate.** The one-call functions — `derivative`, `second_derivative`,
-`partial`, `integral` — need no imported trait and no configuration, and use exact automatic
-differentiation. The strategy objects — `AutoDiffSingle`, `FiniteDifferenceSingle`,
-`IterativeSingle`, `GaussianSingle` — are how you choose a different method, a step size, an
-iteration count, or a derivative order above the second. Both compute the same answers.
-
-## Example snippets
-
-### Exact derivatives
-
-The short way, and the configurable way when you need a third derivative:
-
-```rust
-use multicalc::{derivative, second_derivative, partial};
-use multicalc::scalar_fn;
-
-let f = scalar_fn!(|x| x * x * x);                       // f(x) = x^3
-let first = derivative(&f, 2.0_f64);                     // 12.0
-let second = second_derivative(&f, 2.0_f64);             // 12.0
-
-// One partial of a multivariable function, by variable index.
-let g = scalar_fn!(|v: &[f64; 2]| v[0] * v[0] * v[1]);   // g(x, y) = x^2 * y
-let dx = partial(&g, 0, &[3.0_f64, 4.0])?;               // dg/dx = 2xy = 24.0
-# Ok::<(), multicalc::DiffError>(())
-```
-
-Any order, and mixed partials, through the autodiff objects:
-
-```rust
-use multicalc::{AutoDiffSingle, AutoDiffMulti};
-use multicalc::{DerivatorSingleVariable, DerivatorMultiVariable};
-use multicalc::scalar_fn;
-
-let f = scalar_fn!(|x| x * x * x);           // f(x) = x^3
-let d = AutoDiffSingle::default();           // forward-mode autodiff, exact
-let first = d.differentiate(1, &f, 2.0).unwrap();      // 12.0
-let third = d.differentiate(3, &f, 2.0).unwrap();      //  6.0
-
-// Partial derivatives of a multivariable function; order = number of indices.
-let g = scalar_fn!(|v: &[f64; 2]| v[0] * v[0] * v[1]);          // g(x, y) = x^2 * y
-let dm = AutoDiffMulti::default();
-let dx    = dm.first_partial_derivative(&g, 0, &[3.0, 4.0]).unwrap(); // dg/dx = 2xy   = 24.0
-let mixed = dm.differentiate(&g, &[0, 1], &[3.0, 4.0]).unwrap();          // d^2g/dxdy = 2x =  6.0
-```
-
-### Integration
-
-Newton-Cotes and Gaussian rules over finite, semi-infinite, and infinite limits:
-
-```rust
-use multicalc::IntegratorSingleVariable;
-use multicalc::IterativeSingle;
-use multicalc::GaussianSingle;
-use multicalc::GaussianQuadratureMethod;
-
-let integrator = IterativeSingle::default();     // Boole's rule, 120 intervals
-
-let area = integrator.single_integral(&|x: f64| 2.0 * x, &[0.0, 2.0]).unwrap();       // 2x on [0, 2]        -> 4.0
-// decaying integrands may run to a semi-infinite or infinite limit
-let tail = integrator.single_integral(&|x: f64| (-x).exp(), &[0.0, f64::INFINITY]).unwrap();  // e^-x on [0, inf)  -> 1.0
-let bell = integrator
-    .single_integral(&|x: f64| (-x * x).exp(), &[f64::NEG_INFINITY, f64::INFINITY])
-    .unwrap();                                                                   // e^(-x^2) on R       -> sqrt(pi)
-
-// Gauss-Hermite already carries the e^(-x^2) weight, so pass the bare integrand.
-let gh = GaussianSingle::from_parameters(5, GaussianQuadratureMethod::GaussHermite);
-let moment = gh.single_integral(&|x: f64| x * x, &[f64::NEG_INFINITY, f64::INFINITY]).unwrap();  // x^2, weight e^(-x^2) -> sqrt(pi)/2
-```
-
-### Nonlinear curve fitting
-
-Author the residuals `model - data` with `scalar_fn_vec!`; `LevenbergMarquardt` differentiates
-them under autodiff and drives the fit:
-
-```rust
-use multicalc::LevenbergMarquardt;
-use multicalc::AutoDiffMulti;
-use multicalc::c;
-use multicalc::scalar_fn_vec;
-
-// Fit a*e^(b*t) to (0, 100), (1, 50), (2, 25): the minimum is a = 100, b = -ln 2.
-let residuals = scalar_fn_vec!(|v: &[f64; 2]| [
-    c(-100.0) + v[0],
-    c(-50.0) + v[0] * v[1].exp(),
-    c(-25.0) + v[0] * (c(2.0) * v[1]).exp(),
-]);
-let report = LevenbergMarquardt::<AutoDiffMulti>::default()
-    .minimize(&residuals, &[80.0, -0.3])
-    .unwrap();
-// report.solution ~ [100.0, -0.693]; report.termination says which test converged
-```
-
-### Linear solves
-
-Fixed-size `Matrix` and `Vector` with dimensions as const generics (shape mismatches are
-compile errors):
-
-```rust
-use multicalc::{Matrix, Vector};
-
-// Solve A·x = b.
-let a = Matrix::<3, 3>::new([[2.0, 1.0, 1.0], [4.0, 3.0, 3.0], [8.0, 7.0, 9.0]]);
-let b = Vector::new([7.0, 19.0, 49.0]);
-let x = a.solve(b).unwrap();                        // [1, 2, 3]
-
-// A symmetric positive-definite matrix has a faster Cholesky path.
-let s = Matrix::<2, 2>::new([[4.0, 2.0], [2.0, 3.0]]);
-let s_inv = s.cholesky().unwrap().inverse();
-```
-
-### Rotations and rigid-body transforms
-
-`Quaternion` plus the `SO2`/`SE2`/`SO3`/`SE3` Lie groups, generic over the scalar so autodiff
-flows straight through:
-
-```rust
-use multicalc::{SE3, SO3};
-use multicalc::Vector;
-
-let r = SO3::<f64>::exp(Vector::new([0.0, 0.0, core::f64::consts::FRAC_PI_2])); // 90° about z
-let g = SE3::from_parts(r, Vector::new([1.0, 2.0, 3.0]));
-let p = g.act(Vector::new([1.0, 0.0, 0.0]));   // rotate then translate → (1, 3, 3)
-let xi = g.log();                              // 6-vector twist [v; ω]
-```
-
-### Tracking a robot's state
-
-`ExtendedKalmanFilter` takes its process and measurement models as functions instead of matrices and
-re-linearizes them each step, with the Jacobians coming from autodiff, so a nonlinear model needs no
-hand-derived matrices. The linear filter from [Quick start](#quick-start) also reports how
-surprising each measurement was, which is how you reject an outlier before folding it in:
-
-```rust
-use multicalc::{CovarianceUpdate, KalmanFilter, KalmanModel, Matrix, Vector};
-
-let mut filter = KalmanFilter::new(
-    Vector::new([0.0, 0.0]),
-    Matrix::new([[1.0, 0.0], [0.0, 1.0]]),
-    KalmanModel {
-        state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
-        measurement_model: Matrix::new([[1.0, 0.0]]),
-        process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
-        measurement_noise: Matrix::new([[0.1]]),
-    },
-)
-.with_covariance_update(CovarianceUpdate::Joseph);   // the default; symmetric by construction
-
-filter.predict();
-filter.update(Vector::new([1.0]))?;
-
-// How far the measurement fell from the prediction, in units of its own uncertainty.
-let gate = filter.normalized_innovation_squared()?;
-# Ok::<(), multicalc::EstimationError>(())
-```
-
-### Root finding
-
-Scalar equations and square systems `F(x) = 0`, with exact autodiff derivatives:
-
-```rust
-use multicalc::{Bisection, Newton, NewtonSystem};
-use multicalc::{AutoDiffMulti, AutoDiffSingle};
-use multicalc::c;
-use multicalc::{scalar_fn, scalar_fn_vec};
-
-let f = scalar_fn!(|x| c(-2.0) + x * x);       // f(x) = x^2 - 2, root at sqrt(2)
-let bracketed = Bisection::default().solve(&f, 0.0, 2.0).unwrap();          // ~ 1.41421356
-let newton = Newton::<AutoDiffSingle>::default().solve(&f, 2.0).unwrap();   // ~ 1.41421356
-
-// Square system: x^2 + y^2 = 4 and x*y = 1.
-let system = scalar_fn_vec!(|v: &[f64; 2]| [c(-4.0) + v[0] * v[0] + v[1] * v[1], c(-1.0) + v[0] * v[1]]);
-let solved = NewtonSystem::<AutoDiffMulti>::default().solve(&system, &[1.5, 0.8]).unwrap();
-// solved.root ~ [1.9319, 0.5176]
-```
-
-### ODE integration
-
-Initial-value solvers for `y' = f(t, y)` systems, generic over the state dimension:
-
-```rust
-use multicalc::{Rk4, Rk45};
-use multicalc::Vector;
-
-// Harmonic oscillator y'' = -y as the first-order system [position, velocity].
-let f = |_t: f64, y: &Vector<2, f64>| Vector::new([y[1], -y[0]]);
-let y0 = Vector::new([1.0, 0.0]);
-
-let step = Rk4::step(&f, 0.0, &y0, 0.1);       // one fixed RK4 step of size 0.1
-// adaptive Dormand-Prince 5(4) over one full period returns to the start [1, 0]
-let yf = Rk45::default().solve(&f, 0.0, &y0, core::f64::consts::TAU).unwrap();
-```
-
-Refer to the [guide](https://github.com/kmolan/multicalc-rust/blob/main/crates/multicalc/GUIDE.md) for a comprehensive tutorial.
-
-## Error handling
-
-Every fallible call returns a `Result` whose error is the module family's own enum
-(`LinalgError`, `DiffError`, `IntegrateError`, `SolveError`, `KinematicsError`,
-`EstimationError`, `ControlError`, or `MotionError`), each convertible into the `CalcError`
-umbrella. All variants are listed in
-[error.rs](https://github.com/kmolan/multicalc-rust/blob/main/crates/multicalc/src/error.rs).
+Refer to the [guide](https://github.com/kmolan/multicalc-rust/blob/main/crates/multicalc/GUIDE.md) for a comprehensive tutorial for each module. It shows the full imports,
+expected outputs in comments, error-path notes, and pointers to runnable demos. Start there when you need the complete picture of a feature.
 
 ## Accuracy
 
-Accuracy is verified against external-library fixtures (`mpmath`, `numpy`, `scipy`, `filterpy`) in
+Verified against external-library fixtures (`mpmath`, `numpy`, `scipy`, `filterpy`) in
 the `multicalc-qa` crate, with per-module tables generated from those fixtures. See
 [benchmarks/README.md](https://github.com/kmolan/multicalc-rust/tree/main/benchmarks/README.md)
 for the index, or go straight to

--- a/crates/multicalc/src/approximation/linear_approximation.rs
+++ b/crates/multicalc/src/approximation/linear_approximation.rs
@@ -1,7 +1,7 @@
 use crate::error::DiffError;
 use crate::linear_algebra::Vector;
-use crate::numerical_derivative::autodiff::AutoDiffMulti;
-use crate::numerical_derivative::derivator::DerivatorMultiVariable;
+use crate::numerical_derivative::AutoDiffMulti;
+use crate::numerical_derivative::DerivatorMultiVariable;
 use crate::scalar::{Numeric, ScalarFnN};
 use crate::utils::summation::SummationMethod;
 
@@ -66,7 +66,7 @@ impl<const NUM_VARS: usize, T: Numeric> LinearApproximation<NUM_VARS, T> {
     ///
     /// `r_squared` is `NaN` when the truth is constant over `points`;
     /// `adjusted_r_squared` is `NaN` when there are too few points.
-    pub fn get_prediction_metrics<O: ScalarFnN<NUM_VARS>, const NUM_POINTS: usize>(
+    pub fn prediction_metrics<O: ScalarFnN<NUM_VARS>, const NUM_POINTS: usize>(
         &self,
         points: &[[T; NUM_VARS]; NUM_POINTS],
         original_function: &O,
@@ -109,7 +109,7 @@ impl LinearApproximator<AutoDiffMulti> {
     /// An approximator using exact autodiff derivatives.
     ///
     /// ```
-    /// use multicalc::approximation::linear_approximation::LinearApproximator;
+    /// use multicalc::approximation::LinearApproximator;
     ///
     /// const APPROXIMATOR: LinearApproximator = LinearApproximator::new();
     /// ```
@@ -130,7 +130,7 @@ impl<D: DerivatorMultiVariable> LinearApproximator<D> {
 
     /// Opt in to Kahan compensated summation for prediction metrics.
     ///
-    /// Pairwise summation remains the default. Call this before [`Self::get`] so the
+    /// Pairwise summation remains the default. Call this before [`Self::approximate`] so the
     /// resulting [`LinearApproximation`] accumulates metrics with Kahan.
     pub fn with_kahan_summation(mut self) -> Self {
         self.summation = SummationMethod::Kahan;
@@ -144,7 +144,7 @@ impl<D: DerivatorMultiVariable> LinearApproximator<D> {
     ///
     /// # Examples
     /// ```
-    /// use multicalc::approximation::linear_approximation::LinearApproximator;
+    /// use multicalc::approximation::LinearApproximator;
     /// use multicalc::scalar::ScalarFnN;
     /// use multicalc::scalar_fn;
     ///
@@ -153,12 +153,12 @@ impl<D: DerivatorMultiVariable> LinearApproximator<D> {
     ///
     /// let point = [1.0, 2.0, 3.0]; // the point we want to linearize around
     /// let approximator: LinearApproximator = LinearApproximator::default();
-    /// let result = approximator.get(&function_to_approximate, &point).unwrap();
+    /// let result = approximator.approximate(&function_to_approximate, &point).unwrap();
     ///
     /// // the approximation is exact at the base point
     /// assert!(f64::abs(function_to_approximate.eval(&point) - result.predict(&point)) < 1e-12);
     /// ```
-    pub fn get<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize>(
+    pub fn approximate<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize>(
         &self,
         function: &F,
         point: &[D::Scalar; NUM_VARS],
@@ -167,7 +167,9 @@ impl<D: DerivatorMultiVariable> LinearApproximator<D> {
 
         let mut gradient = [<D::Scalar as Numeric>::ZERO; NUM_VARS];
         for (i, slot) in gradient.iter_mut().enumerate() {
-            *slot = self.derivator.get_single_partial(function, i, point)?;
+            *slot = self
+                .derivator
+                .first_partial_derivative(function, i, point)?;
         }
 
         Ok(LinearApproximation {

--- a/crates/multicalc/src/approximation/mod.rs
+++ b/crates/multicalc/src/approximation/mod.rs
@@ -1,14 +1,14 @@
 //! Least-squares function approximation with goodness-of-fit metrics.
 //!
-//! - [`linear_approximation`] — fit a linear model to sampled points.
-//! - [`quadratic_approximation`] — fit a quadratic model.
+//! - [`LinearApproximator`] — fit a linear model to sampled points.
+//! - [`QuadraticApproximator`] — fit a quadratic model.
 
 use crate::scalar::Numeric;
 use crate::utils::summation::Acc;
 pub use crate::utils::summation::SummationMethod;
 
-pub mod linear_approximation;
-pub mod quadratic_approximation;
+mod linear_approximation;
+mod quadratic_approximation;
 
 pub use linear_approximation::{
     LinearApproximation, LinearApproximationPredictionMetrics, LinearApproximator,

--- a/crates/multicalc/src/approximation/quadratic_approximation.rs
+++ b/crates/multicalc/src/approximation/quadratic_approximation.rs
@@ -1,7 +1,7 @@
 use crate::error::DiffError;
 use crate::linear_algebra::{Matrix, Vector};
-use crate::numerical_derivative::autodiff::AutoDiffMulti;
-use crate::numerical_derivative::derivator::DerivatorMultiVariable;
+use crate::numerical_derivative::AutoDiffMulti;
+use crate::numerical_derivative::DerivatorMultiVariable;
 use crate::scalar::{Numeric, ScalarFnN};
 use crate::utils::summation::SummationMethod;
 
@@ -65,7 +65,7 @@ impl<const NUM_VARS: usize, T: Numeric> QuadraticApproximation<NUM_VARS, T> {
     ///
     /// `r_squared` is `NaN` when the truth is constant over `points`;
     /// `adjusted_r_squared` is `NaN` when there are too few points.
-    pub fn get_prediction_metrics<O: ScalarFnN<NUM_VARS>, const NUM_POINTS: usize>(
+    pub fn prediction_metrics<O: ScalarFnN<NUM_VARS>, const NUM_POINTS: usize>(
         &self,
         points: &[[T; NUM_VARS]; NUM_POINTS],
         original_function: &O,
@@ -108,7 +108,7 @@ impl QuadraticApproximator<AutoDiffMulti> {
     /// An approximator using exact autodiff derivatives.
     ///
     /// ```
-    /// use multicalc::approximation::quadratic_approximation::QuadraticApproximator;
+    /// use multicalc::approximation::QuadraticApproximator;
     ///
     /// const APPROXIMATOR: QuadraticApproximator = QuadraticApproximator::new();
     /// ```
@@ -129,7 +129,7 @@ impl<D: DerivatorMultiVariable> QuadraticApproximator<D> {
 
     /// Opt in to Kahan compensated summation for prediction metrics.
     ///
-    /// Pairwise summation remains the default. Call this before [`Self::get`] so the
+    /// Pairwise summation remains the default. Call this before [`Self::approximate`] so the
     /// resulting [`QuadraticApproximation`] accumulates metrics with Kahan.
     pub fn with_kahan_summation(mut self) -> Self {
         self.summation = SummationMethod::Kahan;
@@ -143,7 +143,7 @@ impl<D: DerivatorMultiVariable> QuadraticApproximator<D> {
     ///
     /// # Examples
     /// ```
-    /// use multicalc::approximation::quadratic_approximation::QuadraticApproximator;
+    /// use multicalc::approximation::QuadraticApproximator;
     /// use multicalc::scalar::{c, ScalarFnN};
     /// use multicalc::scalar_fn;
     ///
@@ -153,12 +153,12 @@ impl<D: DerivatorMultiVariable> QuadraticApproximator<D> {
     ///
     /// let point = [0.0, 1.57, 10.0]; // the point we want to approximate around
     /// let approximator: QuadraticApproximator = QuadraticApproximator::default();
-    /// let result = approximator.get(&function_to_approximate, &point).unwrap();
+    /// let result = approximator.approximate(&function_to_approximate, &point).unwrap();
     ///
     /// // the approximation is exact at the base point
     /// assert!(f64::abs(function_to_approximate.eval(&point) - result.predict(&point)) < 1e-12);
     /// ```
-    pub fn get<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize>(
+    pub fn approximate<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize>(
         &self,
         function: &F,
         point: &[D::Scalar; NUM_VARS],
@@ -167,7 +167,9 @@ impl<D: DerivatorMultiVariable> QuadraticApproximator<D> {
 
         let mut gradient = [<D::Scalar as Numeric>::ZERO; NUM_VARS];
         for (i, slot) in gradient.iter_mut().enumerate() {
-            *slot = self.derivator.get_single_partial(function, i, point)?;
+            *slot = self
+                .derivator
+                .first_partial_derivative(function, i, point)?;
         }
 
         // symmetric fill: compute the upper triangle + diagonal once, mirror the rest.
@@ -179,7 +181,7 @@ impl<D: DerivatorMultiVariable> QuadraticApproximator<D> {
                 if hessian[row][col].is_nan() {
                     hessian[row][col] =
                         self.derivator
-                            .get_double_partial(function, &[row, col], point)?;
+                            .second_partial_derivative(function, &[row, col], point)?;
                     hessian[col][row] = hessian[row][col];
                 }
             }

--- a/crates/multicalc/src/control/derivative_filter.rs
+++ b/crates/multicalc/src/control/derivative_filter.rs
@@ -13,17 +13,20 @@ use crate::scalar::Numeric;
 /// ```
 /// use multicalc::control::OnePoleLowPass;
 ///
-/// // Pass-through: the output reproduces the input exactly.
-/// let mut passthrough = OnePoleLowPass::new(1.0_f64).unwrap();
+/// // A weight of 1 keeps all of the new sample, so the output reproduces the input exactly.
+/// let keep_everything = 1.0_f64;
+/// let mut passthrough = OnePoleLowPass::new(keep_everything).unwrap();
 /// assert_eq!(passthrough.filter(3.0), 3.0);
 /// assert_eq!(passthrough.filter(-2.0), -2.0);
 ///
-/// // A constant input converges to that constant.
-/// let mut smoother = OnePoleLowPass::new(0.5_f64).unwrap();
+/// // A smaller weight leans on the history, and a constant input converges to that constant.
+/// let half_new_half_old = 0.5_f64;
+/// let mut smoother = OnePoleLowPass::new(half_new_half_old).unwrap();
+/// let steady_input = 10.0;
 /// for _ in 0..64 {
-///     smoother.filter(10.0);
+///     smoother.filter(steady_input);
 /// }
-/// assert!((smoother.value() - 10.0).abs() < 1e-9);
+/// assert!((smoother.value() - steady_input).abs() < 1e-9);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct OnePoleLowPass<T: Numeric = f64> {

--- a/crates/multicalc/src/control/follow_the_gap.rs
+++ b/crates/multicalc/src/control/follow_the_gap.rs
@@ -274,17 +274,26 @@ impl<const BEAMS: usize, T: Numeric> FollowTheGap<BEAMS, T> {
     /// ```
     /// use multicalc::control::FollowTheGap;
     ///
-    /// // 31 beams over 120°, 4 m range, a 0.5 m robot, 0.5 m open-space threshold, 0.4 m/s cruise.
+    /// let field_of_view = 2.0 * core::f64::consts::PI / 3.0;   // 120°, over 31 beams
+    /// let max_range = 4.0;
+    /// let robot_radius = 0.5;
+    /// let clearance = 0.5;      // a gap must be this much wider than the robot to count
+    /// let cruise_speed = 0.4;
+    ///
     /// let follower: FollowTheGap<31, f64> =
-    ///     FollowTheGap::try_new(2.0 * core::f64::consts::PI / 3.0, 4.0, 0.5, 0.5, 0.4).unwrap();
+    ///     FollowTheGap::try_new(field_of_view, max_range, robot_radius, clearance, cruise_speed)
+    ///         .unwrap();
     ///
     /// // Nothing in the way: drive straight ahead at cruise speed.
-    /// let output = follower.compute(&[4.0; 31], 0.0).unwrap();
+    /// let goal_angle = 0.0;
+    /// let clear_scan = [4.0; 31];
+    /// let output = follower.compute(&clear_scan, goal_angle).unwrap();
     /// assert!(output.heading().abs() < 1e-12);
-    /// assert!((output.body_twist().linear() - 0.4).abs() < 1e-12);
+    /// assert!((output.body_twist().linear() - cruise_speed).abs() < 1e-12);
     ///
     /// // A wall all round: stop, and say so.
-    /// let blocked = follower.compute(&[0.2; 31], 0.0).unwrap();
+    /// let walled_in = [0.2; 31];
+    /// let blocked = follower.compute(&walled_in, goal_angle).unwrap();
     /// assert!(blocked.is_blocked());
     /// assert_eq!(blocked.body_twist().linear(), 0.0);
     /// ```

--- a/crates/multicalc/src/control/pid.rs
+++ b/crates/multicalc/src/control/pid.rs
@@ -18,14 +18,19 @@ use crate::scalar::Numeric;
 /// ```
 /// use multicalc::control::Pid;
 ///
-/// // Drive a scalar integrator plant `x_next = x + dt * output` to a setpoint.
-/// let dt = 0.01_f64;
-/// let mut controller = Pid::new(2.0, 1.0, 0.0, dt).unwrap();
+/// // Drive a scalar integrator plant `x_next = x + timestep * output` to a setpoint.
+/// let proportional_gain = 2.0_f64;
+/// let integral_gain = 1.0;
+/// let derivative_gain = 0.0;
+/// let timestep = 0.01;
+///
+/// let mut controller =
+///     Pid::new(proportional_gain, integral_gain, derivative_gain, timestep).unwrap();
 /// let setpoint = 1.0;
 /// let mut measurement = 0.0;
 /// for _ in 0..2000 {
 ///     let output = controller.update(setpoint, measurement);
-///     measurement += dt * output;
+///     measurement += timestep * output;
 /// }
 /// assert!((measurement - setpoint).abs() < 1e-3);
 /// ```

--- a/crates/multicalc/src/control/pure_pursuit.rs
+++ b/crates/multicalc/src/control/pure_pursuit.rs
@@ -52,11 +52,16 @@ impl<T: Numeric> Curvature<T> {
 /// use multicalc::linear_algebra::Vector;
 ///
 /// let pose = SE2::identity();
+/// let lookahead_distance = 2.0;
+///
 /// // A point straight ahead needs no turn.
-/// let ahead = pure_pursuit_curvature(pose, Vector::new([2.0_f64, 0.0]), 2.0).unwrap();
+/// let straight_ahead = Vector::new([2.0_f64, 0.0]);
+/// let ahead = pure_pursuit_curvature(pose, straight_ahead, lookahead_distance).unwrap();
 /// assert!(ahead.value().abs() < 1e-12);
+///
 /// // A point to the left curves left (positive curvature).
-/// let left = pure_pursuit_curvature(pose, Vector::new([2.0_f64, 1.0]), 2.0).unwrap();
+/// let off_to_the_left = Vector::new([2.0_f64, 1.0]);
+/// let left = pure_pursuit_curvature(pose, off_to_the_left, lookahead_distance).unwrap();
 /// assert!(left.value() > 0.0);
 /// ```
 pub fn pure_pursuit_curvature<T: Numeric>(

--- a/crates/multicalc/src/discretization/mod.rs
+++ b/crates/multicalc/src/discretization/mod.rs
@@ -20,9 +20,11 @@ use crate::scalar::Numeric;
 /// // Double integrator: A = [[0,1],[0,0]], B = [[0],[1]].
 /// let a = Matrix::<2, 2>::new([[0.0, 1.0], [0.0, 0.0]]);
 /// let b = Matrix::<2, 1>::new([[0.0], [1.0]]);
-/// let (f, g) = zoh::<2, 1, 3, f64>(a, b, 0.1)?;
-/// assert!((f[(0, 1)] - 0.1).abs() < 1e-9); // F = [[1, dt], [0, 1]]
-/// assert!((g[(0, 0)] - 0.005).abs() < 1e-9); // G = [[dt²/2], [dt]]
+/// let timestep = 0.1;
+///
+/// let (f, g) = zoh::<2, 1, 3, f64>(a, b, timestep)?;
+/// assert!((f[(0, 1)] - 0.1).abs() < 1e-9); // F = [[1, timestep], [0, 1]]
+/// assert!((g[(0, 0)] - 0.005).abs() < 1e-9); // G = [[timestep²/2], [timestep]]
 /// # Ok(())
 /// # }
 /// ```
@@ -98,8 +100,11 @@ pub fn van_loan<const N: usize, const N2: usize, T: Numeric>(
 ///
 /// ```
 /// use multicalc::discretization::q_discrete_white_noise;
-/// let q = q_discrete_white_noise::<2, f64>(0.1, 2.0);
-/// assert!((q[(1, 1)] - 2.0 * 0.1 * 0.1).abs() < 1e-15); // var · dt²
+/// let timestep = 0.1;
+/// let variance = 2.0;
+///
+/// let q = q_discrete_white_noise::<2, f64>(timestep, variance);
+/// assert!((q[(1, 1)] - 2.0 * 0.1 * 0.1).abs() < 1e-15); // variance · timestep²
 /// ```
 pub fn q_discrete_white_noise<const DIM: usize, T: Numeric>(
     dt: T,

--- a/crates/multicalc/src/estimation/extended_kalman_filter.rs
+++ b/crates/multicalc/src/estimation/extended_kalman_filter.rs
@@ -21,9 +21,9 @@
 use crate::error::EstimationError;
 use crate::estimation::CovarianceUpdate;
 use crate::linear_algebra::{Matrix, Vector};
-use crate::numerical_derivative::autodiff::AutoDiffMulti;
-use crate::numerical_derivative::derivator::DerivatorMultiVariable;
-use crate::numerical_derivative::jacobian::Jacobian;
+use crate::numerical_derivative::AutoDiffMulti;
+use crate::numerical_derivative::DerivatorMultiVariable;
+use crate::numerical_derivative::Jacobian;
 use crate::scalar::{Numeric, VectorFn};
 
 /// An extended Kalman filter over a `STATE_DIMENSION`-state model with `MEASUREMENT_DIMENSION`
@@ -137,7 +137,7 @@ where
     D: DerivatorMultiVariable<Scalar = T> + Clone,
 {
     /// Builds a filter with an explicit differentiation backend — a
-    /// [`FiniteDifferenceMulti`](crate::numerical_derivative::finite_difference::FiniteDifferenceMulti)
+    /// [`FiniteDifferenceMulti`](crate::numerical_derivative::FiniteDifferenceMulti)
     /// or your own [`DerivatorMultiVariable`]. [`new`](Self::new) is the autodiff default.
     pub fn from_derivator(
         initial_state: Vector<STATE_DIMENSION, T>,
@@ -247,7 +247,7 @@ where
         ProcessModel: VectorFn<STATE_DIMENSION, STATE_DIMENSION>,
     {
         let state_transition = Jacobian::from_derivator(self.derivator.clone())
-            .get(process_model, self.state.as_array())?;
+            .evaluate(process_model, self.state.as_array())?;
 
         let propagated = Vector::new(process_model.eval(self.state.as_array()));
         if !propagated.is_finite() || !state_transition.is_finite() {
@@ -344,7 +344,7 @@ where
         }
 
         let measurement_model_jacobian = Jacobian::from_derivator(self.derivator.clone())
-            .get(measurement_model, self.state.as_array())?;
+            .evaluate(measurement_model, self.state.as_array())?;
 
         self.innovation = residual;
         self.innovation_covariance =

--- a/crates/multicalc/src/estimation/kalman_filter.rs
+++ b/crates/multicalc/src/estimation/kalman_filter.rs
@@ -80,18 +80,20 @@ pub struct KalmanModel<const STATE_DIMENSION: usize, const MEASUREMENT_DIMENSION
 /// use multicalc::linear_algebra::{Matrix, Vector};
 /// # fn main() -> Result<(), multicalc::error::EstimationError> {
 /// // Constant velocity: position integrates velocity over a 1 s step; position is measured.
-/// let mut filter = KalmanFilter::new(
-///     Vector::new([0.0, 0.0]),                // initial state
-///     Matrix::new([[1.0, 0.0], [0.0, 1.0]]),  // initial covariance
-///     KalmanModel {
-///         state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
-///         measurement_model: Matrix::new([[1.0, 0.0]]),
-///         process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
-///         measurement_noise: Matrix::new([[0.1]]),
-///     },
-/// );
+/// let initial_state = Vector::new([0.0, 0.0]);
+/// let initial_covariance = Matrix::new([[1.0, 0.0], [0.0, 1.0]]);
+/// let model = KalmanModel {
+///     state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
+///     measurement_model: Matrix::new([[1.0, 0.0]]),
+///     process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
+///     measurement_noise: Matrix::new([[0.1]]),
+/// };
+///
+/// let mut filter = KalmanFilter::new(initial_state, initial_covariance, model);
 /// filter.predict();
-/// filter.update(Vector::new([1.0]))?;
+///
+/// let measurement = Vector::new([1.0]);
+/// filter.update(measurement)?;
 /// assert!(filter.state()[0] > 0.0);
 /// # Ok(())
 /// # }
@@ -152,19 +154,21 @@ impl<const STATE_DIMENSION: usize, const MEASUREMENT_DIMENSION: usize, T: Numeri
     /// use multicalc::estimation::{CovarianceUpdate, KalmanFilter, KalmanModel};
     /// use multicalc::linear_algebra::{Matrix, Vector};
     /// # fn main() -> Result<(), multicalc::error::EstimationError> {
-    /// let mut filter = KalmanFilter::new(
-    ///     Vector::new([0.0, 0.0]),
-    ///     Matrix::new([[1.0, 0.0], [0.0, 1.0]]),
-    ///     KalmanModel {
-    ///         state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
-    ///         measurement_model: Matrix::new([[1.0, 0.0]]),
-    ///         process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
-    ///         measurement_noise: Matrix::new([[0.1]]),
-    ///     },
-    /// )
-    /// .with_covariance_update(CovarianceUpdate::Naive);
+    /// let initial_state = Vector::new([0.0, 0.0]);
+    /// let initial_covariance = Matrix::new([[1.0, 0.0], [0.0, 1.0]]);
+    /// let model = KalmanModel {
+    ///     state_transition: Matrix::new([[1.0, 1.0], [0.0, 1.0]]),
+    ///     measurement_model: Matrix::new([[1.0, 0.0]]),
+    ///     process_noise: Matrix::new([[0.01, 0.0], [0.0, 0.01]]),
+    ///     measurement_noise: Matrix::new([[0.1]]),
+    /// };
+    ///
+    /// let mut filter = KalmanFilter::new(initial_state, initial_covariance, model)
+    ///     .with_covariance_update(CovarianceUpdate::Naive);
     /// filter.predict();
-    /// filter.update(Vector::new([1.0]))?;
+    ///
+    /// let measurement = Vector::new([1.0]);
+    /// filter.update(measurement)?;
     /// assert!(filter.covariance()[(0, 0)] > 0.0);
     /// # Ok(())
     /// # }

--- a/crates/multicalc/src/estimation/particle_filter.rs
+++ b/crates/multicalc/src/estimation/particle_filter.rs
@@ -262,18 +262,27 @@ impl<const MEASUREMENT_DIMENSION: usize, T: Numeric> Likelihood<MEASUREMENT_DIME
 ///     }
 /// }
 ///
+/// let particle_count = 1000;
+/// let initial_mean = Vector::new([0.0, 0.0]);
+/// let initial_covariance = Matrix::new([[1.0, 0.0], [0.0, 1.0]]);
+/// let process_noise = Matrix::new([[0.01, 0.0], [0.0, 0.01]]);
+/// let seed = 7;
+///
 /// let mut filter = ParticleFilter::<2, 2>::new(
-///     1000,
-///     Vector::new([0.0, 0.0]),                  // initial mean
-///     Matrix::new([[1.0, 0.0], [0.0, 1.0]]),    // initial covariance
-///     Matrix::new([[0.01, 0.0], [0.0, 0.01]]),  // process noise
-///     7,                                        // seed
+///     particle_count,
+///     initial_mean,
+///     initial_covariance,
+///     process_noise,
+///     seed,
 /// )?;
-/// let sensor = GaussianLikelihood::new(Matrix::new([[0.05, 0.0], [0.0, 0.05]]))?;
+///
+/// let measurement_noise = Matrix::new([[0.05, 0.0], [0.0, 0.05]]);
+/// let sensor = GaussianLikelihood::new(measurement_noise)?;
+/// let measurement = Vector::new([1.0, 2.0]);
 ///
 /// for _ in 0..20 {
 ///     filter.predict(&Stationary)?;
-///     filter.update(&Stationary, &sensor, Vector::new([1.0, 2.0]))?;
+///     filter.update(&Stationary, &sensor, measurement)?;
 /// }
 /// // The cloud has settled onto the measured point.
 /// assert!((filter.mean()[0] - 1.0).abs() < 0.2);

--- a/crates/multicalc/src/gaussian_tables/mod.rs
+++ b/crates/multicalc/src/gaussian_tables/mod.rs
@@ -4,7 +4,7 @@
 //! `scripts/build_gaussian_integration_tables.py`.
 
 use crate::error::IntegrateError;
-use crate::numerical_integration::mode::GaussianQuadratureMethod;
+use crate::numerical_integration::GaussianQuadratureMethod;
 
 pub mod hermite;
 pub mod laguerre;
@@ -17,7 +17,7 @@ pub const MAX_ORDER: usize = 30;
 ///
 /// ```
 /// use multicalc::gaussian_tables::nodes;
-/// use multicalc::numerical_integration::mode::GaussianQuadratureMethod;
+/// use multicalc::numerical_integration::GaussianQuadratureMethod;
 ///
 /// const PAIRS: &[(f64, f64)] = match nodes(GaussianQuadratureMethod::GaussLegendre, 4) {
 ///     Ok(t) => t,

--- a/crates/multicalc/src/kinematics/differential_drive.rs
+++ b/crates/multicalc/src/kinematics/differential_drive.rs
@@ -227,9 +227,12 @@ impl<T: Numeric> DifferentialDrive<T> {
     ///
     /// ```
     /// use multicalc::kinematics::{DifferentialDrive, WheelVelocities};
-    /// let dd = DifferentialDrive::new(0.036_f64, 0.235).unwrap();
+    /// let wheel_radius = 0.036_f64;   // 36 mm wheels
+    /// let track_width = 0.235;        // 235 mm apart
+    /// let drive = DifferentialDrive::new(wheel_radius, track_width).unwrap();
+    ///
     /// let wheels = WheelVelocities::new(1.0, 2.0);
-    /// let back = dd.inverse(dd.forward(wheels));
+    /// let back = drive.inverse(drive.forward(wheels));
     /// assert!((back.left() - 1.0).abs() < 1e-15);
     /// assert!((back.right() - 2.0).abs() < 1e-15);
     /// ```

--- a/crates/multicalc/src/kinematics/odometry.rs
+++ b/crates/multicalc/src/kinematics/odometry.rs
@@ -20,8 +20,9 @@ use crate::spatial::{SE2, SO2};
 /// use multicalc::kinematics::{BodyArc, integrate};
 /// use multicalc::spatial::SE2;
 /// // Two ticks of 0.05 rad turn each leave the pose rotated by 0.1 rad.
-/// let d = BodyArc::new(0.1_f64, 0.05);
-/// let pose = integrate(integrate(SE2::identity(), d), d);
+/// let start = SE2::identity();
+/// let step = BodyArc::new(0.1_f64, 0.05);   // turn 0.1 rad while moving 0.05 m along the arc
+/// let pose = integrate(integrate(start, step), step);
 /// assert!((pose.rotation().log() - 0.1).abs() < 1e-12);
 /// ```
 #[inline]

--- a/crates/multicalc/src/kinematics/unicycle.rs
+++ b/crates/multicalc/src/kinematics/unicycle.rs
@@ -13,8 +13,13 @@ use crate::scalar::Numeric;
 /// use multicalc::kinematics::{BodyTwist, Unicycle};
 /// use multicalc::linear_algebra::Vector;
 /// use multicalc::ode::Rk4;
-/// let plant = Unicycle::new(BodyTwist::new(1.0_f64, 0.0));
-/// let state = Rk4::step(&plant.field(), 0.0, &Vector::new([0.0, 0.0, 0.0]), 0.1);
+/// let command = BodyTwist::new(1.0_f64, 0.0);   // 1 m/s forward, no turn
+/// let plant = Unicycle::new(command);
+///
+/// let start_time = 0.0;
+/// let start_pose = Vector::new([0.0, 0.0, 0.0]);
+/// let timestep = 0.1;
+/// let state = Rk4::step(&plant.field(), start_time, &start_pose, timestep);
 /// assert!((state[0] - 0.1).abs() < 1e-12);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/multicalc/src/lib.rs
+++ b/crates/multicalc/src/lib.rs
@@ -27,7 +27,7 @@ pub use scalar::Jet;
 pub use scalar::{ScalarFn, ScalarFnN, VectorFn};
 
 /// The plain scalar wrapper, and the marker for numeric constants inside a `scalar_fn!` body.
-pub use scalar::{Primal, c};
+pub use scalar::{Const, Primal, c};
 
 /// Differentiation: the autodiff and finite-difference backends, their shared traits, and the
 /// derivative-matrix types.
@@ -127,5 +127,5 @@ pub mod random;
 pub mod root_finding;
 pub mod scalar;
 pub mod spatial;
-pub mod utils;
+mod utils;
 pub mod vector_field;

--- a/crates/multicalc/src/lib.rs
+++ b/crates/multicalc/src/lib.rs
@@ -2,7 +2,8 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[cfg(doctest)]
+// Some guide examples use the alloc-only types, so they are compiled under `alloc` only.
+#[cfg(all(doctest, feature = "alloc"))]
 #[doc = include_str!("../GUIDE.md")]
 pub struct GuideExamples;
 

--- a/crates/multicalc/src/lib.rs
+++ b/crates/multicalc/src/lib.rs
@@ -2,6 +2,10 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(doctest)]
+#[doc = include_str!("../GUIDE.md")]
+pub struct GuideExamples;
+
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 extern crate alloc;

--- a/crates/multicalc/src/linear_algebra/cholesky.rs
+++ b/crates/multicalc/src/linear_algebra/cholesky.rs
@@ -97,8 +97,9 @@ impl<const N: usize, T: Numeric> Cholesky<N, T> {
     /// ```
     /// use multicalc::linear_algebra::{Matrix, Vector};
     /// let a = Matrix::<2, 2>::new([[4.0, 2.0], [2.0, 3.0]]);
+    /// let b = Vector::new([8.0, 8.0]);
     /// // A·x = b has the exact solution x = [1, 2].
-    /// let x = a.cholesky().unwrap().solve(Vector::new([8.0, 8.0]));
+    /// let x = a.cholesky().unwrap().solve(b);
     /// assert!((x[0] - 1.0).abs() < 1e-12);
     /// assert!((x[1] - 2.0).abs() < 1e-12);
     /// ```
@@ -131,8 +132,9 @@ impl<const N: usize, T: Numeric> Cholesky<N, T> {
     /// ```
     /// use multicalc::linear_algebra::Matrix;
     /// let a = Matrix::<2, 2>::new([[4.0, 2.0], [2.0, 3.0]]);
+    /// let identity = Matrix::<2, 2>::identity();
     /// // Solving A·X = I gives X = A⁻¹.
-    /// let x = a.cholesky().unwrap().solve_matrix(Matrix::<2, 2>::identity());
+    /// let x = a.cholesky().unwrap().solve_matrix(identity);
     /// let p = a * x;
     /// assert!((p[(0, 0)] - 1.0).abs() < 1e-12);
     /// assert!((p[(1, 1)] - 1.0).abs() < 1e-12);

--- a/crates/multicalc/src/linear_algebra/lu.rs
+++ b/crates/multicalc/src/linear_algebra/lu.rs
@@ -97,7 +97,8 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
     /// ```
     /// use multicalc::linear_algebra::{Matrix, Vector};
     /// let a = Matrix::<3, 3>::new([[2.0, 1.0, 1.0], [4.0, 3.0, 3.0], [8.0, 7.0, 9.0]]);
-    /// let x = a.solve(Vector::new([7.0, 19.0, 49.0])).unwrap();
+    /// let b = Vector::new([7.0, 19.0, 49.0]);
+    /// let x = a.solve(b).unwrap();
     /// assert!((x[0] - 1.0).abs() < 1e-12);
     /// assert!((x[1] - 2.0).abs() < 1e-12);
     /// assert!((x[2] - 3.0).abs() < 1e-12);
@@ -157,8 +158,9 @@ impl<const N: usize, T: Numeric> Lu<N, T> {
     /// ```
     /// use multicalc::linear_algebra::{Matrix, Vector};
     /// let a = Matrix::<3, 3>::new([[2.0, 1.0, 1.0], [4.0, 3.0, 3.0], [8.0, 7.0, 9.0]]);
+    /// let b = Vector::new([7.0, 19.0, 49.0]);
     /// // A·x = b has the exact solution x = [1, 2, 3].
-    /// let x = a.lu().unwrap().solve(Vector::new([7.0, 19.0, 49.0]));
+    /// let x = a.lu().unwrap().solve(b);
     /// assert!((x[0] - 1.0).abs() < 1e-12);
     /// assert!((x[1] - 2.0).abs() < 1e-12);
     /// assert!((x[2] - 3.0).abs() < 1e-12);
@@ -193,8 +195,9 @@ impl<const N: usize, T: Numeric> Lu<N, T> {
     /// ```
     /// use multicalc::linear_algebra::Matrix;
     /// let a = Matrix::<2, 2>::new([[4.0, 3.0], [6.0, 3.0]]);
+    /// let identity = Matrix::<2, 2>::identity();
     /// // Solving A·X = I gives X = A⁻¹.
-    /// let x = a.lu().unwrap().solve_matrix(Matrix::<2, 2>::identity());
+    /// let x = a.lu().unwrap().solve_matrix(identity);
     /// let p = a * x;
     /// assert!((p[(0, 0)] - 1.0).abs() < 1e-12);
     /// assert!((p[(1, 1)] - 1.0).abs() < 1e-12);

--- a/crates/multicalc/src/linear_algebra/matrix.rs
+++ b/crates/multicalc/src/linear_algebra/matrix.rs
@@ -125,7 +125,9 @@ impl<const ROWS: usize, const COLS: usize, T: Numeric> Matrix<ROWS, COLS, T> {
     ///
     /// ```
     /// use multicalc::linear_algebra::Matrix;
-    /// assert_eq!(Matrix::new([[1.0, 2.0]]).scale(3.0).into_array(), [[3.0, 6.0]]);
+    /// let m = Matrix::new([[1.0, 2.0]]);
+    /// let factor = 3.0;
+    /// assert_eq!(m.scale(factor).into_array(), [[3.0, 6.0]]);
     /// ```
     #[inline]
     pub fn scale(self, scalar: T) -> Self {

--- a/crates/multicalc/src/linear_algebra/mod.rs
+++ b/crates/multicalc/src/linear_algebra/mod.rs
@@ -10,21 +10,24 @@
 //! let _ = Vector::new([1.0, 2.0]) + Vector::new([1.0, 2.0, 3.0]);
 //! ```
 
-pub mod cholesky;
-pub mod expm;
-pub mod lu;
-pub mod macros;
-pub mod matrix;
-pub mod qr;
-pub mod svd;
-pub mod vector;
+mod cholesky;
+mod expm;
+mod lu;
+mod macros;
+mod matrix;
+mod qr;
+mod svd;
+mod vector;
 
 pub use cholesky::Cholesky;
 pub use lu::Lu;
 pub use matrix::Matrix;
-pub use qr::PivotedQr;
+pub use qr::{CholeskyFactor, DampedLeastSquares, PivotedQr};
 pub use svd::Svd;
 pub use vector::Vector;
+
+/// Shared numeric helpers, reachable inside the crate now that `qr` is private.
+pub(crate) use qr::{enorm, max, min};
 
 #[cfg(test)]
 mod test;

--- a/crates/multicalc/src/linear_algebra/svd.rs
+++ b/crates/multicalc/src/linear_algebra/svd.rs
@@ -243,7 +243,8 @@ impl<const M: usize, const N: usize, T: Numeric> Svd<M, N, T> {
     /// use multicalc::linear_algebra::Matrix;
     /// // Column 2 is twice column 1, so the matrix has rank 1.
     /// let a = Matrix::<3, 2>::new([[1.0, 2.0], [2.0, 4.0], [3.0, 6.0]]);
-    /// assert_eq!(a.svd().unwrap().rank(1e-9), 1);
+    /// let tolerance = 1e-9;
+    /// assert_eq!(a.svd().unwrap().rank(tolerance), 1);
     /// ```
     #[inline]
     #[must_use]
@@ -325,7 +326,8 @@ impl<const M: usize, const N: usize, T: Numeric> Svd<M, N, T> {
     /// use multicalc::linear_algebra::{Matrix, Vector};
     /// // Overdetermined and consistent: the exact solution is x = [1, 2].
     /// let a = Matrix::<3, 2>::new([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]);
-    /// let x = a.svd().unwrap().solve(Vector::new([1.0, 2.0, 3.0]));
+    /// let b = Vector::new([1.0, 2.0, 3.0]);
+    /// let x = a.svd().unwrap().solve(b);
     /// assert!((x[0] - 1.0).abs() < 1e-12);
     /// assert!((x[1] - 2.0).abs() < 1e-12);
     /// ```

--- a/crates/multicalc/src/linear_algebra/vector.rs
+++ b/crates/multicalc/src/linear_algebra/vector.rs
@@ -123,7 +123,9 @@ impl<const N: usize, T: Numeric> Vector<N, T> {
     ///
     /// ```
     /// use multicalc::linear_algebra::Vector;
-    /// assert_eq!(Vector::new([1.0, 2.0]).scale(3.0), Vector::new([3.0, 6.0]));
+    /// let v = Vector::new([1.0, 2.0]);
+    /// let factor = 3.0;
+    /// assert_eq!(v.scale(factor), Vector::new([3.0, 6.0]));
     /// ```
     #[inline]
     pub fn scale(self, scalar: T) -> Self {
@@ -134,8 +136,14 @@ impl<const N: usize, T: Numeric> Vector<N, T> {
     ///
     /// ```
     /// use multicalc::linear_algebra::Vector;
-    /// assert_eq!(Vector::new([1.0, 2.0, 3.0]).dot(Vector::new([4.0, 5.0, 6.0])), 32.0);
-    /// assert_eq!(Vector::new([1.0, 0.0]).dot(Vector::new([0.0, 1.0])), 0.0);
+    /// let a = Vector::new([1.0, 2.0, 3.0]);
+    /// let b = Vector::new([4.0, 5.0, 6.0]);
+    /// assert_eq!(a.dot(b), 32.0);
+    ///
+    /// // perpendicular vectors have a zero dot product
+    /// let along_x = Vector::new([1.0, 0.0]);
+    /// let along_y = Vector::new([0.0, 1.0]);
+    /// assert_eq!(along_x.dot(along_y), 0.0);
     /// ```
     #[inline]
     #[must_use]

--- a/crates/multicalc/src/motion/polyline_path.rs
+++ b/crates/multicalc/src/motion/polyline_path.rs
@@ -72,7 +72,12 @@ impl<const DIMENSION: usize, T: Numeric> PathProjection<DIMENSION, T> {
 /// assert!((path.total_arc_length() - 7.0).abs() < 1e-12);
 ///
 /// // Two units along from the start sits on the first leg.
-/// let [x, y] = path.lookahead_point(0.0, 2.0).unwrap().into_array();
+/// let arc_length_so_far = 0.0;
+/// let lookahead_distance = 2.0;
+/// let [x, y] = path
+///     .lookahead_point(arc_length_so_far, lookahead_distance)
+///     .unwrap()
+///     .into_array();
 /// assert!((x - 2.0).abs() < 1e-12 && y.abs() < 1e-12);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/multicalc/src/numerical_derivative/autodiff.rs
+++ b/crates/multicalc/src/numerical_derivative/autodiff.rs
@@ -16,8 +16,8 @@ const MAX_ORDER: usize = 6;
 /// Forward-mode autodiff differentiator for single-variable functions.
 ///
 /// ```
-/// use multicalc::numerical_derivative::autodiff::AutoDiffSingle;
-/// use multicalc::numerical_derivative::derivator::DerivatorSingleVariable;
+/// use multicalc::numerical_derivative::AutoDiffSingle;
+/// use multicalc::numerical_derivative::DerivatorSingleVariable;
 /// use multicalc::scalar_fn;
 ///
 /// // f(x) = x^3 -> f' = 3x^2, f'' = 6x, f''' = 6
@@ -25,9 +25,9 @@ const MAX_ORDER: usize = 6;
 /// let d = AutoDiffSingle::default();
 ///
 /// // exact to rounding, no step size
-/// assert!((d.get(1, &f, 2.0_f64).unwrap() - 12.0).abs() < 1e-12);
-/// assert!((d.get(2, &f, 2.0_f64).unwrap() - 12.0).abs() < 1e-12);
-/// assert!((d.get(3, &f, 2.0_f64).unwrap() - 6.0).abs() < 1e-12);
+/// assert!((d.differentiate(1, &f, 2.0_f64).unwrap() - 12.0).abs() < 1e-12);
+/// assert!((d.differentiate(2, &f, 2.0_f64).unwrap() - 12.0).abs() < 1e-12);
+/// assert!((d.differentiate(3, &f, 2.0_f64).unwrap() - 6.0).abs() < 1e-12);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AutoDiffSingle<T = f64> {
@@ -44,7 +44,7 @@ impl<T> AutoDiffSingle<T> {
     /// Const constructor (same as [`Default::default`]).
     ///
     /// ```
-    /// use multicalc::numerical_derivative::autodiff::AutoDiffSingle;
+    /// use multicalc::numerical_derivative::AutoDiffSingle;
     ///
     /// const D: AutoDiffSingle = AutoDiffSingle::new();
     /// ```
@@ -61,7 +61,7 @@ impl<T: Numeric> DerivatorSingleVariable for AutoDiffSingle<T> {
 
     /// Orders 1 and 2 use [`Dual`]/[`HyperDual`]; orders 3..=`MAX_ORDER` use a [`Jet`]. Higher
     /// orders return [`DiffError::OrderUnsupported`].
-    fn get<F: ScalarFn>(&self, order: usize, func: &F, point: T) -> Result<T, DiffError> {
+    fn differentiate<F: ScalarFn>(&self, order: usize, func: &F, point: T) -> Result<T, DiffError> {
         match order {
             0 => Err(DiffError::OrderZero),
             1 => Ok(func.eval(Dual::variable(point)).deriv),
@@ -77,9 +77,9 @@ impl<T: Numeric> DerivatorSingleVariable for AutoDiffSingle<T> {
 /// Forward-mode autodiff differentiator for multi-variable functions.
 ///
 /// ```
-/// use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
-/// use multicalc::numerical_derivative::derivator::DerivatorMultiVariable;
-/// use multicalc::numerical_derivative::finite_difference::FiniteDifferenceMulti;
+/// use multicalc::numerical_derivative::AutoDiffMulti;
+/// use multicalc::numerical_derivative::DerivatorMultiVariable;
+/// use multicalc::numerical_derivative::FiniteDifferenceMulti;
 /// use multicalc::scalar_fn;
 ///
 /// // f(x, y) = x^2 * y + sin(x)
@@ -89,12 +89,12 @@ impl<T: Numeric> DerivatorSingleVariable for AutoDiffSingle<T> {
 /// let point = [1.0, 2.0];
 ///
 /// // df/dx = 2xy + cos(x): exact, and it agrees with finite differences
-/// let ad_dx = ad.get_single_partial(&f, 0, &point).unwrap();
+/// let ad_dx = ad.first_partial_derivative(&f, 0, &point).unwrap();
 /// assert!((ad_dx - (2.0 * 1.0 * 2.0 + f64::cos(1.0))).abs() < 1e-12);
-/// assert!((ad_dx - fd.get_single_partial(&f, 0, &point).unwrap()).abs() < 1e-5);
+/// assert!((ad_dx - fd.first_partial_derivative(&f, 0, &point).unwrap()).abs() < 1e-5);
 ///
 /// // mixed second partial d2f/dx dy = 2x
-/// assert!((ad.get_double_partial(&f, &[0, 1], &point).unwrap() - 2.0).abs() < 1e-12);
+/// assert!((ad.second_partial_derivative(&f, &[0, 1], &point).unwrap() - 2.0).abs() < 1e-12);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AutoDiffMulti<T = f64> {
@@ -111,7 +111,7 @@ impl<T> AutoDiffMulti<T> {
     /// Const constructor (same as [`Default::default`]).
     ///
     /// ```
-    /// use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+    /// use multicalc::numerical_derivative::AutoDiffMulti;
     ///
     /// const D: AutoDiffMulti = AutoDiffMulti::new();
     /// ```
@@ -130,7 +130,7 @@ impl<T: Numeric> DerivatorMultiVariable for AutoDiffMulti<T> {
     /// `Dual<HyperDual>` (three independent directions). Orders beyond 3 return
     /// [`DiffError::OrderUnsupported`] (use [`AutoDiffSingle`] for high single-variable
     /// orders, or a finite-difference differentiator).
-    fn get<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize, const NUM_ORDER: usize>(
+    fn differentiate<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize, const NUM_ORDER: usize>(
         &self,
         func: &F,
         idx_to_differentiate: &[usize; NUM_ORDER],

--- a/crates/multicalc/src/numerical_derivative/autodiff.rs
+++ b/crates/multicalc/src/numerical_derivative/autodiff.rs
@@ -21,13 +21,14 @@ const MAX_ORDER: usize = 6;
 /// use multicalc::scalar_fn;
 ///
 /// // f(x) = x^3 -> f' = 3x^2, f'' = 6x, f''' = 6
-/// let f = scalar_fn!(|x| x * x * x);
-/// let d = AutoDiffSingle::default();
+/// let function = scalar_fn!(|x| x * x * x);
+/// let derivator = AutoDiffSingle::default();
+/// let point = 2.0_f64;
 ///
 /// // exact to rounding, no step size
-/// assert!((d.differentiate(1, &f, 2.0_f64).unwrap() - 12.0).abs() < 1e-12);
-/// assert!((d.differentiate(2, &f, 2.0_f64).unwrap() - 12.0).abs() < 1e-12);
-/// assert!((d.differentiate(3, &f, 2.0_f64).unwrap() - 6.0).abs() < 1e-12);
+/// assert!((derivator.differentiate(1, &function, point).unwrap() - 12.0).abs() < 1e-12);
+/// assert!((derivator.differentiate(2, &function, point).unwrap() - 12.0).abs() < 1e-12);
+/// assert!((derivator.differentiate(3, &function, point).unwrap() - 6.0).abs() < 1e-12);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AutoDiffSingle<T = f64> {
@@ -83,18 +84,26 @@ impl<T: Numeric> DerivatorSingleVariable for AutoDiffSingle<T> {
 /// use multicalc::scalar_fn;
 ///
 /// // f(x, y) = x^2 * y + sin(x)
-/// let f = scalar_fn!(|v: &[f64; 2]| v[0] * v[0] * v[1] + v[0].sin());
-/// let ad = AutoDiffMulti::default();
-/// let fd = FiniteDifferenceMulti::default();
+/// let function = scalar_fn!(|v: &[f64; 2]| v[0] * v[0] * v[1] + v[0].sin());
+/// let autodiff = AutoDiffMulti::default();
+/// let finite_difference = FiniteDifferenceMulti::default();
 /// let point = [1.0, 2.0];
+/// let x_index = 0;
 ///
 /// // df/dx = 2xy + cos(x): exact, and it agrees with finite differences
-/// let ad_dx = ad.first_partial_derivative(&f, 0, &point).unwrap();
-/// assert!((ad_dx - (2.0 * 1.0 * 2.0 + f64::cos(1.0))).abs() < 1e-12);
-/// assert!((ad_dx - fd.first_partial_derivative(&f, 0, &point).unwrap()).abs() < 1e-5);
+/// let slope_x = autodiff.first_partial_derivative(&function, x_index, &point).unwrap();
+/// assert!((slope_x - (2.0 * 1.0 * 2.0 + f64::cos(1.0))).abs() < 1e-12);
+/// let estimated = finite_difference
+///     .first_partial_derivative(&function, x_index, &point)
+///     .unwrap();
+/// assert!((slope_x - estimated).abs() < 1e-5);
 ///
 /// // mixed second partial d2f/dx dy = 2x
-/// assert!((ad.second_partial_derivative(&f, &[0, 1], &point).unwrap() - 2.0).abs() < 1e-12);
+/// let variable_indices = [0, 1];
+/// let mixed = autodiff
+///     .second_partial_derivative(&function, &variable_indices, &point)
+///     .unwrap();
+/// assert!((mixed - 2.0).abs() < 1e-12);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AutoDiffMulti<T = f64> {

--- a/crates/multicalc/src/numerical_derivative/derivator.rs
+++ b/crates/multicalc/src/numerical_derivative/derivator.rs
@@ -18,13 +18,17 @@ pub trait DerivatorSingleVariable {
     /// use multicalc::numerical_derivative::FiniteDifferenceSingle;
     /// use multicalc::scalar_fn;
     ///
-    /// let func = scalar_fn!(|x| x * x * x);
+    /// let function = scalar_fn!(|x| x * x * x);
     /// let derivator = FiniteDifferenceSingle::default();
+    /// let point = 2.0;
     ///
-    /// let val = derivator.differentiate(1, &func, 2.0).unwrap();
-    /// assert!(f64::abs(val - 12.0) < 1e-7);
-    /// let val = derivator.differentiate(2, &func, 2.0).unwrap();
-    /// assert!(f64::abs(val - 12.0) < 1e-5);
+    /// let first_order = 1;
+    /// let slope = derivator.differentiate(first_order, &function, point).unwrap();
+    /// assert!(f64::abs(slope - 12.0) < 1e-7);
+    ///
+    /// let second_order = 2;
+    /// let bend = derivator.differentiate(second_order, &function, point).unwrap();
+    /// assert!(f64::abs(bend - 12.0) < 1e-5);
     /// ```
     fn differentiate<F: ScalarFn>(
         &self,
@@ -73,13 +77,14 @@ pub trait DerivatorMultiVariable {
     /// use multicalc::scalar_fn;
     ///
     /// // f(x, y, z) = y*sin(x) + x*cos(y) + x*y*e^z
-    /// let func = scalar_fn!(|v: &[f64; 3]| v[1] * v[0].sin() + v[0] * v[1].cos() + v[0] * v[1] * v[2].exp());
+    /// let function = scalar_fn!(|v: &[f64; 3]| v[1] * v[0].sin() + v[0] * v[1].cos() + v[0] * v[1] * v[2].exp());
     /// let derivator = FiniteDifferenceMulti::default();
+    /// let variable_indices = [0, 1];   // once by x, then by y
+    /// let point = [1.0, 2.0, 3.0];
     ///
-    /// // mixed partial d(df/dx)/dy
-    /// let val = derivator.differentiate(&func, &[0, 1], &[1.0, 2.0, 3.0]).unwrap();
+    /// let mixed = derivator.differentiate(&function, &variable_indices, &point).unwrap();
     /// let expected = f64::cos(1.0) - f64::sin(2.0) + f64::exp(3.0);
-    /// assert!(f64::abs(val - expected) < 0.001);
+    /// assert!(f64::abs(mixed - expected) < 0.001);
     /// ```
     fn differentiate<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize, const NUM_ORDER: usize>(
         &self,

--- a/crates/multicalc/src/numerical_derivative/derivator.rs
+++ b/crates/multicalc/src/numerical_derivative/derivator.rs
@@ -14,19 +14,19 @@ pub trait DerivatorSingleVariable {
     ///
     /// # Examples
     /// ```
-    /// use multicalc::numerical_derivative::derivator::DerivatorSingleVariable;
-    /// use multicalc::numerical_derivative::finite_difference::FiniteDifferenceSingle;
+    /// use multicalc::numerical_derivative::DerivatorSingleVariable;
+    /// use multicalc::numerical_derivative::FiniteDifferenceSingle;
     /// use multicalc::scalar_fn;
     ///
     /// let func = scalar_fn!(|x| x * x * x);
     /// let derivator = FiniteDifferenceSingle::default();
     ///
-    /// let val = derivator.get(1, &func, 2.0).unwrap();
+    /// let val = derivator.differentiate(1, &func, 2.0).unwrap();
     /// assert!(f64::abs(val - 12.0) < 1e-7);
-    /// let val = derivator.get(2, &func, 2.0).unwrap();
+    /// let val = derivator.differentiate(2, &func, 2.0).unwrap();
     /// assert!(f64::abs(val - 12.0) < 1e-5);
     /// ```
-    fn get<F: ScalarFn>(
+    fn differentiate<F: ScalarFn>(
         &self,
         order: usize,
         func: &F,
@@ -34,21 +34,21 @@ pub trait DerivatorSingleVariable {
     ) -> Result<Self::Scalar, DiffError>;
 
     /// Convenience wrapper for the first derivative.
-    fn get_single<F: ScalarFn>(
+    fn first_derivative<F: ScalarFn>(
         &self,
         func: &F,
         point: Self::Scalar,
     ) -> Result<Self::Scalar, DiffError> {
-        self.get(1, func, point)
+        self.differentiate(1, func, point)
     }
 
     /// Convenience wrapper for the second derivative.
-    fn get_double<F: ScalarFn>(
+    fn second_derivative<F: ScalarFn>(
         &self,
         func: &F,
         point: Self::Scalar,
     ) -> Result<Self::Scalar, DiffError> {
-        self.get(2, func, point)
+        self.differentiate(2, func, point)
     }
 }
 
@@ -68,8 +68,8 @@ pub trait DerivatorMultiVariable {
     ///
     /// # Examples
     /// ```
-    /// use multicalc::numerical_derivative::derivator::DerivatorMultiVariable;
-    /// use multicalc::numerical_derivative::finite_difference::FiniteDifferenceMulti;
+    /// use multicalc::numerical_derivative::DerivatorMultiVariable;
+    /// use multicalc::numerical_derivative::FiniteDifferenceMulti;
     /// use multicalc::scalar_fn;
     ///
     /// // f(x, y, z) = y*sin(x) + x*cos(y) + x*y*e^z
@@ -77,11 +77,11 @@ pub trait DerivatorMultiVariable {
     /// let derivator = FiniteDifferenceMulti::default();
     ///
     /// // mixed partial d(df/dx)/dy
-    /// let val = derivator.get(&func, &[0, 1], &[1.0, 2.0, 3.0]).unwrap();
+    /// let val = derivator.differentiate(&func, &[0, 1], &[1.0, 2.0, 3.0]).unwrap();
     /// let expected = f64::cos(1.0) - f64::sin(2.0) + f64::exp(3.0);
     /// assert!(f64::abs(val - expected) < 0.001);
     /// ```
-    fn get<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize, const NUM_ORDER: usize>(
+    fn differentiate<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize, const NUM_ORDER: usize>(
         &self,
         func: &F,
         idx_to_differentiate: &[usize; NUM_ORDER],
@@ -89,23 +89,23 @@ pub trait DerivatorMultiVariable {
     ) -> Result<Self::Scalar, DiffError>;
 
     /// Convenience wrapper for a single partial derivative.
-    fn get_single_partial<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize>(
+    fn first_partial_derivative<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize>(
         &self,
         func: &F,
         idx_to_differentiate: usize,
         point: &[Self::Scalar; NUM_VARS],
     ) -> Result<Self::Scalar, DiffError> {
-        self.get(func, &[idx_to_differentiate], point)
+        self.differentiate(func, &[idx_to_differentiate], point)
     }
 
     /// Convenience wrapper for a second partial derivative.
-    fn get_double_partial<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize>(
+    fn second_partial_derivative<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize>(
         &self,
         func: &F,
         idx_to_differentiate: &[usize; 2],
         point: &[Self::Scalar; NUM_VARS],
     ) -> Result<Self::Scalar, DiffError> {
-        self.get(func, idx_to_differentiate, point)
+        self.differentiate(func, idx_to_differentiate, point)
     }
 
     /// Returns one column of a vector function's Jacobian: the partial derivative of every

--- a/crates/multicalc/src/numerical_derivative/finite_difference.rs
+++ b/crates/multicalc/src/numerical_derivative/finite_difference.rs
@@ -104,7 +104,7 @@ impl<T: Numeric> FiniteDifferenceSingle<T> {
 impl<T: Numeric> DerivatorSingleVariable for FiniteDifferenceSingle<T> {
     type Scalar = T;
 
-    fn get<F: ScalarFn>(&self, order: usize, func: &F, point: T) -> Result<T, DiffError> {
+    fn differentiate<F: ScalarFn>(&self, order: usize, func: &F, point: T) -> Result<T, DiffError> {
         if order == 0 {
             return Err(DiffError::OrderZero);
         }
@@ -166,7 +166,7 @@ impl<T: Numeric> FiniteDifferenceMulti<T> {
 impl<T: Numeric> DerivatorMultiVariable for FiniteDifferenceMulti<T> {
     type Scalar = T;
 
-    fn get<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize, const NUM_ORDER: usize>(
+    fn differentiate<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize, const NUM_ORDER: usize>(
         &self,
         func: &F,
         idx_to_differentiate: &[usize; NUM_ORDER],

--- a/crates/multicalc/src/numerical_derivative/hessian.rs
+++ b/crates/multicalc/src/numerical_derivative/hessian.rs
@@ -23,7 +23,7 @@ impl Hessian<AutoDiffMulti> {
     /// A Hessian using exact autodiff derivatives.
     ///
     /// ```
-    /// use multicalc::numerical_derivative::hessian::Hessian;
+    /// use multicalc::numerical_derivative::Hessian;
     ///
     /// const H: Hessian = Hessian::new();
     /// ```
@@ -55,7 +55,7 @@ impl<D: DerivatorMultiVariable> Hessian<D> {
     ///
     /// # Examples
     /// ```
-    /// use multicalc::numerical_derivative::hessian::Hessian;
+    /// use multicalc::numerical_derivative::Hessian;
     /// use multicalc::scalar::c;
     /// use multicalc::scalar_fn;
     ///
@@ -65,10 +65,10 @@ impl<D: DerivatorMultiVariable> Hessian<D> {
     ///
     ///
     /// let hessian: Hessian = Hessian::default();
-    /// let result = hessian.get(&my_func, &[1.0, 2.0]).unwrap();
+    /// let result = hessian.evaluate(&my_func, &[1.0, 2.0]).unwrap();
     /// assert!(f64::abs(result[(0, 0)] - (-2.0 * f64::sin(1.0))) < 1e-12);
     /// ```
-    pub fn get<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize>(
+    pub fn evaluate<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize>(
         &self,
         function: &F,
         vector_of_points: &[D::Scalar; NUM_VARS],
@@ -80,7 +80,7 @@ impl<D: DerivatorMultiVariable> Hessian<D> {
         for row_index in 0..NUM_VARS {
             for col_index in 0..NUM_VARS {
                 if result[(row_index, col_index)].is_nan() {
-                    result[(row_index, col_index)] = self.derivator.get_double_partial(
+                    result[(row_index, col_index)] = self.derivator.second_partial_derivative(
                         function,
                         &[row_index, col_index],
                         vector_of_points,

--- a/crates/multicalc/src/numerical_derivative/hessian.rs
+++ b/crates/multicalc/src/numerical_derivative/hessian.rs
@@ -60,12 +60,12 @@ impl<D: DerivatorMultiVariable> Hessian<D> {
     /// use multicalc::scalar_fn;
     ///
     /// // f(x, y) = y*sin(x) + 2*x*e^y
-    /// let my_func =
+    /// let function =
     ///     scalar_fn!(|args: &[f64; 2]| args[1] * args[0].sin() + c(2.0) * args[0] * args[1].exp());
-    ///
+    /// let point = [1.0, 2.0];
     ///
     /// let hessian: Hessian = Hessian::default();
-    /// let result = hessian.evaluate(&my_func, &[1.0, 2.0]).unwrap();
+    /// let result = hessian.evaluate(&function, &point).unwrap();
     /// assert!(f64::abs(result[(0, 0)] - (-2.0 * f64::sin(1.0))) < 1e-12);
     /// ```
     pub fn evaluate<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize>(

--- a/crates/multicalc/src/numerical_derivative/jacobian.rs
+++ b/crates/multicalc/src/numerical_derivative/jacobian.rs
@@ -62,11 +62,11 @@ impl<D: DerivatorMultiVariable> Jacobian<D> {
     /// use multicalc::scalar_fn_vec;
     ///
     /// // the vector function (x*y*z, x^2 + y^2)
-    /// let f = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
-    ///
+    /// let function = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
+    /// let point = [1.0, 2.0, 3.0];
     ///
     /// let jacobian: Jacobian = Jacobian::default();
-    /// let result = jacobian.evaluate(&f, &[1.0, 2.0, 3.0]).unwrap();
+    /// let result = jacobian.evaluate(&function, &point).unwrap();
     /// // result is [[6, 3, 2], [2, 4, 0]]
     /// assert!(f64::abs(result[(0, 0)] - 6.0) < 1e-12);
     /// ```

--- a/crates/multicalc/src/numerical_derivative/jacobian.rs
+++ b/crates/multicalc/src/numerical_derivative/jacobian.rs
@@ -26,7 +26,7 @@ impl Jacobian<AutoDiffMulti> {
     /// A Jacobian using exact autodiff derivatives.
     ///
     /// ```
-    /// use multicalc::numerical_derivative::jacobian::Jacobian;
+    /// use multicalc::numerical_derivative::Jacobian;
     ///
     /// const J: Jacobian = Jacobian::new();
     /// ```
@@ -58,7 +58,7 @@ impl<D: DerivatorMultiVariable> Jacobian<D> {
     ///
     /// # Examples
     /// ```
-    /// use multicalc::numerical_derivative::jacobian::Jacobian;
+    /// use multicalc::numerical_derivative::Jacobian;
     /// use multicalc::scalar_fn_vec;
     ///
     /// // the vector function (x*y*z, x^2 + y^2)
@@ -66,11 +66,15 @@ impl<D: DerivatorMultiVariable> Jacobian<D> {
     ///
     ///
     /// let jacobian: Jacobian = Jacobian::default();
-    /// let result = jacobian.get(&f, &[1.0, 2.0, 3.0]).unwrap();
+    /// let result = jacobian.evaluate(&f, &[1.0, 2.0, 3.0]).unwrap();
     /// // result is [[6, 3, 2], [2, 4, 0]]
     /// assert!(f64::abs(result[(0, 0)] - 6.0) < 1e-12);
     /// ```
-    pub fn get<F: VectorFn<NUM_VARS, NUM_FUNCS>, const NUM_FUNCS: usize, const NUM_VARS: usize>(
+    pub fn evaluate<
+        F: VectorFn<NUM_VARS, NUM_FUNCS>,
+        const NUM_FUNCS: usize,
+        const NUM_VARS: usize,
+    >(
         &self,
         function: &F,
         vector_of_points: &[D::Scalar; NUM_VARS],
@@ -93,7 +97,7 @@ impl<D: DerivatorMultiVariable> Jacobian<D> {
         Ok(result)
     }
 
-    /// Same as [`Jacobian::get`] but returns a heap-allocated `Vec<Vec<_>>`, which avoids a
+    /// Same as [`Jacobian::evaluate`] but returns a heap-allocated `Vec<Vec<_>>`, which avoids a
     /// stack overflow on large inputs. Requires the `alloc` feature (off by default).
     ///
     /// The result has one row per output and one column per variable, so entry `[m][n]`
@@ -108,7 +112,7 @@ impl<D: DerivatorMultiVariable> Jacobian<D> {
     /// [`DiffError::StepSizeZero`] if the derivator's step size is zero.
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-    pub fn get_on_heap<
+    pub fn evaluate_on_heap<
         F: VectorFn<NUM_VARS, NUM_FUNCS>,
         const NUM_FUNCS: usize,
         const NUM_VARS: usize,

--- a/crates/multicalc/src/numerical_derivative/mod.rs
+++ b/crates/multicalc/src/numerical_derivative/mod.rs
@@ -1,15 +1,16 @@
 //! Differentiation: exact automatic differentiation and finite differences.
 //!
 //! - [`derivative`] / [`second_derivative`] / [`partial`] — the short way to take one derivative.
-//! - [`autodiff`] / [`finite_difference`] — the two [`derivator`] backends (autodiff is exact).
-//! - [`jacobian`] / [`hessian`] — derivative matrices of vector- and scalar-valued functions.
+//! - [`AutoDiffSingle`] / [`FiniteDifferenceSingle`] and their multi-variable siblings — the two
+//!   backends behind [`DerivatorSingleVariable`] and [`DerivatorMultiVariable`] (autodiff is exact).
+//! - [`Jacobian`] / [`Hessian`] — derivative matrices of vector- and scalar-valued functions.
 
-pub mod autodiff;
-pub mod derivator;
-pub mod finite_difference;
-pub mod hessian;
-pub mod jacobian;
-pub mod mode;
+mod autodiff;
+mod derivator;
+mod finite_difference;
+mod hessian;
+mod jacobian;
+mod mode;
 
 pub use autodiff::{AutoDiffMulti, AutoDiffSingle};
 pub use derivator::{DerivatorMultiVariable, DerivatorSingleVariable};
@@ -85,5 +86,5 @@ pub fn partial<T: Numeric, F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize>(
     variable_index: usize,
     point: &[T; NUM_VARS],
 ) -> Result<T, DiffError> {
-    AutoDiffMulti::<T>::new().get_single_partial(function, variable_index, point)
+    AutoDiffMulti::<T>::new().first_partial_derivative(function, variable_index, point)
 }

--- a/crates/multicalc/src/numerical_derivative/mod.rs
+++ b/crates/multicalc/src/numerical_derivative/mod.rs
@@ -34,9 +34,11 @@ use crate::scalar::{Dual, HyperDual, Numeric, ScalarFn, ScalarFnN};
 /// use multicalc::numerical_derivative::derivative;
 /// use multicalc::scalar_fn;
 ///
-/// // f(x) = x^3, so f'(2) = 12
-/// let f = scalar_fn!(|x| x * x * x);
-/// assert!((derivative(&f, 2.0_f64) - 12.0).abs() < 1e-12);
+/// let function = scalar_fn!(|x| x * x * x);   // f(x) = x^3
+/// let point = 2.0_f64;
+///
+/// let slope = derivative(&function, point);   // f'(2) = 3x^2 = 12
+/// assert!((slope - 12.0).abs() < 1e-12);
 /// ```
 #[must_use]
 #[inline]
@@ -51,9 +53,11 @@ pub fn derivative<T: Numeric, F: ScalarFn>(function: &F, point: T) -> T {
 /// use multicalc::numerical_derivative::second_derivative;
 /// use multicalc::scalar_fn;
 ///
-/// // f(x) = x^3, so f''(2) = 12; f32 works the same way
-/// let f = scalar_fn!(|x| x * x * x);
-/// assert!((second_derivative(&f, 2.0_f32) - 12.0).abs() < 1e-4);
+/// let function = scalar_fn!(|x| x * x * x);   // f(x) = x^3
+/// let point = 2.0_f32;                        // f32 works the same way
+///
+/// let bend = second_derivative(&function, point);   // f''(2) = 6x = 12
+/// assert!((bend - 12.0).abs() < 1e-4);
 /// ```
 #[must_use]
 #[inline]
@@ -74,9 +78,12 @@ pub fn second_derivative<T: Numeric, F: ScalarFn>(function: &F, point: T) -> T {
 /// use multicalc::numerical_derivative::partial;
 /// use multicalc::scalar_fn;
 /// # fn main() -> Result<(), multicalc::error::DiffError> {
-/// // g(x, y) = x^2 * y, so dg/dx at (3, 4) is 2xy = 24
-/// let g = scalar_fn!(|v: &[f64; 2]| v[0] * v[0] * v[1]);
-/// assert!((partial(&g, 0, &[3.0_f64, 4.0])? - 24.0).abs() < 1e-12);
+/// let function = scalar_fn!(|v: &[f64; 2]| v[0] * v[0] * v[1]);   // g(x, y) = x^2 * y
+/// let variable_index = 0;                                         // differentiate by x
+/// let point = [3.0_f64, 4.0];
+///
+/// let slope = partial(&function, variable_index, &point)?;        // dg/dx = 2xy = 24
+/// assert!((slope - 24.0).abs() < 1e-12);
 /// # Ok(())
 /// # }
 /// ```

--- a/crates/multicalc/src/numerical_integration/gaussian_integration.rs
+++ b/crates/multicalc/src/numerical_integration/gaussian_integration.rs
@@ -186,16 +186,16 @@ impl<T: Numeric> IntegratorSingleVariable for GaussianSingle<T> {
     ///
     /// # Examples
     /// ```
-    /// use multicalc::numerical_integration::integrator::IntegratorSingleVariable;
-    /// use multicalc::numerical_integration::gaussian_integration::GaussianSingle;
+    /// use multicalc::numerical_integration::IntegratorSingleVariable;
+    /// use multicalc::numerical_integration::GaussianSingle;
     ///
     /// // Gauss-Legendre is exact for polynomials: integral of 4x^3 - 3x^2 over [0, 2] is 8
     /// let my_func = |x: f64| 4.0 * x * x * x - 3.0 * x * x;
     /// let integrator = GaussianSingle::default();
-    /// let val = integrator.get(&my_func, &[[0.0, 2.0]; 1]).unwrap();
+    /// let val = integrator.integrate(&my_func, &[[0.0, 2.0]; 1]).unwrap();
     /// assert!(f64::abs(val - 8.0) < 1e-7);
     /// ```
-    fn get<F: Fn(T) -> T, const NUM_INTEGRATIONS: usize>(
+    fn integrate<F: Fn(T) -> T, const NUM_INTEGRATIONS: usize>(
         &self,
         func: &F,
         integration_limit: &[[T; 2]; NUM_INTEGRATIONS],
@@ -352,18 +352,22 @@ impl<T: Numeric> IntegratorMultiVariable for GaussianMulti<T> {
     ///
     /// # Examples
     /// ```
-    /// use multicalc::numerical_integration::integrator::IntegratorMultiVariable;
-    /// use multicalc::numerical_integration::gaussian_integration::GaussianMulti;
+    /// use multicalc::numerical_integration::IntegratorMultiVariable;
+    /// use multicalc::numerical_integration::GaussianMulti;
     ///
     /// // f(x, y, z) = 2x + yz, integrated over x in [0, 1] with (y, z) = (2, 3); result is 7
     /// let my_func = |args: &[f64; 3]| 2.0 * args[0] + args[1] * args[2];
     /// let integrator = GaussianMulti::default();
     /// let point = [1.0, 2.0, 3.0];
     ///
-    /// let val = integrator.get([0; 1], &my_func, &[[0.0, 1.0]; 1], &point).unwrap();
+    /// let val = integrator.integrate([0; 1], &my_func, &[[0.0, 1.0]; 1], &point).unwrap();
     /// assert!(f64::abs(val - 7.0) < 1e-7);
     /// ```
-    fn get<F: Fn(&[T; NUM_VARS]) -> T, const NUM_VARS: usize, const NUM_INTEGRATIONS: usize>(
+    fn integrate<
+        F: Fn(&[T; NUM_VARS]) -> T,
+        const NUM_VARS: usize,
+        const NUM_INTEGRATIONS: usize,
+    >(
         &self,
         idx_to_integrate: [usize; NUM_INTEGRATIONS],
         func: &F,

--- a/crates/multicalc/src/numerical_integration/gaussian_integration.rs
+++ b/crates/multicalc/src/numerical_integration/gaussian_integration.rs
@@ -190,10 +190,12 @@ impl<T: Numeric> IntegratorSingleVariable for GaussianSingle<T> {
     /// use multicalc::numerical_integration::GaussianSingle;
     ///
     /// // Gauss-Legendre is exact for polynomials: integral of 4x^3 - 3x^2 over [0, 2] is 8
-    /// let my_func = |x: f64| 4.0 * x * x * x - 3.0 * x * x;
+    /// let cubic = |x: f64| 4.0 * x * x * x - 3.0 * x * x;
     /// let integrator = GaussianSingle::default();
-    /// let val = integrator.integrate(&my_func, &[[0.0, 2.0]; 1]).unwrap();
-    /// assert!(f64::abs(val - 8.0) < 1e-7);
+    /// let limits = [[0.0, 2.0]];
+    ///
+    /// let area = integrator.integrate(&cubic, &limits).unwrap();
+    /// assert!(f64::abs(area - 8.0) < 1e-7);
     /// ```
     fn integrate<F: Fn(T) -> T, const NUM_INTEGRATIONS: usize>(
         &self,
@@ -355,13 +357,15 @@ impl<T: Numeric> IntegratorMultiVariable for GaussianMulti<T> {
     /// use multicalc::numerical_integration::IntegratorMultiVariable;
     /// use multicalc::numerical_integration::GaussianMulti;
     ///
-    /// // f(x, y, z) = 2x + yz, integrated over x in [0, 1] with (y, z) = (2, 3); result is 7
-    /// let my_func = |args: &[f64; 3]| 2.0 * args[0] + args[1] * args[2];
+    /// // f(x, y, z) = 2x + yz, integrated over x with (y, z) held at (2, 3); result is 7
+    /// let function = |args: &[f64; 3]| 2.0 * args[0] + args[1] * args[2];
     /// let integrator = GaussianMulti::default();
+    /// let variable_indices = [0];        // integrate over x
+    /// let limits = [[0.0, 1.0]];
     /// let point = [1.0, 2.0, 3.0];
     ///
-    /// let val = integrator.integrate([0; 1], &my_func, &[[0.0, 1.0]; 1], &point).unwrap();
-    /// assert!(f64::abs(val - 7.0) < 1e-7);
+    /// let area = integrator.integrate(variable_indices, &function, &limits, &point).unwrap();
+    /// assert!(f64::abs(area - 7.0) < 1e-7);
     /// ```
     fn integrate<
         F: Fn(&[T; NUM_VARS]) -> T,

--- a/crates/multicalc/src/numerical_integration/integrator.rs
+++ b/crates/multicalc/src/numerical_integration/integrator.rs
@@ -85,28 +85,28 @@ pub trait IntegratorSingleVariable {
     /// # Errors
     /// [`IntegrateError::IterationsZero`] if the configured iteration count is zero, or
     /// [`IntegrateError::LimitsIllDefined`] if any limit is ill-defined.
-    fn get<F: Fn(Self::Scalar) -> Self::Scalar, const NUM_INTEGRATIONS: usize>(
+    fn integrate<F: Fn(Self::Scalar) -> Self::Scalar, const NUM_INTEGRATIONS: usize>(
         &self,
         func: &F,
         integration_limit: &[[Self::Scalar; 2]; NUM_INTEGRATIONS],
     ) -> Result<Self::Scalar, IntegrateError>;
 
     /// Convenience wrapper for a single integral of a single variable function.
-    fn get_single<F: Fn(Self::Scalar) -> Self::Scalar>(
+    fn single_integral<F: Fn(Self::Scalar) -> Self::Scalar>(
         &self,
         func: &F,
         integration_limit: &[Self::Scalar; 2],
     ) -> Result<Self::Scalar, IntegrateError> {
-        self.get(func, &[*integration_limit])
+        self.integrate(func, &[*integration_limit])
     }
 
     /// Convenience wrapper for a double integral of a single variable function.
-    fn get_double<F: Fn(Self::Scalar) -> Self::Scalar>(
+    fn double_integral<F: Fn(Self::Scalar) -> Self::Scalar>(
         &self,
         func: &F,
         integration_limit: &[[Self::Scalar; 2]; 2],
     ) -> Result<Self::Scalar, IntegrateError> {
-        self.get(func, integration_limit)
+        self.integrate(func, integration_limit)
     }
 }
 
@@ -128,7 +128,7 @@ pub trait IntegratorMultiVariable {
     /// # Errors
     /// [`IntegrateError::IterationsZero`] if the configured iteration count is zero, or
     /// [`IntegrateError::LimitsIllDefined`] if any limit is ill-defined.
-    fn get<
+    fn integrate<
         F: Fn(&[Self::Scalar; NUM_VARS]) -> Self::Scalar,
         const NUM_VARS: usize,
         const NUM_INTEGRATIONS: usize,
@@ -141,7 +141,7 @@ pub trait IntegratorMultiVariable {
     ) -> Result<Self::Scalar, IntegrateError>;
 
     /// Convenience wrapper for a single partial integral of a multi variable function.
-    fn get_single_partial<
+    fn single_partial_integral<
         F: Fn(&[Self::Scalar; NUM_VARS]) -> Self::Scalar,
         const NUM_VARS: usize,
     >(
@@ -151,11 +151,11 @@ pub trait IntegratorMultiVariable {
         integration_limits: &[Self::Scalar; 2],
         point: &[Self::Scalar; NUM_VARS],
     ) -> Result<Self::Scalar, IntegrateError> {
-        self.get([idx_to_integrate], func, &[*integration_limits], point)
+        self.integrate([idx_to_integrate], func, &[*integration_limits], point)
     }
 
     /// Convenience wrapper for a double partial integral of a multi variable function.
-    fn get_double_partial<
+    fn double_partial_integral<
         F: Fn(&[Self::Scalar; NUM_VARS]) -> Self::Scalar,
         const NUM_VARS: usize,
     >(
@@ -165,6 +165,6 @@ pub trait IntegratorMultiVariable {
         integration_limits: &[[Self::Scalar; 2]; 2],
         point: &[Self::Scalar; NUM_VARS],
     ) -> Result<Self::Scalar, IntegrateError> {
-        self.get(idx_to_integrate, func, integration_limits, point)
+        self.integrate(idx_to_integrate, func, integration_limits, point)
     }
 }

--- a/crates/multicalc/src/numerical_integration/iterative_integration.rs
+++ b/crates/multicalc/src/numerical_integration/iterative_integration.rs
@@ -288,20 +288,24 @@ impl<T: Numeric> IntegratorSingleVariable for IterativeSingle<T> {
     /// use multicalc::numerical_integration::IntegratorSingleVariable;
     /// use multicalc::numerical_integration::IterativeSingle;
     ///
-    /// let my_func = |x: f64| 2.0 * x;
+    /// let line = |x: f64| 2.0 * x;
     /// let integrator = IterativeSingle::default();
     ///
-    /// // single integration of 2x over [0, 2] is 4
-    /// let val = integrator.integrate(&my_func, &[[0.0, 2.0]; 1]).unwrap();
-    /// assert!(f64::abs(val - 4.0) < 1e-6);
+    /// // one integration of 2x over [0, 2] is 4
+    /// let single_limits = [[0.0, 2.0]];
+    /// let area = integrator.integrate(&line, &single_limits).unwrap();
+    /// assert!(f64::abs(area - 4.0) < 1e-6);
     ///
-    /// // double integration over [0, 2] then [-1, 1] is 8
-    /// let val = integrator.integrate(&my_func, &[[0.0, 2.0], [-1.0, 1.0]]).unwrap();
-    /// assert!(f64::abs(val - 8.0) < 1e-6);
+    /// // integrating twice, over [0, 2] then [-1, 1], is 8
+    /// let double_limits = [[0.0, 2.0], [-1.0, 1.0]];
+    /// let volume = integrator.integrate(&line, &double_limits).unwrap();
+    /// assert!(f64::abs(volume - 8.0) < 1e-6);
     ///
-    /// // an infinite limit, for a decaying integrand: integral of e^(-x^2) over the real line is sqrt(pi)
-    /// let val = integrator.integrate(&|x| (-x * x).exp(), &[[f64::NEG_INFINITY, f64::INFINITY]]).unwrap();
-    /// assert!(f64::abs(val - std::f64::consts::PI.sqrt()) < 1e-6);
+    /// // an infinite limit, for a decaying integrand
+    /// let bell = |x: f64| (-x * x).exp();
+    /// let real_line = [[f64::NEG_INFINITY, f64::INFINITY]];
+    /// let total = integrator.integrate(&bell, &real_line).unwrap();
+    /// assert!(f64::abs(total - std::f64::consts::PI.sqrt()) < 1e-6);
     /// ```
     fn integrate<F: Fn(T) -> T, const NUM_INTEGRATIONS: usize>(
         &self,
@@ -470,13 +474,15 @@ impl<T: Numeric> IntegratorMultiVariable for IterativeMulti<T> {
     /// use multicalc::numerical_integration::IntegratorMultiVariable;
     /// use multicalc::numerical_integration::IterativeMulti;
     ///
-    /// // f(x, y, z) = 2x + yz, integrated over x in [0, 1] with (y, z) = (2, 3); result is 7
-    /// let func = |args: &[f64; 3]| 2.0 * args[0] + args[1] * args[2];
-    /// let point = [1.0, 2.0, 3.0];
+    /// // f(x, y, z) = 2x + yz, integrated over x with (y, z) held at (2, 3); result is 7
+    /// let function = |args: &[f64; 3]| 2.0 * args[0] + args[1] * args[2];
     /// let integrator = IterativeMulti::default();
+    /// let variable_indices = [0];        // integrate over x
+    /// let limits = [[0.0, 1.0]];
+    /// let point = [1.0, 2.0, 3.0];
     ///
-    /// let val = integrator.integrate([0; 1], &func, &[[0.0, 1.0]; 1], &point).unwrap();
-    /// assert!(f64::abs(val - 7.0) < 1e-6);
+    /// let area = integrator.integrate(variable_indices, &function, &limits, &point).unwrap();
+    /// assert!(f64::abs(area - 7.0) < 1e-6);
     /// ```
     fn integrate<
         F: Fn(&[T; NUM_VARS]) -> T,

--- a/crates/multicalc/src/numerical_integration/iterative_integration.rs
+++ b/crates/multicalc/src/numerical_integration/iterative_integration.rs
@@ -285,25 +285,25 @@ impl<T: Numeric> IntegratorSingleVariable for IterativeSingle<T> {
     ///
     /// # Examples
     /// ```
-    /// use multicalc::numerical_integration::integrator::IntegratorSingleVariable;
-    /// use multicalc::numerical_integration::iterative_integration::IterativeSingle;
+    /// use multicalc::numerical_integration::IntegratorSingleVariable;
+    /// use multicalc::numerical_integration::IterativeSingle;
     ///
     /// let my_func = |x: f64| 2.0 * x;
     /// let integrator = IterativeSingle::default();
     ///
     /// // single integration of 2x over [0, 2] is 4
-    /// let val = integrator.get(&my_func, &[[0.0, 2.0]; 1]).unwrap();
+    /// let val = integrator.integrate(&my_func, &[[0.0, 2.0]; 1]).unwrap();
     /// assert!(f64::abs(val - 4.0) < 1e-6);
     ///
     /// // double integration over [0, 2] then [-1, 1] is 8
-    /// let val = integrator.get(&my_func, &[[0.0, 2.0], [-1.0, 1.0]]).unwrap();
+    /// let val = integrator.integrate(&my_func, &[[0.0, 2.0], [-1.0, 1.0]]).unwrap();
     /// assert!(f64::abs(val - 8.0) < 1e-6);
     ///
     /// // an infinite limit, for a decaying integrand: integral of e^(-x^2) over the real line is sqrt(pi)
-    /// let val = integrator.get(&|x| (-x * x).exp(), &[[f64::NEG_INFINITY, f64::INFINITY]]).unwrap();
+    /// let val = integrator.integrate(&|x| (-x * x).exp(), &[[f64::NEG_INFINITY, f64::INFINITY]]).unwrap();
     /// assert!(f64::abs(val - std::f64::consts::PI.sqrt()) < 1e-6);
     /// ```
-    fn get<F: Fn(T) -> T, const NUM_INTEGRATIONS: usize>(
+    fn integrate<F: Fn(T) -> T, const NUM_INTEGRATIONS: usize>(
         &self,
         func: &F,
         integration_limit: &[[T; 2]; NUM_INTEGRATIONS],
@@ -467,18 +467,22 @@ impl<T: Numeric> IntegratorMultiVariable for IterativeMulti<T> {
     ///
     /// # Examples
     /// ```
-    /// use multicalc::numerical_integration::integrator::IntegratorMultiVariable;
-    /// use multicalc::numerical_integration::iterative_integration::IterativeMulti;
+    /// use multicalc::numerical_integration::IntegratorMultiVariable;
+    /// use multicalc::numerical_integration::IterativeMulti;
     ///
     /// // f(x, y, z) = 2x + yz, integrated over x in [0, 1] with (y, z) = (2, 3); result is 7
     /// let func = |args: &[f64; 3]| 2.0 * args[0] + args[1] * args[2];
     /// let point = [1.0, 2.0, 3.0];
     /// let integrator = IterativeMulti::default();
     ///
-    /// let val = integrator.get([0; 1], &func, &[[0.0, 1.0]; 1], &point).unwrap();
+    /// let val = integrator.integrate([0; 1], &func, &[[0.0, 1.0]; 1], &point).unwrap();
     /// assert!(f64::abs(val - 7.0) < 1e-6);
     /// ```
-    fn get<F: Fn(&[T; NUM_VARS]) -> T, const NUM_VARS: usize, const NUM_INTEGRATIONS: usize>(
+    fn integrate<
+        F: Fn(&[T; NUM_VARS]) -> T,
+        const NUM_VARS: usize,
+        const NUM_INTEGRATIONS: usize,
+    >(
         &self,
         idx_to_integrate: [usize; NUM_INTEGRATIONS],
         func: &F,

--- a/crates/multicalc/src/numerical_integration/mod.rs
+++ b/crates/multicalc/src/numerical_integration/mod.rs
@@ -42,11 +42,18 @@ use crate::scalar::Numeric;
 /// ```
 /// use multicalc::numerical_integration::integral;
 /// # fn main() -> Result<(), multicalc::error::IntegrateError> {
-/// // 2x over [0, 2] is 4
-/// assert!((integral(&|x: f64| 2.0 * x, [0.0, 2.0])? - 4.0).abs() < 1e-9);
+/// let line = |x: f64| 2.0 * x;
+/// let limits = [0.0, 2.0];
 ///
-/// // a decaying integrand may run to infinity: e^-x over [0, inf) is 1
-/// assert!((integral(&|x: f64| (-x).exp(), [0.0, f64::INFINITY])? - 1.0).abs() < 1e-6);
+/// let area = integral(&line, limits)?;                    // 2x over [0, 2] is 4
+/// assert!((area - 4.0).abs() < 1e-9);
+///
+/// // a decaying integrand may run to infinity
+/// let decay = |x: f64| (-x).exp();
+/// let to_infinity = [0.0, f64::INFINITY];
+///
+/// let tail = integral(&decay, to_infinity)?;              // e^-x over [0, inf) is 1
+/// assert!((tail - 1.0).abs() < 1e-6);
 /// # Ok(())
 /// # }
 /// ```

--- a/crates/multicalc/src/numerical_integration/mod.rs
+++ b/crates/multicalc/src/numerical_integration/mod.rs
@@ -1,15 +1,17 @@
 //! Numerical integration.
 //!
 //! - [`integral`] — the short way to integrate one function over one interval.
-//! - [`gaussian_integration`] — Gaussian quadrature (nodes from
-//!   [`gaussian_tables`](crate::gaussian_tables)).
-//! - [`iterative_integration`] — iterative refinement of a running estimate.
-//! - [`integrator`] — the shared integrator traits; [`mode`] picks the method.
+//! - [`GaussianSingle`] / [`GaussianMulti`] — Gaussian quadrature (nodes from
+//!   [`gaussian_tables`](crate::gaussian_tables)), picking a family with
+//!   [`GaussianQuadratureMethod`].
+//! - [`IterativeSingle`] / [`IterativeMulti`] — iterative refinement of a running estimate, picking
+//!   a rule with [`IterativeMethod`].
+//! - [`IntegratorSingleVariable`] / [`IntegratorMultiVariable`] — the shared integrator traits.
 
-pub mod gaussian_integration;
-pub mod integrator;
-pub mod iterative_integration;
-pub mod mode;
+mod gaussian_integration;
+mod integrator;
+mod iterative_integration;
+mod mode;
 
 pub use crate::utils::summation::SummationMethod;
 
@@ -53,5 +55,5 @@ pub fn integral<T: Numeric, F: Fn(T) -> T>(
     function: &F,
     limits: [T; 2],
 ) -> Result<T, IntegrateError> {
-    IterativeSingle::<T>::default().get_single(function, &limits)
+    IterativeSingle::<T>::default().single_integral(function, &limits)
 }

--- a/crates/multicalc/src/ode/rk4.rs
+++ b/crates/multicalc/src/ode/rk4.rs
@@ -12,9 +12,14 @@ impl Rk4 {
     /// ```
     /// use multicalc::ode::Rk4;
     /// use multicalc::linear_algebra::Vector;
-    /// // y' = y, y(0) = 1  ->  y(dt) ≈ e^{dt}
-    /// let y1 = Rk4::step(&|_t, y: &Vector<1, f64>| *y, 0.0, &Vector::new([1.0]), 0.1);
-    /// assert!((y1[0] - 0.1_f64.exp()).abs() < 1e-6);
+    /// // y' = y, y(0) = 1  ->  y(timestep) ≈ e^{timestep}
+    /// let rate_of_change = |_t, y: &Vector<1, f64>| *y;
+    /// let start_time = 0.0;
+    /// let start_state = Vector::new([1.0]);
+    /// let timestep = 0.1;
+    ///
+    /// let next = Rk4::step(&rate_of_change, start_time, &start_state, timestep);
+    /// assert!((next[0] - 0.1_f64.exp()).abs() < 1e-6);
     /// ```
     pub fn step<const N: usize, T, F>(f: &F, t: T, y: &Vector<N, T>, dt: T) -> Vector<N, T>
     where
@@ -36,12 +41,24 @@ impl Rk4 {
     /// ```
     /// use multicalc::ode::Rk4;
     /// use multicalc::linear_algebra::Vector;
-    /// let mut last = 0.0;
     /// // y' = -y over [0, 1] in 100 steps; endpoint ≈ e^{-1}.
-    /// let yf = Rk4::integrate(&|_t, y: &Vector<1, f64>| -*y, 0.0,
-    ///     &Vector::new([1.0]), 0.01, 100, |_t, y| last = y[0]);
-    /// assert!((yf[0] - (-1.0_f64).exp()).abs() < 1e-6);
-    /// assert_eq!(last, yf[0]);
+    /// let rate_of_change = |_t, y: &Vector<1, f64>| -*y;
+    /// let start_time = 0.0;
+    /// let start_state = Vector::new([1.0]);
+    /// let timestep = 0.01;
+    /// let step_count = 100;
+    ///
+    /// let mut last = 0.0;
+    /// let final_state = Rk4::integrate(
+    ///     &rate_of_change,
+    ///     start_time,
+    ///     &start_state,
+    ///     timestep,
+    ///     step_count,
+    ///     |_t, y| last = y[0],
+    /// );
+    /// assert!((final_state[0] - (-1.0_f64).exp()).abs() < 1e-6);
+    /// assert_eq!(last, final_state[0]);
     /// ```
     pub fn integrate<const N: usize, T, F, O>(
         f: &F,

--- a/crates/multicalc/src/ode/rk45.rs
+++ b/crates/multicalc/src/ode/rk45.rs
@@ -271,10 +271,15 @@ impl<T: Numeric> Rk45<T> {
     /// use multicalc::ode::Rk45;
     /// use multicalc::linear_algebra::Vector;
     /// // y' = -y over [0, 2]; y(2) = e^{-2}.
-    /// let yf = Rk45::default()
-    ///     .solve(&|_t, y: &Vector<1, f64>| -*y, 0.0, &Vector::new([1.0]), 2.0)
+    /// let rate_of_change = |_t, y: &Vector<1, f64>| -*y;
+    /// let start_time = 0.0;
+    /// let start_state = Vector::new([1.0]);
+    /// let end_time = 2.0;
+    ///
+    /// let final_state = Rk45::default()
+    ///     .solve(&rate_of_change, start_time, &start_state, end_time)
     ///     .unwrap();
-    /// assert!((yf[0] - (-2.0_f64).exp()).abs() < 1e-6);
+    /// assert!((final_state[0] - (-2.0_f64).exp()).abs() < 1e-6);
     /// ```
     pub fn for_each_step<const N: usize, F, O>(
         &self,

--- a/crates/multicalc/src/optimization/gauss_newton.rs
+++ b/crates/multicalc/src/optimization/gauss_newton.rs
@@ -2,10 +2,10 @@
 
 use crate::error::SolveError;
 use crate::linear_algebra::Vector;
-use crate::linear_algebra::qr::{PivotedQr, enorm, max};
-use crate::numerical_derivative::autodiff::AutoDiffMulti;
-use crate::numerical_derivative::derivator::DerivatorMultiVariable;
-use crate::numerical_derivative::jacobian::Jacobian;
+use crate::linear_algebra::{PivotedQr, enorm, max};
+use crate::numerical_derivative::AutoDiffMulti;
+use crate::numerical_derivative::DerivatorMultiVariable;
+use crate::numerical_derivative::Jacobian;
 use crate::optimization::{MinimizationReport, TerminationReason, is_finite, report};
 use crate::scalar::{Numeric, Primal, VectorFn};
 
@@ -22,7 +22,7 @@ const MAX_BACKTRACK: usize = 20;
 /// # Examples
 /// ```
 /// use multicalc::optimization::GaussNewton;
-/// use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+/// use multicalc::numerical_derivative::AutoDiffMulti;
 /// use multicalc::scalar::c;
 /// use multicalc::scalar_fn_vec;
 ///
@@ -147,7 +147,7 @@ impl<D: DerivatorMultiVariable> GaussNewton<D> {
         let mut evaluations = 1usize;
 
         for _ in 0..self.patience {
-            let j = jacobian.get(f, &x)?;
+            let j = jacobian.evaluate(f, &x)?;
             if !j.is_finite() {
                 return Err(SolveError::NonFinite);
             }

--- a/crates/multicalc/src/optimization/gauss_newton.rs
+++ b/crates/multicalc/src/optimization/gauss_newton.rs
@@ -32,7 +32,10 @@ const MAX_BACKTRACK: usize = 20;
 ///     c(-3.0) + v[0] + v[1],
 ///     c(-5.0) + c(2.0) * v[0] + v[1],
 /// ]);
-/// let report = GaussNewton::<AutoDiffMulti>::default().minimize(&f, &[0.0, 0.0]).unwrap();
+/// let initial_guess = [0.0, 0.0];
+///
+/// let solver = GaussNewton::<AutoDiffMulti>::default();
+/// let report = solver.minimize(&f, &initial_guess).unwrap();
 /// assert!((report.solution[0] - 2.0).abs() < 1e-9);
 /// assert!((report.solution[1] - 1.0).abs() < 1e-9);
 /// ```

--- a/crates/multicalc/src/optimization/levenberg_marquardt.rs
+++ b/crates/multicalc/src/optimization/levenberg_marquardt.rs
@@ -2,10 +2,10 @@
 
 use crate::error::SolveError;
 use crate::linear_algebra::Vector;
-use crate::linear_algebra::qr::{PivotedQr, enorm, max, min};
-use crate::numerical_derivative::autodiff::AutoDiffMulti;
-use crate::numerical_derivative::derivator::DerivatorMultiVariable;
-use crate::numerical_derivative::jacobian::Jacobian;
+use crate::linear_algebra::{PivotedQr, enorm, max, min};
+use crate::numerical_derivative::AutoDiffMulti;
+use crate::numerical_derivative::DerivatorMultiVariable;
+use crate::numerical_derivative::Jacobian;
 use crate::optimization::trust_region::determine_lambda_and_parameter_update;
 use crate::optimization::{MinimizationReport, TerminationReason, is_finite, report};
 use crate::scalar::{Numeric, Primal, VectorFn};
@@ -22,7 +22,7 @@ const MAX_TRUST_REGION_TRIALS: usize = 100;
 /// # Examples
 /// ```
 /// use multicalc::optimization::LevenbergMarquardt;
-/// use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+/// use multicalc::numerical_derivative::AutoDiffMulti;
 /// use multicalc::scalar::c;
 /// use multicalc::scalar_fn_vec;
 ///
@@ -162,7 +162,7 @@ impl<D: DerivatorMultiVariable> LevenbergMarquardt<D> {
         let mut first = true;
 
         for _ in 0..self.patience {
-            let j = jacobian.get(f, &x)?;
+            let j = jacobian.evaluate(f, &x)?;
             if !j.is_finite() {
                 return Err(SolveError::NonFinite);
             }

--- a/crates/multicalc/src/optimization/levenberg_marquardt.rs
+++ b/crates/multicalc/src/optimization/levenberg_marquardt.rs
@@ -27,8 +27,11 @@ const MAX_TRUST_REGION_TRIALS: usize = 100;
 /// use multicalc::scalar_fn_vec;
 ///
 /// // Minimize the Rosenbrock residual; the minimum is at (1, 1).
-/// let f = scalar_fn_vec!(|v: &[f64; 2]| [c(10.0) * (v[1] - v[0] * v[0]), c(1.0) - v[0]]);
-/// let report = LevenbergMarquardt::<AutoDiffMulti>::default().minimize(&f, &[-1.2, 1.0]).unwrap();
+/// let residuals = scalar_fn_vec!(|v: &[f64; 2]| [c(10.0) * (v[1] - v[0] * v[0]), c(1.0) - v[0]]);
+/// let initial_guess = [-1.2, 1.0];
+///
+/// let solver = LevenbergMarquardt::<AutoDiffMulti>::default();
+/// let report = solver.minimize(&residuals, &initial_guess).unwrap();
 /// assert!((report.solution[0] - 1.0).abs() < 1e-6);
 /// assert!((report.solution[1] - 1.0).abs() < 1e-6);
 /// ```

--- a/crates/multicalc/src/optimization/mod.rs
+++ b/crates/multicalc/src/optimization/mod.rs
@@ -13,8 +13,8 @@
 //! 10 — a clean-room, fixed-size `no_std` reimplementation on this crate's own
 //! [`Vector`](crate::linear_algebra::Vector) and [`Matrix`](crate::linear_algebra::Matrix) types.
 
-pub mod gauss_newton;
-pub mod levenberg_marquardt;
+mod gauss_newton;
+mod levenberg_marquardt;
 pub(crate) mod trust_region;
 
 pub use gauss_newton::GaussNewton;

--- a/crates/multicalc/src/optimization/trust_region.rs
+++ b/crates/multicalc/src/optimization/trust_region.rs
@@ -1,7 +1,7 @@
 //! The Levenberg-Marquardt trust-region parameter search (MINPACK `lmpar`).
 
 use crate::linear_algebra::Vector;
-use crate::linear_algebra::qr::{DampedLeastSquares, enorm, max, min};
+use crate::linear_algebra::{DampedLeastSquares, enorm, max, min};
 use crate::scalar::Numeric;
 
 /// The damping parameter and step produced by the trust-region search.

--- a/crates/multicalc/src/root_finding/bisection.rs
+++ b/crates/multicalc/src/root_finding/bisection.rs
@@ -20,8 +20,11 @@ use crate::scalar::{Numeric, Primal, ScalarFn};
 /// use multicalc::scalar_fn;
 ///
 /// // f(x) = x² − 2, root at √2 ≈ 1.41421356
-/// let f = scalar_fn!(|x| c(-2.0) + x * x);
-/// let report = Bisection::default().solve(&f, 0.0_f64, 2.0).unwrap();
+/// let function = scalar_fn!(|x| c(-2.0) + x * x);
+/// let lower_bound = 0.0_f64;
+/// let upper_bound = 2.0;
+///
+/// let report = Bisection::default().solve(&function, lower_bound, upper_bound).unwrap();
 /// assert!((report.root - 2.0_f64.sqrt()).abs() < 1e-9);
 /// ```
 pub struct Bisection<T = f64> {

--- a/crates/multicalc/src/root_finding/mod.rs
+++ b/crates/multicalc/src/root_finding/mod.rs
@@ -2,14 +2,14 @@
 //!
 //! - [`Bisection`] — brackets a scalar root and halves the interval within a guaranteed budget.
 //! - [`Newton`] / [`NewtonSystem`] — Newton steps from any
-//!   [`Derivator`](crate::numerical_derivative::derivator) (exact autodiff by default), with an
-//!   optional backtracking line search.
+//!   [`DerivatorSingleVariable`](crate::numerical_derivative::DerivatorSingleVariable) (exact
+//!   autodiff by default), with an optional backtracking line search.
 //!
 //! Every solver takes an iteration budget and reports why it stopped as a [`RootTermination`].
 
-pub mod bisection;
-pub mod newton;
-pub mod newton_system;
+mod bisection;
+mod newton;
+mod newton_system;
 
 pub use bisection::Bisection;
 pub use newton::Newton;

--- a/crates/multicalc/src/root_finding/newton.rs
+++ b/crates/multicalc/src/root_finding/newton.rs
@@ -1,8 +1,8 @@
 //! Scalar Newton and damped Newton solvers.
 
 use crate::error::{LinalgError, SolveError};
-use crate::numerical_derivative::autodiff::AutoDiffSingle;
-use crate::numerical_derivative::derivator::DerivatorSingleVariable;
+use crate::numerical_derivative::AutoDiffSingle;
+use crate::numerical_derivative::DerivatorSingleVariable;
 use crate::root_finding::{RootReport, RootTermination};
 use crate::scalar::{Numeric, Primal, ScalarFn};
 
@@ -67,7 +67,7 @@ impl<D: DerivatorSingleVariable> Newton<D> {
     /// tolerances of `30 × EPSILON`, budget of 100 iterations, backtracking off.
     ///
     /// ```
-    /// use multicalc::numerical_derivative::autodiff::AutoDiffSingle;
+    /// use multicalc::numerical_derivative::AutoDiffSingle;
     /// use multicalc::root_finding::Newton;
     ///
     /// const D: AutoDiffSingle = AutoDiffSingle::new();
@@ -146,7 +146,7 @@ impl<D: DerivatorSingleVariable> Newton<D> {
                 });
             }
 
-            let dfx = self.derivator.get_single(f, x)?;
+            let dfx = self.derivator.first_derivative(f, x)?;
             if !dfx.is_finite() {
                 return Err(SolveError::NonFinite);
             }

--- a/crates/multicalc/src/root_finding/newton.rs
+++ b/crates/multicalc/src/root_finding/newton.rs
@@ -29,9 +29,11 @@ const MAX_BACKTRACK: usize = 20;
 /// use multicalc::scalar_fn;
 ///
 /// // f(x) = x² − 2, root at √2 ≈ 1.41421356
-/// let f = scalar_fn!(|x| c(-2.0) + x * x);
+/// let function = scalar_fn!(|x| c(-2.0) + x * x);
 /// let solver: Newton = Newton::default();
-/// let report = solver.solve(&f, 2.0_f64).unwrap();
+/// let initial_guess = 2.0_f64;
+///
+/// let report = solver.solve(&function, initial_guess).unwrap();
 /// assert!((report.root - 2.0_f64.sqrt()).abs() < 1e-12);
 /// ```
 pub struct Newton<D: DerivatorSingleVariable = AutoDiffSingle> {

--- a/crates/multicalc/src/root_finding/newton_system.rs
+++ b/crates/multicalc/src/root_finding/newton_system.rs
@@ -38,7 +38,9 @@ const MAX_BACKTRACK: usize = 20;
 ///     c(-1.0) + v[0] * v[1],
 /// ]);
 /// let solver: NewtonSystem = NewtonSystem::default();
-/// let report = solver.solve(&f, &[1.5_f64, 0.8]).unwrap();
+/// let initial_guess = [1.5_f64, 0.8];
+///
+/// let report = solver.solve(&f, &initial_guess).unwrap();
 /// assert!(report.residual_norm < 1e-12);
 /// ```
 pub struct NewtonSystem<D: DerivatorMultiVariable = AutoDiffMulti> {

--- a/crates/multicalc/src/root_finding/newton_system.rs
+++ b/crates/multicalc/src/root_finding/newton_system.rs
@@ -2,10 +2,10 @@
 
 use crate::error::SolveError;
 use crate::linear_algebra::Vector;
-use crate::linear_algebra::qr::enorm;
-use crate::numerical_derivative::autodiff::AutoDiffMulti;
-use crate::numerical_derivative::derivator::DerivatorMultiVariable;
-use crate::numerical_derivative::jacobian::Jacobian;
+use crate::linear_algebra::enorm;
+use crate::numerical_derivative::AutoDiffMulti;
+use crate::numerical_derivative::DerivatorMultiVariable;
+use crate::numerical_derivative::Jacobian;
 use crate::root_finding::{RootReportN, RootTermination, all_finite};
 use crate::scalar::{Numeric, Primal, VectorFn};
 
@@ -151,7 +151,7 @@ impl<D: DerivatorMultiVariable> NewtonSystem<D> {
                 });
             }
 
-            let j = jacobian.get(f, &x)?;
+            let j = jacobian.evaluate(f, &x)?;
             if !j.is_finite() {
                 return Err(SolveError::NonFinite);
             }

--- a/crates/multicalc/src/scalar/mod.rs
+++ b/crates/multicalc/src/scalar/mod.rs
@@ -6,16 +6,20 @@
 //! - [`ScalarFn`] / [`ScalarFnN`] / [`VectorFn`] — functions evaluable at any [`Numeric`] scalar, so
 //!   one formula drives both finite differences and autodiff.
 
-pub mod dual;
-pub mod function;
-pub mod hyper_dual;
-pub mod jet;
-pub mod numeric;
-pub mod primal;
+mod dual;
+mod function;
+mod hyper_dual;
+mod jet;
+mod numeric;
+mod primal;
 
 pub use dual::Dual;
-pub use function::{ScalarFn, ScalarFnN, VectorFn, c};
+pub use function::{Const, ScalarFn, ScalarFnN, VectorFn, c};
 pub use hyper_dual::HyperDual;
 pub use jet::Jet;
 pub use numeric::Numeric;
 pub use primal::Primal;
+
+/// One output of a vector function seen as a scalar function, reachable inside the crate now that
+/// `function` is private.
+pub(crate) use function::Component;

--- a/crates/multicalc/src/spatial/lie/so3.rs
+++ b/crates/multicalc/src/spatial/lie/so3.rs
@@ -14,10 +14,13 @@ use crate::spatial::lie::{inverse_left_jacobian_so3, left_jacobian_so3, skew3};
 /// ```
 /// use multicalc::spatial::SO3;
 /// use multicalc::linear_algebra::Vector;
-/// let r = SO3::<f64>::exp(Vector::new([0.0, 0.0, core::f64::consts::FRAC_PI_2]));
-/// let p = r.act(Vector::new([1.0, 0.0, 0.0]));
-/// assert!(p[0].abs() < 1e-12);
-/// assert!((p[1] - 1.0).abs() < 1e-12);
+/// let quarter_turn_about_z = Vector::new([0.0, 0.0, core::f64::consts::FRAC_PI_2]);
+/// let rotation = SO3::<f64>::exp(quarter_turn_about_z);
+///
+/// let point = Vector::new([1.0, 0.0, 0.0]);
+/// let rotated = rotation.act(point);          // the x axis swings onto the y axis
+/// assert!(rotated[0].abs() < 1e-12);
+/// assert!((rotated[1] - 1.0).abs() < 1e-12);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[allow(clippy::upper_case_acronyms)]

--- a/crates/multicalc/src/spatial/mod.rs
+++ b/crates/multicalc/src/spatial/mod.rs
@@ -6,10 +6,10 @@
 
 use crate::scalar::Numeric;
 
-pub mod lie;
-pub mod quaternion;
-pub mod twist;
-pub mod wrench;
+mod lie;
+mod quaternion;
+mod twist;
+mod wrench;
 
 pub use lie::{SE2, SE3, SO2, SO3};
 pub use quaternion::Quaternion;

--- a/crates/multicalc/src/spatial/quaternion.rs
+++ b/crates/multicalc/src/spatial/quaternion.rs
@@ -226,12 +226,15 @@ impl<T: Numeric> Quaternion<T> {
     /// ```
     /// use multicalc::spatial::Quaternion;
     /// use multicalc::linear_algebra::Vector;
-    /// let q = Quaternion::from_axis_angle(Vector::new([0.0, 0.0, 1.0]),
-    ///                                     core::f64::consts::FRAC_PI_2);
-    /// let p = q.transform_point(Vector::new([1.0, 0.0, 0.0]));
-    /// assert!((p[0] - 0.0).abs() < 1e-12);
-    /// assert!((p[1] - 1.0).abs() < 1e-12);
-    /// assert!((p[2] - 0.0).abs() < 1e-12);
+    /// let axis = Vector::new([0.0, 0.0, 1.0]);
+    /// let angle = core::f64::consts::FRAC_PI_2;
+    /// let rotation = Quaternion::from_axis_angle(axis, angle);
+    ///
+    /// let point = Vector::new([1.0, 0.0, 0.0]);
+    /// let rotated = rotation.transform_point(point);
+    /// assert!((rotated[0] - 0.0).abs() < 1e-12);
+    /// assert!((rotated[1] - 1.0).abs() < 1e-12);
+    /// assert!((rotated[2] - 0.0).abs() < 1e-12);
     /// ```
     #[inline]
     pub fn from_axis_angle(axis: Vector<3, T>, angle: T) -> Self {

--- a/crates/multicalc/src/spatial/twist.rs
+++ b/crates/multicalc/src/spatial/twist.rs
@@ -36,7 +36,9 @@ impl<T: Numeric> Twist<T> {
     /// ```
     /// use multicalc::linear_algebra::Vector;
     /// use multicalc::spatial::Twist;
-    /// let t = Twist::new(Vector::new([1.0_f64, 2.0, 3.0]), Vector::new([4.0, 5.0, 6.0]));
+    /// let linear = Vector::new([1.0_f64, 2.0, 3.0]);
+    /// let angular = Vector::new([4.0, 5.0, 6.0]);
+    /// let t = Twist::new(linear, angular);
     /// assert_eq!(t.linear(), Vector::new([1.0, 2.0, 3.0]));
     /// assert_eq!(t.angular(), Vector::new([4.0, 5.0, 6.0]));
     /// ```

--- a/crates/multicalc/src/spatial/wrench.rs
+++ b/crates/multicalc/src/spatial/wrench.rs
@@ -34,7 +34,9 @@ impl<T: Numeric> Wrench<T> {
     /// ```
     /// use multicalc::linear_algebra::Vector;
     /// use multicalc::spatial::Wrench;
-    /// let w = Wrench::new(Vector::new([1.0_f64, 2.0, 3.0]), Vector::new([4.0, 5.0, 6.0]));
+    /// let force = Vector::new([1.0_f64, 2.0, 3.0]);
+    /// let torque = Vector::new([4.0, 5.0, 6.0]);
+    /// let w = Wrench::new(force, torque);
     /// assert_eq!(w.force(), Vector::new([1.0, 2.0, 3.0]));
     /// assert_eq!(w.torque(), Vector::new([4.0, 5.0, 6.0]));
     /// ```

--- a/crates/multicalc/src/vector_field/curl.rs
+++ b/crates/multicalc/src/vector_field/curl.rs
@@ -27,7 +27,8 @@ use crate::scalar::{Numeric, VectorFn};
 /// let vf = scalar_fn_vec!(|v: &[f64; 3]| [v[1], -v[0], c(2.0) * v[2]]);
 ///
 /// let derivator = AutoDiffMulti::default();
-/// let val = curl_3d(derivator, &vf, &[0.0, 1.0, 3.0]).unwrap();
+/// let point = [0.0, 1.0, 3.0];
+/// let val = curl_3d(derivator, &vf, &point).unwrap();
 /// // curl is known to be (0, 0, -2)
 /// assert!(f64::abs(val[2] + 2.0) < 1e-12);
 /// ```
@@ -74,7 +75,8 @@ pub fn curl_3d<D: DerivatorMultiVariable, F: VectorFn<NUM_VARS, 3>, const NUM_VA
 /// let vf = scalar_fn_vec!(|v: &[f64; 2]| [c(2.0) * v[0] * v[1], c(3.0) * v[1].cos()]);
 ///
 /// let derivator = AutoDiffMulti::default();
-/// let val = curl_2d(derivator, &vf, &[1.0, 3.14]).unwrap();
+/// let point = [1.0, 3.14];
+/// let val = curl_2d(derivator, &vf, &point).unwrap();
 /// // curl is known to be -2
 /// assert!(f64::abs(val + 2.0) < 1e-12);
 /// ```

--- a/crates/multicalc/src/vector_field/curl.rs
+++ b/crates/multicalc/src/vector_field/curl.rs
@@ -1,6 +1,6 @@
 use crate::error::DiffError;
-use crate::numerical_derivative::derivator::DerivatorMultiVariable;
-use crate::scalar::function::Component;
+use crate::numerical_derivative::DerivatorMultiVariable;
+use crate::scalar::Component;
 use crate::scalar::{Numeric, VectorFn};
 
 /// Computes the curl of a 3D vector field at a point.
@@ -18,20 +18,20 @@ use crate::scalar::{Numeric, VectorFn};
 ///
 /// # Examples
 /// ```
-/// use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+/// use multicalc::numerical_derivative::AutoDiffMulti;
 /// use multicalc::scalar::c;
 /// use multicalc::scalar_fn_vec;
-/// use multicalc::vector_field::curl;
+/// use multicalc::vector_field::curl_3d;
 ///
 /// // the field (y, -x, 2z)
 /// let vf = scalar_fn_vec!(|v: &[f64; 3]| [v[1], -v[0], c(2.0) * v[2]]);
 ///
 /// let derivator = AutoDiffMulti::default();
-/// let val = curl::get_3d(derivator, &vf, &[0.0, 1.0, 3.0]).unwrap();
+/// let val = curl_3d(derivator, &vf, &[0.0, 1.0, 3.0]).unwrap();
 /// // curl is known to be (0, 0, -2)
 /// assert!(f64::abs(val[2] + 2.0) < 1e-12);
 /// ```
-pub fn get_3d<D: DerivatorMultiVariable, F: VectorFn<NUM_VARS, 3>, const NUM_VARS: usize>(
+pub fn curl_3d<D: DerivatorMultiVariable, F: VectorFn<NUM_VARS, 3>, const NUM_VARS: usize>(
     derivator: D,
     vector_field: &F,
     point: &[D::Scalar; NUM_VARS],
@@ -41,12 +41,12 @@ pub fn get_3d<D: DerivatorMultiVariable, F: VectorFn<NUM_VARS, 3>, const NUM_VAR
     let vz = Component::new(vector_field, 2);
 
     let mut ans = [<D::Scalar as Numeric>::ZERO; 3];
-    ans[0] = derivator.get_single_partial(&vz, 1, point)?
-        - derivator.get_single_partial(&vy, 2, point)?;
-    ans[1] = derivator.get_single_partial(&vx, 2, point)?
-        - derivator.get_single_partial(&vz, 0, point)?;
-    ans[2] = derivator.get_single_partial(&vy, 0, point)?
-        - derivator.get_single_partial(&vx, 1, point)?;
+    ans[0] = derivator.first_partial_derivative(&vz, 1, point)?
+        - derivator.first_partial_derivative(&vy, 2, point)?;
+    ans[1] = derivator.first_partial_derivative(&vx, 2, point)?
+        - derivator.first_partial_derivative(&vz, 0, point)?;
+    ans[2] = derivator.first_partial_derivative(&vy, 0, point)?
+        - derivator.first_partial_derivative(&vx, 1, point)?;
 
     Ok(ans)
 }
@@ -65,20 +65,20 @@ pub fn get_3d<D: DerivatorMultiVariable, F: VectorFn<NUM_VARS, 3>, const NUM_VAR
 ///
 /// # Examples
 /// ```
-/// use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+/// use multicalc::numerical_derivative::AutoDiffMulti;
 /// use multicalc::scalar::c;
 /// use multicalc::scalar_fn_vec;
-/// use multicalc::vector_field::curl;
+/// use multicalc::vector_field::curl_2d;
 ///
 /// // the field (2xy, 3cos(y))
 /// let vf = scalar_fn_vec!(|v: &[f64; 2]| [c(2.0) * v[0] * v[1], c(3.0) * v[1].cos()]);
 ///
 /// let derivator = AutoDiffMulti::default();
-/// let val = curl::get_2d(derivator, &vf, &[1.0, 3.14]).unwrap();
+/// let val = curl_2d(derivator, &vf, &[1.0, 3.14]).unwrap();
 /// // curl is known to be -2
 /// assert!(f64::abs(val + 2.0) < 1e-12);
 /// ```
-pub fn get_2d<D: DerivatorMultiVariable, F: VectorFn<NUM_VARS, 2>, const NUM_VARS: usize>(
+pub fn curl_2d<D: DerivatorMultiVariable, F: VectorFn<NUM_VARS, 2>, const NUM_VARS: usize>(
     derivator: D,
     vector_field: &F,
     point: &[D::Scalar; NUM_VARS],
@@ -86,6 +86,6 @@ pub fn get_2d<D: DerivatorMultiVariable, F: VectorFn<NUM_VARS, 2>, const NUM_VAR
     let vx = Component::new(vector_field, 0);
     let vy = Component::new(vector_field, 1);
 
-    Ok(derivator.get_single_partial(&vy, 0, point)?
-        - derivator.get_single_partial(&vx, 1, point)?)
+    Ok(derivator.first_partial_derivative(&vy, 0, point)?
+        - derivator.first_partial_derivative(&vx, 1, point)?)
 }

--- a/crates/multicalc/src/vector_field/divergence.rs
+++ b/crates/multicalc/src/vector_field/divergence.rs
@@ -1,7 +1,7 @@
 use crate::error::DiffError;
-use crate::numerical_derivative::derivator::DerivatorMultiVariable;
+use crate::numerical_derivative::DerivatorMultiVariable;
+use crate::scalar::Component;
 use crate::scalar::VectorFn;
-use crate::scalar::function::Component;
 
 /// Computes the divergence of a 3D vector field at a point.
 ///
@@ -17,20 +17,20 @@ use crate::scalar::function::Component;
 ///
 /// # Examples
 /// ```
-/// use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+/// use multicalc::numerical_derivative::AutoDiffMulti;
 /// use multicalc::scalar::c;
 /// use multicalc::scalar_fn_vec;
-/// use multicalc::vector_field::divergence;
+/// use multicalc::vector_field::divergence_3d;
 ///
 /// // the field (y, -x, 2z)
 /// let vf = scalar_fn_vec!(|v: &[f64; 3]| [v[1], -v[0], c(2.0) * v[2]]);
 ///
 /// let derivator = AutoDiffMulti::default();
-/// let val = divergence::get_3d(derivator, &vf, &[0.0, 1.0, 3.0]).unwrap();
+/// let val = divergence_3d(derivator, &vf, &[0.0, 1.0, 3.0]).unwrap();
 /// // divergence is known to be 2
 /// assert!(f64::abs(val - 2.0) < 1e-12);
 /// ```
-pub fn get_3d<D: DerivatorMultiVariable, F: VectorFn<NUM_VARS, 3>, const NUM_VARS: usize>(
+pub fn divergence_3d<D: DerivatorMultiVariable, F: VectorFn<NUM_VARS, 3>, const NUM_VARS: usize>(
     derivator: D,
     vector_field: &F,
     point: &[D::Scalar; NUM_VARS],
@@ -39,9 +39,9 @@ pub fn get_3d<D: DerivatorMultiVariable, F: VectorFn<NUM_VARS, 3>, const NUM_VAR
     let vy = Component::new(vector_field, 1);
     let vz = Component::new(vector_field, 2);
 
-    Ok(derivator.get_single_partial(&vx, 0, point)?
-        + derivator.get_single_partial(&vy, 1, point)?
-        + derivator.get_single_partial(&vz, 2, point)?)
+    Ok(derivator.first_partial_derivative(&vx, 0, point)?
+        + derivator.first_partial_derivative(&vy, 1, point)?
+        + derivator.first_partial_derivative(&vz, 2, point)?)
 }
 
 /// Computes the divergence of a 2D vector field at a point.
@@ -58,19 +58,19 @@ pub fn get_3d<D: DerivatorMultiVariable, F: VectorFn<NUM_VARS, 3>, const NUM_VAR
 ///
 /// # Examples
 /// ```
-/// use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+/// use multicalc::numerical_derivative::AutoDiffMulti;
 /// use multicalc::scalar_fn_vec;
-/// use multicalc::vector_field::divergence;
+/// use multicalc::vector_field::divergence_2d;
 ///
 /// // the field (y, -x)
 /// let vf = scalar_fn_vec!(|v: &[f64; 2]| [v[1], -v[0]]);
 ///
 /// let derivator = AutoDiffMulti::default();
-/// let val = divergence::get_2d(derivator, &vf, &[0.0, 1.0]).unwrap();
+/// let val = divergence_2d(derivator, &vf, &[0.0, 1.0]).unwrap();
 /// // divergence is known to be 0
 /// assert!(f64::abs(val) < 1e-12);
 /// ```
-pub fn get_2d<D: DerivatorMultiVariable, F: VectorFn<NUM_VARS, 2>, const NUM_VARS: usize>(
+pub fn divergence_2d<D: DerivatorMultiVariable, F: VectorFn<NUM_VARS, 2>, const NUM_VARS: usize>(
     derivator: D,
     vector_field: &F,
     point: &[D::Scalar; NUM_VARS],
@@ -78,6 +78,6 @@ pub fn get_2d<D: DerivatorMultiVariable, F: VectorFn<NUM_VARS, 2>, const NUM_VAR
     let vx = Component::new(vector_field, 0);
     let vy = Component::new(vector_field, 1);
 
-    Ok(derivator.get_single_partial(&vx, 0, point)?
-        + derivator.get_single_partial(&vy, 1, point)?)
+    Ok(derivator.first_partial_derivative(&vx, 0, point)?
+        + derivator.first_partial_derivative(&vy, 1, point)?)
 }

--- a/crates/multicalc/src/vector_field/divergence.rs
+++ b/crates/multicalc/src/vector_field/divergence.rs
@@ -26,7 +26,8 @@ use crate::scalar::VectorFn;
 /// let vf = scalar_fn_vec!(|v: &[f64; 3]| [v[1], -v[0], c(2.0) * v[2]]);
 ///
 /// let derivator = AutoDiffMulti::default();
-/// let val = divergence_3d(derivator, &vf, &[0.0, 1.0, 3.0]).unwrap();
+/// let point = [0.0, 1.0, 3.0];
+/// let val = divergence_3d(derivator, &vf, &point).unwrap();
 /// // divergence is known to be 2
 /// assert!(f64::abs(val - 2.0) < 1e-12);
 /// ```
@@ -66,7 +67,8 @@ pub fn divergence_3d<D: DerivatorMultiVariable, F: VectorFn<NUM_VARS, 3>, const 
 /// let vf = scalar_fn_vec!(|v: &[f64; 2]| [v[1], -v[0]]);
 ///
 /// let derivator = AutoDiffMulti::default();
-/// let val = divergence_2d(derivator, &vf, &[0.0, 1.0]).unwrap();
+/// let point = [0.0, 1.0];
+/// let val = divergence_2d(derivator, &vf, &point).unwrap();
 /// // divergence is known to be 0
 /// assert!(f64::abs(val) < 1e-12);
 /// ```

--- a/crates/multicalc/src/vector_field/flux_integral.rs
+++ b/crates/multicalc/src/vector_field/flux_integral.rs
@@ -29,7 +29,8 @@ use crate::vector_field::line_integral::{line_integral_partial_2d, line_integral
 /// let transformation_matrix: [&dyn Fn(f64) -> f64; 2] =
 ///     [&(|t: f64| t.cos()), &(|t: f64| t.sin())];
 ///
-/// let val = flux_integral_2d(&vector_field_matrix, &transformation_matrix, &[0.0, 6.28]).unwrap();
+/// let limits = [0.0, 6.28];   // one full turn around the circle
+/// let val = flux_integral_2d(&vector_field_matrix, &transformation_matrix, &limits).unwrap();
 /// // the flux integral is 0
 /// assert!(f64::abs(val) < 0.01);
 /// ```

--- a/crates/multicalc/src/vector_field/flux_integral.rs
+++ b/crates/multicalc/src/vector_field/flux_integral.rs
@@ -1,14 +1,14 @@
 use crate::error::IntegrateError;
-use crate::numerical_integration::iterative_integration::DEFAULT_TOTAL_ITERATIONS;
+use crate::numerical_integration::DEFAULT_TOTAL_ITERATIONS;
 use crate::scalar::Numeric;
 
-use crate::vector_field::line_integral;
+use crate::vector_field::line_integral::{line_integral_partial_2d, line_integral_partial_3d};
 
 /// Computes the flux integral of a 2D vector field across a parametrized curve.
 ///
 /// The curve is described by a parameter `t`: the transforms map `t` to each coordinate, and
 /// the field is sampled at the resulting curve position. Uses the default iteration count;
-/// see [`get_2d_custom`] to set it.
+/// see [`flux_integral_2d_custom`] to set it.
 ///
 /// # Arguments
 /// * `vector_field` - the two field components, each taking the curve position `[x, y]`.
@@ -21,7 +21,7 @@ use crate::vector_field::line_integral;
 ///
 /// # Examples
 /// ```
-/// use multicalc::vector_field::flux_integral;
+/// use multicalc::vector_field::flux_integral_2d;
 ///
 /// // the field (y, -x) across the unit circle (cos t, sin t), for t in [0, 2*pi]
 /// let vector_field_matrix: [&dyn Fn(&[f64; 2]) -> f64; 2] =
@@ -29,16 +29,16 @@ use crate::vector_field::line_integral;
 /// let transformation_matrix: [&dyn Fn(f64) -> f64; 2] =
 ///     [&(|t: f64| t.cos()), &(|t: f64| t.sin())];
 ///
-/// let val = flux_integral::get_2d(&vector_field_matrix, &transformation_matrix, &[0.0, 6.28]).unwrap();
+/// let val = flux_integral_2d(&vector_field_matrix, &transformation_matrix, &[0.0, 6.28]).unwrap();
 /// // the flux integral is 0
 /// assert!(f64::abs(val) < 0.01);
 /// ```
-pub fn get_2d<T: Numeric>(
+pub fn flux_integral_2d<T: Numeric>(
     vector_field: &[&dyn Fn(&[T; 2]) -> T; 2],
     transformations: &[&dyn Fn(T) -> T; 2],
     integration_limit: &[T; 2],
 ) -> Result<T, IntegrateError> {
-    get_2d_custom(
+    flux_integral_2d_custom(
         vector_field,
         transformations,
         integration_limit,
@@ -46,25 +46,25 @@ pub fn get_2d<T: Numeric>(
     )
 }
 
-/// Same as [`get_2d`] but with an explicit iteration count for finer control.
+/// Same as [`flux_integral_2d`] but with an explicit iteration count for finer control.
 ///
 /// # Errors
 /// [`IntegrateError::IterationsZero`] if `total_iterations` is zero, or
 /// [`IntegrateError::LimitsIllDefined`] if the lower limit is not strictly less than the
 /// upper limit.
-pub fn get_2d_custom<T: Numeric>(
+pub fn flux_integral_2d_custom<T: Numeric>(
     vector_field: &[&dyn Fn(&[T; 2]) -> T; 2],
     transformations: &[&dyn Fn(T) -> T; 2],
     integration_limit: &[T; 2],
     total_iterations: u64,
 ) -> Result<T, IntegrateError> {
-    Ok(line_integral::get_partial_2d(
+    Ok(line_integral_partial_2d(
         vector_field,
         transformations,
         integration_limit,
         total_iterations,
         0,
-    )? - line_integral::get_partial_2d(
+    )? - line_integral_partial_2d(
         vector_field,
         transformations,
         integration_limit,
@@ -73,12 +73,12 @@ pub fn get_2d_custom<T: Numeric>(
     )?)
 }
 
-pub fn get_3d<T: Numeric>(
+pub fn flux_integral_3d<T: Numeric>(
     vector_field: &[&dyn Fn(&[T; 3]) -> T; 3],
     transformations: &[&dyn Fn(T) -> T; 3],
     integration_limit: &[T; 2],
 ) -> Result<T, IntegrateError> {
-    get_3d_custom(
+    flux_integral_3d_custom(
         vector_field,
         transformations,
         integration_limit,
@@ -86,25 +86,25 @@ pub fn get_3d<T: Numeric>(
     )
 }
 
-pub fn get_3d_custom<T: Numeric>(
+pub fn flux_integral_3d_custom<T: Numeric>(
     vector_field: &[&dyn Fn(&[T; 3]) -> T; 3],
     transformations: &[&dyn Fn(T) -> T; 3],
     integration_limit: &[T; 2],
     total_iterations: u64,
 ) -> Result<T, IntegrateError> {
-    Ok(line_integral::get_partial_3d(
+    Ok(line_integral_partial_3d(
         vector_field,
         transformations,
         integration_limit,
         total_iterations,
         0,
-    )? - line_integral::get_partial_3d(
+    )? - line_integral_partial_3d(
         vector_field,
         transformations,
         integration_limit,
         total_iterations,
         1,
-    )? - line_integral::get_partial_3d(
+    )? - line_integral_partial_3d(
         vector_field,
         transformations,
         integration_limit,

--- a/crates/multicalc/src/vector_field/line_integral.rs
+++ b/crates/multicalc/src/vector_field/line_integral.rs
@@ -1,5 +1,5 @@
 use crate::error::IntegrateError;
-use crate::numerical_integration::iterative_integration::DEFAULT_TOTAL_ITERATIONS;
+use crate::numerical_integration::DEFAULT_TOTAL_ITERATIONS;
 use crate::scalar::Numeric;
 
 /// Builds the curve position [transformations[0](t), ..., transformations[N-1](t)].
@@ -59,7 +59,7 @@ fn get_partial<T: Numeric, const N: usize>(
 ///
 /// The curve is described by a parameter `t`: the transforms map `t` to each coordinate, and
 /// the field is sampled at the resulting curve position. Uses the default iteration count;
-/// see [`get_2d_custom`] to set it.
+/// see [`line_integral_2d_custom`] to set it.
 ///
 /// # Arguments
 /// * `vector_field` - the two field components, each taking the curve position `[x, y]`.
@@ -72,7 +72,7 @@ fn get_partial<T: Numeric, const N: usize>(
 ///
 /// # Examples
 /// ```
-/// use multicalc::vector_field::line_integral;
+/// use multicalc::vector_field::line_integral_2d;
 ///
 /// // the field (y, -x) along the unit circle (cos t, sin t), for t in [0, 2*pi]
 /// let vector_field_matrix: [&dyn Fn(&[f64; 2]) -> f64; 2] =
@@ -80,16 +80,16 @@ fn get_partial<T: Numeric, const N: usize>(
 /// let transformation_matrix: [&dyn Fn(f64) -> f64; 2] =
 ///     [&(|t: f64| t.cos()), &(|t: f64| t.sin())];
 ///
-/// let val = line_integral::get_2d(&vector_field_matrix, &transformation_matrix, &[0.0, 6.28]).unwrap();
+/// let val = line_integral_2d(&vector_field_matrix, &transformation_matrix, &[0.0, 6.28]).unwrap();
 /// // the line integral is -2*pi
 /// assert!(f64::abs(val + 6.28) < 0.01);
 /// ```
-pub fn get_2d<T: Numeric>(
+pub fn line_integral_2d<T: Numeric>(
     vector_field: &[&dyn Fn(&[T; 2]) -> T; 2],
     transformations: &[&dyn Fn(T) -> T; 2],
     integration_limit: &[T; 2],
 ) -> Result<T, IntegrateError> {
-    get_2d_custom(
+    line_integral_2d_custom(
         vector_field,
         transformations,
         integration_limit,
@@ -97,25 +97,25 @@ pub fn get_2d<T: Numeric>(
     )
 }
 
-/// Same as [`get_2d`] but with an explicit iteration count for finer control.
+/// Same as [`line_integral_2d`] but with an explicit iteration count for finer control.
 ///
 /// # Errors
 /// [`IntegrateError::IterationsZero`] if `total_iterations` is zero, or
 /// [`IntegrateError::LimitsIllDefined`] if the lower limit is not strictly less than the
 /// upper limit.
-pub fn get_2d_custom<T: Numeric>(
+pub fn line_integral_2d_custom<T: Numeric>(
     vector_field: &[&dyn Fn(&[T; 2]) -> T; 2],
     transformations: &[&dyn Fn(T) -> T; 2],
     integration_limit: &[T; 2],
     total_iterations: u64,
 ) -> Result<T, IntegrateError> {
-    Ok(get_partial_2d(
+    Ok(line_integral_partial_2d(
         vector_field,
         transformations,
         integration_limit,
         total_iterations,
         0,
-    )? + get_partial_2d(
+    )? + line_integral_partial_2d(
         vector_field,
         transformations,
         integration_limit,
@@ -125,13 +125,13 @@ pub fn get_2d_custom<T: Numeric>(
 }
 
 /// Line integral of a single field component (`idx`) along the 2D curve. Used by both
-/// [`get_2d_custom`] and the flux integral.
+/// [`line_integral_2d_custom`] and the flux integral.
 ///
 /// # Errors
 /// [`IntegrateError::IterationsZero`] if `total_iterations` is zero, or
 /// [`IntegrateError::LimitsIllDefined`] if the lower limit is not strictly less than the
 /// upper limit.
-pub fn get_partial_2d<T: Numeric>(
+pub fn line_integral_partial_2d<T: Numeric>(
     vector_field: &[&dyn Fn(&[T; 2]) -> T; 2],
     transformations: &[&dyn Fn(T) -> T; 2],
     integration_limit: &[T; 2],
@@ -147,18 +147,18 @@ pub fn get_partial_2d<T: Numeric>(
     )
 }
 
-/// Same as [`get_2d`] but for a parametrized curve in a 3D vector field. Uses the default
-/// iteration count; see [`get_3d_custom`] to set it.
+/// Same as [`line_integral_2d`] but for a parametrized curve in a 3D vector field. Uses the default
+/// iteration count; see [`line_integral_3d_custom`] to set it.
 ///
 /// # Errors
 /// [`IntegrateError::LimitsIllDefined`] if the lower limit is not strictly less than the
 /// upper limit.
-pub fn get_3d<T: Numeric>(
+pub fn line_integral_3d<T: Numeric>(
     vector_field: &[&dyn Fn(&[T; 3]) -> T; 3],
     transformations: &[&dyn Fn(T) -> T; 3],
     integration_limit: &[T; 2],
 ) -> Result<T, IntegrateError> {
-    get_3d_custom(
+    line_integral_3d_custom(
         vector_field,
         transformations,
         integration_limit,
@@ -166,31 +166,31 @@ pub fn get_3d<T: Numeric>(
     )
 }
 
-/// Same as [`get_3d`] but with an explicit iteration count for finer control.
+/// Same as [`line_integral_3d`] but with an explicit iteration count for finer control.
 ///
 /// # Errors
 /// [`IntegrateError::IterationsZero`] if `total_iterations` is zero, or
 /// [`IntegrateError::LimitsIllDefined`] if the lower limit is not strictly less than the
 /// upper limit.
-pub fn get_3d_custom<T: Numeric>(
+pub fn line_integral_3d_custom<T: Numeric>(
     vector_field: &[&dyn Fn(&[T; 3]) -> T; 3],
     transformations: &[&dyn Fn(T) -> T; 3],
     integration_limit: &[T; 2],
     total_iterations: u64,
 ) -> Result<T, IntegrateError> {
-    Ok(get_partial_3d(
+    Ok(line_integral_partial_3d(
         vector_field,
         transformations,
         integration_limit,
         total_iterations,
         0,
-    )? + get_partial_3d(
+    )? + line_integral_partial_3d(
         vector_field,
         transformations,
         integration_limit,
         total_iterations,
         1,
-    )? + get_partial_3d(
+    )? + line_integral_partial_3d(
         vector_field,
         transformations,
         integration_limit,
@@ -200,13 +200,13 @@ pub fn get_3d_custom<T: Numeric>(
 }
 
 /// Line integral of a single field component (`idx`) along the 3D curve. Used by both
-/// [`get_3d_custom`] and the flux integral.
+/// [`line_integral_3d_custom`] and the flux integral.
 ///
 /// # Errors
 /// [`IntegrateError::IterationsZero`] if `total_iterations` is zero, or
 /// [`IntegrateError::LimitsIllDefined`] if the lower limit is not strictly less than the
 /// upper limit.
-pub fn get_partial_3d<T: Numeric>(
+pub fn line_integral_partial_3d<T: Numeric>(
     vector_field: &[&dyn Fn(&[T; 3]) -> T; 3],
     transformations: &[&dyn Fn(T) -> T; 3],
     integration_limit: &[T; 2],

--- a/crates/multicalc/src/vector_field/line_integral.rs
+++ b/crates/multicalc/src/vector_field/line_integral.rs
@@ -80,7 +80,8 @@ fn get_partial<T: Numeric, const N: usize>(
 /// let transformation_matrix: [&dyn Fn(f64) -> f64; 2] =
 ///     [&(|t: f64| t.cos()), &(|t: f64| t.sin())];
 ///
-/// let val = line_integral_2d(&vector_field_matrix, &transformation_matrix, &[0.0, 6.28]).unwrap();
+/// let limits = [0.0, 6.28];   // one full turn around the circle
+/// let val = line_integral_2d(&vector_field_matrix, &transformation_matrix, &limits).unwrap();
 /// // the line integral is -2*pi
 /// assert!(f64::abs(val + 6.28) < 0.01);
 /// ```

--- a/crates/multicalc/src/vector_field/mod.rs
+++ b/crates/multicalc/src/vector_field/mod.rs
@@ -1,9 +1,21 @@
 //! Vector calculus on 2D/3D fields.
 //!
-//! - [`curl`] / [`divergence`] — differential operators on a vector field.
-//! - [`line_integral`] / [`flux_integral`] — a field integrated along a curve or through a surface.
+//! - [`curl_2d`] / [`curl_3d`] / [`divergence_2d`] / [`divergence_3d`] — differential operators on
+//!   a vector field.
+//! - [`line_integral_2d`] / [`flux_integral_2d`] and their 3D forms — a field integrated along a
+//!   curve or through a surface.
 
-pub mod curl;
-pub mod divergence;
-pub mod flux_integral;
-pub mod line_integral;
+mod curl;
+mod divergence;
+mod flux_integral;
+mod line_integral;
+
+pub use curl::{curl_2d, curl_3d};
+pub use divergence::{divergence_2d, divergence_3d};
+pub use flux_integral::{
+    flux_integral_2d, flux_integral_2d_custom, flux_integral_3d, flux_integral_3d_custom,
+};
+pub use line_integral::{
+    line_integral_2d, line_integral_2d_custom, line_integral_3d, line_integral_3d_custom,
+    line_integral_partial_2d, line_integral_partial_3d,
+};

--- a/crates/multicalc/tests/suite/approximation.rs
+++ b/crates/multicalc/tests/suite/approximation.rs
@@ -1,8 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use multicalc::approximation::linear_approximation::*;
-use multicalc::approximation::quadratic_approximation::*;
-use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+use multicalc::approximation::*;
+use multicalc::numerical_derivative::AutoDiffMulti;
 use multicalc::scalar::{Numeric, ScalarFnN, c};
 use multicalc::scalar_fn;
 use proptest::prelude::*;
@@ -17,7 +16,9 @@ fn test_linear_approximation_1() {
 
     let approximator = LinearApproximator::<AutoDiffMulti>::default();
 
-    let result = approximator.get(&function_to_approximate, &point).unwrap();
+    let result = approximator
+        .approximate(&function_to_approximate, &point)
+        .unwrap();
     assert!(f64::abs(function_to_approximate.eval(&point) - result.predict(&point)) < 1e-9);
 
     //now test the prediction metrics. For prediction, generate a list of 1000 points, all centered around the original point
@@ -31,7 +32,7 @@ fn test_linear_approximation_1() {
     }
 
     let prediction_metrics =
-        result.get_prediction_metrics(&prediction_points, &function_to_approximate);
+        result.prediction_metrics(&prediction_points, &function_to_approximate);
 
     assert!(prediction_metrics.root_mean_squared_error < 0.05);
     assert!(prediction_metrics.mean_absolute_error < 0.05);
@@ -50,7 +51,9 @@ fn test_quadratic_approximation_1() {
 
     let approximator = QuadraticApproximator::<AutoDiffMulti>::default();
 
-    let result = approximator.get(&function_to_approximate, &point).unwrap();
+    let result = approximator
+        .approximate(&function_to_approximate, &point)
+        .unwrap();
 
     assert!(f64::abs(function_to_approximate.eval(&point) - result.predict(&point)) < 1e-9);
 
@@ -65,7 +68,7 @@ fn test_quadratic_approximation_1() {
     }
 
     let prediction_metrics =
-        result.get_prediction_metrics(&prediction_points, &function_to_approximate);
+        result.prediction_metrics(&prediction_points, &function_to_approximate);
 
     assert!(prediction_metrics.root_mean_squared_error < 0.01);
     assert!(prediction_metrics.mean_absolute_error < 0.01);
@@ -84,7 +87,9 @@ fn test_linear_approximation_exact() {
     let point = [1.0, 2.0, 3.0];
 
     let approximator = LinearApproximator::<AutoDiffMulti>::default();
-    let result = approximator.get(&function_to_approximate, &point).unwrap();
+    let result = approximator
+        .approximate(&function_to_approximate, &point)
+        .unwrap();
 
     //prediction matches the truth away from the base point, not just at it
     let elsewhere = [4.0, -1.0, 0.5];
@@ -97,7 +102,7 @@ fn test_linear_approximation_exact() {
         *p = [1.0 + s, 2.0 - s, 3.0 + 0.5 * s];
     }
 
-    let metrics = result.get_prediction_metrics(&prediction_points, &function_to_approximate);
+    let metrics = result.prediction_metrics(&prediction_points, &function_to_approximate);
     assert!(metrics.mean_absolute_error < 1e-9);
     assert!(metrics.root_mean_squared_error < 1e-9);
     assert!(f64::abs(metrics.r_squared - 1.0) < 1e-9);
@@ -113,7 +118,7 @@ fn kahan_metrics_exact_on_affine() {
 
     let model = LinearApproximator::<AutoDiffMulti>::default()
         .with_kahan_summation()
-        .get(&truth, &point)
+        .approximate(&truth, &point)
         .unwrap();
 
     let mut points = [[0.0; 3]; 10];
@@ -122,7 +127,7 @@ fn kahan_metrics_exact_on_affine() {
         *p = [1.0 + s, 2.0 - s, 3.0 + 0.5 * s];
     }
 
-    let metrics = model.get_prediction_metrics(&points, &truth);
+    let metrics = model.prediction_metrics(&points, &truth);
 
     assert!(metrics.mean_absolute_error < 1e-9);
     assert!(metrics.root_mean_squared_error < 1e-9);
@@ -140,14 +145,14 @@ fn metrics_are_accurate_on_large_point_set() {
     let a = 6.0;
 
     let approximator = LinearApproximator::<AutoDiffMulti>::default();
-    let result = approximator.get(&truth, &[a]).unwrap();
+    let result = approximator.approximate(&truth, &[a]).unwrap();
 
     let mut prediction_points = [[0.0; 1]; N];
     for (i, p) in prediction_points.iter_mut().enumerate() {
         p[0] = 1.0 + i as f64 * 0.001; //x spread over [1.0, 11.0)
     }
 
-    let metrics = result.get_prediction_metrics(&prediction_points, &truth);
+    let metrics = result.prediction_metrics(&prediction_points, &truth);
 
     //closed-form reference: residual(x) = -(x - a)^2 and y = x^2
     let n = N as f64;
@@ -202,7 +207,7 @@ fn test_linear_approximation_f32() {
     let point = [1.0_f32, 2.0, 3.0];
 
     let approximator = LinearApproximator::<AutoDiffMulti<f32>>::default();
-    let result = approximator.get(&truth, &point).unwrap();
+    let result = approximator.approximate(&truth, &point).unwrap();
 
     let nearby = [1.05_f32, 2.05, 2.95];
     let predicted = result.predict(&nearby);
@@ -261,7 +266,7 @@ proptest! {
         let scale = 1.0 + b.abs() + a0.abs() + a1.abs();
         let tol = approx_tol(scale, 1.0);
         let model = LinearApproximator::<AutoDiffMulti>::default()
-            .get(&f, &point).unwrap();
+            .approximate(&f, &point).unwrap();
 
         let mut points = [[0.0; 2]; 8];
         for (dst, &(x, y)) in points.iter_mut().zip(samples.iter()) {
@@ -273,7 +278,7 @@ proptest! {
             prop_assert!(err < approx_tol(scale, f.eval(p)));
         }
 
-        let metrics = model.get_prediction_metrics(&points, &f);
+        let metrics = model.prediction_metrics(&points, &f);
         prop_assert!(metrics.mean_absolute_error < tol);
         prop_assert!(metrics.root_mean_squared_error < tol);
         prop_assert!(
@@ -308,7 +313,7 @@ proptest! {
         let tol = approx_tol(scale, 1.0);
 
         let model = QuadraticApproximator::<AutoDiffMulti>::default()
-            .get(&f, &point)
+            .approximate(&f, &point)
             .unwrap();
 
         let mut points = [[0.0; 2]; 8];
@@ -321,7 +326,7 @@ proptest! {
             prop_assert!(err < approx_tol(scale, f.eval(p)));
         }
 
-        let metrics = model.get_prediction_metrics(&points, &f);
+        let metrics = model.prediction_metrics(&points, &f);
         prop_assert!(metrics.mean_absolute_error < tol);
         prop_assert!(metrics.root_mean_squared_error < tol);
         prop_assert!(

--- a/crates/multicalc/tests/suite/estimation/extended_kalman_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/extended_kalman_filter.rs
@@ -3,8 +3,8 @@
 use multicalc::error::{DiffError, EstimationError};
 use multicalc::estimation::{CovarianceUpdate, ExtendedKalmanFilter, KalmanFilter, KalmanModel};
 use multicalc::linear_algebra::{Matrix, Vector};
-use multicalc::numerical_derivative::finite_difference::FiniteDifferenceMulti;
-use multicalc::numerical_derivative::mode::FiniteDifferenceMode;
+use multicalc::numerical_derivative::FiniteDifferenceMode;
+use multicalc::numerical_derivative::FiniteDifferenceMulti;
 use multicalc::scalar::{Dual, Numeric, VectorFn};
 use multicalc_testkit::tol::{Tol, assert_matrix_close, assert_vector_close};
 use proptest::prelude::*;

--- a/crates/multicalc/tests/suite/gaussian_tables.rs
+++ b/crates/multicalc/tests/suite/gaussian_tables.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use multicalc::gaussian_tables::{MAX_ORDER, nodes};
-use multicalc::numerical_integration::mode::GaussianQuadratureMethod;
+use multicalc::numerical_integration::GaussianQuadratureMethod;
 
 use proptest::prelude::*;
 

--- a/crates/multicalc/tests/suite/numerical_derivative.rs
+++ b/crates/multicalc/tests/suite/numerical_derivative.rs
@@ -1,12 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use multicalc::error::DiffError;
-use multicalc::numerical_derivative::autodiff::{AutoDiffMulti, AutoDiffSingle};
-use multicalc::numerical_derivative::derivator::*;
-use multicalc::numerical_derivative::finite_difference::*;
-use multicalc::numerical_derivative::hessian::Hessian;
-use multicalc::numerical_derivative::jacobian::Jacobian;
-use multicalc::numerical_derivative::mode::*;
+use multicalc::numerical_derivative::*;
 use multicalc::scalar::{Numeric, ScalarFn, ScalarFnN, VectorFn, c};
 use multicalc::{scalar_fn, scalar_fn_vec};
 use multicalc_testkit::problems::G;
@@ -22,9 +17,9 @@ fn ad_single_derivative() {
     let func = scalar_fn!(|x| x * x * x);
     let d = AutoDiffSingle::default();
 
-    assert!(f64::abs(d.get(1, &func, 2.0).unwrap() - 12.0) < 1e-12);
-    assert!(f64::abs(d.get(2, &func, 2.0).unwrap() - 12.0) < 1e-12);
-    assert!(f64::abs(d.get(3, &func, 2.0).unwrap() - 6.0) < 1e-12);
+    assert!(f64::abs(d.differentiate(1, &func, 2.0).unwrap() - 12.0) < 1e-12);
+    assert!(f64::abs(d.differentiate(2, &func, 2.0).unwrap() - 12.0) < 1e-12);
+    assert!(f64::abs(d.differentiate(3, &func, 2.0).unwrap() - 6.0) < 1e-12);
 }
 
 #[test]
@@ -34,8 +29,8 @@ fn ad_first_partials() {
     let d = AutoDiffMulti::default();
     let point = [1.0, 3.0];
 
-    assert!(f64::abs(d.get_single_partial(&func, 0, &point).unwrap() - 12.0) < 1e-12);
-    assert!(f64::abs(d.get_single_partial(&func, 1, &point).unwrap() - 2.0) < 1e-12);
+    assert!(f64::abs(d.first_partial_derivative(&func, 0, &point).unwrap() - 12.0) < 1e-12);
+    assert!(f64::abs(d.first_partial_derivative(&func, 1, &point).unwrap() - 2.0) < 1e-12);
 }
 
 #[test]
@@ -47,11 +42,11 @@ fn ad_first_partials_transcendental() {
 
     // df/dx = y*cos(x) + cos(y) + y*e^z
     let dx = 2.0 * f64::cos(1.0) + f64::cos(2.0) + 2.0 * f64::exp(3.0);
-    assert!(f64::abs(d.get_single_partial(&func, 0, &point).unwrap() - dx) < 1e-12);
+    assert!(f64::abs(d.first_partial_derivative(&func, 0, &point).unwrap() - dx) < 1e-12);
 
     // df/dz = x*y*e^z
     let dz = 1.0 * 2.0 * f64::exp(3.0);
-    assert!(f64::abs(d.get_single_partial(&func, 2, &point).unwrap() - dz) < 1e-12);
+    assert!(f64::abs(d.first_partial_derivative(&func, 2, &point).unwrap() - dz) < 1e-12);
 }
 
 #[test]
@@ -63,11 +58,11 @@ fn ad_second_partials() {
 
     // d2f/dx2 = -y*sin(x)
     let dxx = -2.0 * f64::sin(1.0);
-    assert!(f64::abs(d.get_double_partial(&func, &[0, 0], &point).unwrap() - dxx) < 1e-12);
+    assert!(f64::abs(d.second_partial_derivative(&func, &[0, 0], &point).unwrap() - dxx) < 1e-12);
 
     // mixed d2f/dx dy = cos(x) - sin(y) + e^z
     let dxy = f64::cos(1.0) - f64::sin(2.0) + f64::exp(3.0);
-    assert!(f64::abs(d.get_double_partial(&func, &[0, 1], &point).unwrap() - dxy) < 1e-12);
+    assert!(f64::abs(d.second_partial_derivative(&func, &[0, 1], &point).unwrap() - dxy) < 1e-12);
 }
 
 #[test]
@@ -77,8 +72,8 @@ fn ad_third_partials() {
     let d = AutoDiffMulti::default();
     let point = [1.0, 2.0, 3.0];
 
-    assert!(f64::abs(d.get(&func, &[0, 1, 2], &point).unwrap() - 972.0) < 1e-9);
-    assert!(f64::abs(d.get(&func, &[0, 0, 1], &point).unwrap() - 1944.0) < 1e-9);
+    assert!(f64::abs(d.differentiate(&func, &[0, 1, 2], &point).unwrap() - 972.0) < 1e-9);
+    assert!(f64::abs(d.differentiate(&func, &[0, 0, 1], &point).unwrap() - 1944.0) < 1e-9);
 }
 
 #[test]
@@ -86,7 +81,7 @@ fn ad_jacobian() {
     // (x*y*z, x^2 + y^2)
     let f = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
     let jacobian: Jacobian = Jacobian::default();
-    let result = jacobian.get(&f, &[1.0, 2.0, 3.0]).unwrap();
+    let result = jacobian.evaluate(&f, &[1.0, 2.0, 3.0]).unwrap();
 
     let expected = [[6.0, 3.0, 2.0], [2.0, 4.0, 0.0]];
     for i in 0..2 {
@@ -101,7 +96,7 @@ fn ad_jacobian() {
 fn ad_jacobian_on_heap() {
     let f = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
     let jacobian: Jacobian = Jacobian::default();
-    let result = jacobian.get_on_heap(&f, &[1.0, 2.0, 3.0]).unwrap();
+    let result = jacobian.evaluate_on_heap(&f, &[1.0, 2.0, 3.0]).unwrap();
 
     let expected = [[6.0, 3.0, 2.0], [2.0, 4.0, 0.0]];
     for i in 0..2 {
@@ -116,7 +111,7 @@ fn ad_hessian() {
     // f(x, y) = y*sin(x) + 2*x*e^y
     let func = scalar_fn!(|v: &[f64; 2]| v[1] * v[0].sin() + c(2.0) * v[0] * v[1].exp());
     let hessian: Hessian = Hessian::default();
-    let result = hessian.get(&func, &[1.0, 2.0]).unwrap();
+    let result = hessian.evaluate(&func, &[1.0, 2.0]).unwrap();
 
     let expected = [
         [-2.0 * f64::sin(1.0), f64::cos(1.0) + 2.0 * f64::exp(2.0)],
@@ -134,7 +129,7 @@ fn ad_f32() {
     // x*x at 0.5; first derivative 2x = 1.0, exact under autodiff
     let func = scalar_fn!(|x| x * x);
     let d = AutoDiffSingle::<f32>::default();
-    assert!(f32::abs(d.get(1, &func, 0.5_f32).unwrap() - 1.0) < 1e-6);
+    assert!(f32::abs(d.differentiate(1, &func, 0.5_f32).unwrap() - 1.0) < 1e-6);
 }
 
 // ----- autodiff error handling -----
@@ -143,7 +138,7 @@ fn ad_f32() {
 fn ad_error_index_out_of_range() {
     let func = scalar_fn!(|v: &[f64; 3]| v[0] + v[1] + v[2]);
     let d = AutoDiffMulti::default();
-    let result = d.get_single_partial(&func, 5, &[1.0, 2.0, 3.0]);
+    let result = d.first_partial_derivative(&func, 5, &[1.0, 2.0, 3.0]);
     assert_eq!(result.unwrap_err(), DiffError::IndexOutOfRange);
 }
 
@@ -153,7 +148,7 @@ fn ad_error_order_zero() {
     let d = AutoDiffMulti::default();
     let idx: [usize; 0] = [];
     assert_eq!(
-        d.get(&func, &idx, &[1.0, 2.0, 3.0]).unwrap_err(),
+        d.differentiate(&func, &idx, &[1.0, 2.0, 3.0]).unwrap_err(),
         DiffError::OrderZero
     );
 }
@@ -164,7 +159,8 @@ fn ad_error_order_unsupported() {
     let func = scalar_fn!(|v: &[f64; 3]| v[0] + v[1] + v[2]);
     let d = AutoDiffMulti::default();
     assert_eq!(
-        d.get(&func, &[0, 1, 2, 0], &[1.0, 2.0, 3.0]).unwrap_err(),
+        d.differentiate(&func, &[0, 1, 2, 0], &[1.0, 2.0, 3.0])
+            .unwrap_err(),
         DiffError::OrderUnsupported
     );
 }
@@ -180,7 +176,7 @@ fn ad_jacobian_empty_error() {
     }
 
     let jacobian: Jacobian = Jacobian::default();
-    let result = jacobian.get(&EmptyVectorFn, &[1.0, 2.0, 3.0]);
+    let result = jacobian.evaluate(&EmptyVectorFn, &[1.0, 2.0, 3.0]);
     assert_eq!(result.unwrap_err(), DiffError::EmptyFunctionSet);
 }
 
@@ -206,7 +202,7 @@ fn ad_jacobian_is_column_seeded() {
         calls: Cell::new(0),
     };
     let jacobian: Jacobian = Jacobian::default();
-    let result = jacobian.get(&f, &[1.0, 2.0, 3.0]).unwrap();
+    let result = jacobian.evaluate(&f, &[1.0, 2.0, 3.0]).unwrap();
 
     // values are unchanged from the old harness
     let expected = [[6.0, 3.0, 2.0], [2.0, 4.0, 0.0]];
@@ -244,7 +240,7 @@ fn fd_jacobian_column_matches() {
     // values to finite-difference tolerance (unchanged from the per-Component path it replaces)
     let f = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
     let jacobian = Jacobian::from_derivator(FiniteDifferenceMulti::default());
-    let result = jacobian.get(&f, &[1.0, 2.0, 3.0]).unwrap();
+    let result = jacobian.evaluate(&f, &[1.0, 2.0, 3.0]).unwrap();
 
     let expected = [[6.0, 3.0, 2.0], [2.0, 4.0, 0.0]];
     for i in 0..2 {
@@ -262,7 +258,7 @@ fn fd_jacobian_is_column_seeded() {
         calls: Cell::new(0),
     };
     let jacobian = Jacobian::from_derivator(FiniteDifferenceMulti::default());
-    let _ = jacobian.get(&f, &[1.0, 2.0, 3.0]).unwrap();
+    let _ = jacobian.evaluate(&f, &[1.0, 2.0, 3.0]).unwrap();
     assert_eq!(f.calls.get(), 6);
 }
 
@@ -280,7 +276,7 @@ fn fd_single_derivative_modes() {
     ] {
         let mut d = FiniteDifferenceSingle::default();
         d.config.method = mode;
-        assert!(f64::abs(d.get(1, &func, 2.0).unwrap() - 2.0) < 0.001);
+        assert!(f64::abs(d.differentiate(1, &func, 2.0).unwrap() - 2.0) < 0.001);
     }
 }
 
@@ -289,7 +285,7 @@ fn fd_step_size_zero_error() {
     let func = scalar_fn!(|v: &[f64; 3]| v[1] * v[0].sin());
     let d = FiniteDifferenceMulti::from_parameters(0.0, FiniteDifferenceMode::Central, 1.0);
     assert_eq!(
-        d.get(&func, &[0], &[1.0, 2.0, 3.0]).unwrap_err(),
+        d.differentiate(&func, &[0], &[1.0, 2.0, 3.0]).unwrap_err(),
         DiffError::StepSizeZero
     );
 }
@@ -348,9 +344,9 @@ proptest! {
         let scale = 1.0 + coeff_l1(&inner) + coeff_l1(&outer);
         let f = PolyComp { inner, outer };
         let h = DEFAULT_STEP_SIZE;
-        let ad = AutoDiffSingle::default().get(1, &f, x).unwrap();
+        let ad = AutoDiffSingle::default().differentiate(1, &f, x).unwrap();
         let fd = FiniteDifferenceSingle::default();
-        let fd_val = fd.get(1, &f, x).unwrap();
+        let fd_val = fd.differentiate(1, &f, x).unwrap();
         let tol = ad_fd_tol(ad, h, 2, 1e3, scale);
         prop_assert!(
             (fd_val - ad).abs() < tol,
@@ -371,8 +367,8 @@ proptest! {
         let ad_d = AutoDiffMulti::default();
         let fd_d = FiniteDifferenceMulti::default();
         for idx in [0usize, 1] {
-            let ad = ad_d.get_single_partial(&f, idx, &point).unwrap();
-            let fd_val = fd_d.get_single_partial(&f, idx, &point).unwrap();
+            let ad = ad_d.first_partial_derivative(&f, idx, &point).unwrap();
+            let fd_val = fd_d.first_partial_derivative(&f, idx, &point).unwrap();
             let tol = ad_fd_tol(ad, h, 2, 1e3, scale);
             prop_assert!(
                 (fd_val -ad).abs() < tol,
@@ -401,13 +397,13 @@ fn proptest_ad_fd_single_second() {
             let scale = 1.0 + coeff_l1(&inner) + coeff_l1(&outer);
             let f = PolyComp { inner, outer };
             let h = 1e-4;
-            let ad = AutoDiffSingle::default().get(2, &f, x).unwrap();
+            let ad = AutoDiffSingle::default().differentiate(2, &f, x).unwrap();
             let fd = FiniteDifferenceSingle::from_parameters(
                 h,
                 FiniteDifferenceMode::Central,
                 DEFAULT_STEP_SIZE_MULTIPLIER,
             );
-            let fd_val = fd.get(2, &f, x).unwrap();
+            let fd_val = fd.differentiate(2, &f, x).unwrap();
             let tol = ad_fd_tol(ad, h, 2, 1e4, scale);
             prop_assert!((fd_val - ad).abs() < tol, "fd={fd_val} ad={ad} tol={tol}");
             Ok(())

--- a/crates/multicalc/tests/suite/numerical_integration.rs
+++ b/crates/multicalc/tests/suite/numerical_integration.rs
@@ -1,11 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use multicalc::numerical_integration::mode::*;
-
 use multicalc::error::IntegrateError;
-use multicalc::numerical_integration::gaussian_integration;
-use multicalc::numerical_integration::integrator::*;
-use multicalc::numerical_integration::iterative_integration;
+use multicalc::numerical_integration::*;
 
 use proptest::prelude::*;
 
@@ -16,11 +12,12 @@ fn test_booles_integration_1() {
 
     let integration_limit = [0.0, 2.0];
 
-    let integrator =
-        iterative_integration::IterativeSingle::from_parameters(100, IterativeMethod::Booles);
+    let integrator = IterativeSingle::from_parameters(100, IterativeMethod::Booles);
 
     //simple integration for x, known to be x*x, expect a value of ~4.00
-    let val = integrator.get_single(&func, &integration_limit).unwrap();
+    let val = integrator
+        .single_integral(&func, &integration_limit)
+        .unwrap();
     assert!(f64::abs(val - 4.0) < 1e-14);
 }
 
@@ -32,12 +29,11 @@ fn test_booles_integration_2() {
     let integration_limit = [0.0, 1.0];
     let point = [1.0, 2.0, 3.0];
 
-    let integrator =
-        iterative_integration::IterativeMulti::from_parameters(100, IterativeMethod::Booles);
+    let integrator = IterativeMulti::from_parameters(100, IterativeMethod::Booles);
 
     //partial integration for x, known to be x*x + x*y*z, expect a value of ~7.00
     let val = integrator
-        .get_single_partial(&func, 0, &integration_limit, &point)
+        .single_partial_integral(&func, 0, &integration_limit, &point)
         .unwrap();
     assert!(f64::abs(val - 7.0) < 1e-25);
 
@@ -45,7 +41,7 @@ fn test_booles_integration_2() {
 
     //partial integration for y, known to be 2.0*x*y + y*y*z/2.0, expect a value of ~10.00
     let val = integrator
-        .get_single_partial(&func, 1, &integration_limit, &point)
+        .single_partial_integral(&func, 1, &integration_limit, &point)
         .unwrap();
     assert!(f64::abs(val - 10.0) < 0.00001);
 
@@ -53,7 +49,7 @@ fn test_booles_integration_2() {
 
     //partial integration for z, known to be 2.0*x*z + y*z*z/2.0, expect a value of ~15.0
     let val = integrator
-        .get_single_partial(&func, 2, &integration_limit, &point)
+        .single_partial_integral(&func, 2, &integration_limit, &point)
         .unwrap();
     assert!(f64::abs(val - 15.0) < 0.00001);
 }
@@ -65,11 +61,12 @@ fn test_booles_integration_3() {
 
     let integration_limits = [[0.0, 2.0], [0.0, 2.0]];
 
-    let integrator =
-        iterative_integration::IterativeSingle::from_parameters(20, IterativeMethod::Booles);
+    let integrator = IterativeSingle::from_parameters(20, IterativeMethod::Booles);
 
     //simple double integration for 6*x, expect a value of ~24.00
-    let val = integrator.get_double(&func, &integration_limits).unwrap();
+    let val = integrator
+        .double_integral(&func, &integration_limits)
+        .unwrap();
     assert!(f64::abs(val - 24.0) < 0.00001);
 }
 
@@ -80,13 +77,12 @@ fn test_gauss_legendre_quadrature_integration_1() {
 
     let integration_limit = [0.0, 2.0];
 
-    let integrator = gaussian_integration::GaussianSingle::from_parameters(
-        4,
-        GaussianQuadratureMethod::GaussLegendre,
-    );
+    let integrator = GaussianSingle::from_parameters(4, GaussianQuadratureMethod::GaussLegendre);
 
     //simple integration for x, known to be x^4 - x^3, expect a value of ~8.00
-    let val = integrator.get_single(&func, &integration_limit).unwrap();
+    let val = integrator
+        .single_integral(&func, &integration_limit)
+        .unwrap();
     assert!(f64::abs(val - 8.0) < 1e-14);
 }
 
@@ -98,14 +94,11 @@ fn test_gauss_legendre_quadrature_integration_2() {
     let integration_limit = [0.0, 1.0];
     let point = [1.0, 2.0, 3.0];
 
-    let integrator = gaussian_integration::GaussianMulti::from_parameters(
-        2,
-        GaussianQuadratureMethod::GaussLegendre,
-    );
+    let integrator = GaussianMulti::from_parameters(2, GaussianQuadratureMethod::GaussLegendre);
 
     //partial integration for x, known to be x*x + x*y*z, expect a value of ~7.00
     let val = integrator
-        .get_single_partial(&func, 0, &integration_limit, &point)
+        .single_partial_integral(&func, 0, &integration_limit, &point)
         .unwrap();
     assert!(f64::abs(val - 7.0) < 1e-14);
 
@@ -113,7 +106,7 @@ fn test_gauss_legendre_quadrature_integration_2() {
 
     //partial integration for y, known to be 2.0*x*y + y*y*z/2.0, expect a value of ~10.00
     let val = integrator
-        .get_single_partial(&func, 1, &integration_limit, &point)
+        .single_partial_integral(&func, 1, &integration_limit, &point)
         .unwrap();
     assert!(f64::abs(val - 10.0) < 1e-14);
 
@@ -121,7 +114,7 @@ fn test_gauss_legendre_quadrature_integration_2() {
 
     //partial integration for z, known to be 2.0*x*z + y*z*z/2.0, expect a value of ~15.0
     let val = integrator
-        .get_single_partial(&func, 2, &integration_limit, &point)
+        .single_partial_integral(&func, 2, &integration_limit, &point)
         .unwrap();
     assert!(f64::abs(val - 15.0) < 1e-14);
 }
@@ -132,13 +125,12 @@ fn test_gauss_legendre_quadrature_integration_3() {
     let func = |args: f64| -> f64 { 6.0 * args };
 
     let integration_limits = [[0.0, 2.0], [0.0, 2.0]];
-    let integrator = gaussian_integration::GaussianSingle::from_parameters(
-        2,
-        GaussianQuadratureMethod::GaussLegendre,
-    );
+    let integrator = GaussianSingle::from_parameters(2, GaussianQuadratureMethod::GaussLegendre);
 
     //simple double integration for 6*x, expect a value of ~24.00
-    let val = integrator.get_double(&func, &integration_limits).unwrap();
+    let val = integrator
+        .double_integral(&func, &integration_limits)
+        .unwrap();
     assert!(f64::abs(val - 24.0) < 1e-14);
 }
 
@@ -149,11 +141,12 @@ fn test_simpsons_integration_1() {
 
     let integration_limit = [0.0, 2.0];
 
-    let integrator =
-        iterative_integration::IterativeSingle::from_parameters(200, IterativeMethod::Simpsons);
+    let integrator = IterativeSingle::from_parameters(200, IterativeMethod::Simpsons);
 
     //simple integration for x, known to be x*x, expect a value of ~4.00
-    let val = integrator.get_single(&func, &integration_limit).unwrap();
+    let val = integrator
+        .single_integral(&func, &integration_limit)
+        .unwrap();
     assert!(f64::abs(val - 4.0) < 0.05);
 }
 
@@ -165,12 +158,11 @@ fn test_simpsons_integration_2() {
     let integration_limit = [0.0, 1.0];
     let point = [1.0, 2.0, 3.0];
 
-    let integrator =
-        iterative_integration::IterativeMulti::from_parameters(200, IterativeMethod::Simpsons);
+    let integrator = IterativeMulti::from_parameters(200, IterativeMethod::Simpsons);
 
     //partial integration for x, known to be x*x + x*y*z, expect a value of ~7.00
     let val = integrator
-        .get_single_partial(&func, 0, &integration_limit, &point)
+        .single_partial_integral(&func, 0, &integration_limit, &point)
         .unwrap();
     assert!(f64::abs(val - 7.0) < 0.05);
 
@@ -178,7 +170,7 @@ fn test_simpsons_integration_2() {
 
     //partial integration for y, known to be 2.0*x*y + y*y*z/2.0, expect a value of ~10.00
     let val = integrator
-        .get_single_partial(&func, 1, &integration_limit, &point)
+        .single_partial_integral(&func, 1, &integration_limit, &point)
         .unwrap();
     assert!(f64::abs(val - 10.0) < 0.05);
 
@@ -186,7 +178,7 @@ fn test_simpsons_integration_2() {
 
     //partial integration for z, known to be 2.0*x*z + y*z*z/2.0, expect a value of ~15.0
     let val = integrator
-        .get_single_partial(&func, 2, &integration_limit, &point)
+        .single_partial_integral(&func, 2, &integration_limit, &point)
         .unwrap();
     assert!(f64::abs(val - 15.0) < 0.05);
 }
@@ -198,11 +190,12 @@ fn test_simpsons_integration_3() {
 
     let integration_limits = [[0.0, 2.0], [0.0, 2.0]];
 
-    let integrator =
-        iterative_integration::IterativeSingle::from_parameters(200, IterativeMethod::Simpsons);
+    let integrator = IterativeSingle::from_parameters(200, IterativeMethod::Simpsons);
 
     //simple double integration for 6*x, expect a value of ~24.00
-    let val = integrator.get_double(&func, &integration_limits).unwrap();
+    let val = integrator
+        .double_integral(&func, &integration_limits)
+        .unwrap();
     assert!(f64::abs(val - 24.0) < 0.05);
 }
 
@@ -214,12 +207,11 @@ fn test_simpsons_integration_4() {
     let integration_limits = [[0.0, 1.0], [0.0, 1.0]];
     let point = [1.0, 1.0, 1.0];
 
-    let integrator =
-        iterative_integration::IterativeMulti::from_parameters(200, IterativeMethod::Simpsons);
+    let integrator = IterativeMulti::from_parameters(200, IterativeMethod::Simpsons);
 
     //double partial integration for first x then y, expect a value of ~1.50
     let val = integrator
-        .get_double_partial(&func, [0, 1], &integration_limits, &point)
+        .double_partial_integral(&func, [0, 1], &integration_limits, &point)
         .unwrap();
     assert!(f64::abs(val - 1.50) < 0.05);
 }
@@ -231,9 +223,8 @@ fn test_trapezoidal_integration_1() {
 
     let integration_limit = [0.0, 2.0];
 
-    let iterator =
-        iterative_integration::IterativeSingle::from_parameters(100, IterativeMethod::Trapezoidal);
-    let val = iterator.get_single(&func, &integration_limit).unwrap();
+    let iterator = IterativeSingle::from_parameters(100, IterativeMethod::Trapezoidal);
+    let val = iterator.single_integral(&func, &integration_limit).unwrap();
 
     assert!(f64::abs(val - 4.0) < 0.00001);
 }
@@ -246,12 +237,11 @@ fn test_trapezoidal_integration_2() {
     let integration_limit = [0.0, 1.0];
     let point = [1.0, 2.0, 3.0];
 
-    let iterator =
-        iterative_integration::IterativeMulti::from_parameters(100, IterativeMethod::Trapezoidal);
+    let iterator = IterativeMulti::from_parameters(100, IterativeMethod::Trapezoidal);
 
     //partial integration for x, known to be x*x + x*y*z, expect a value of ~7.00
     let val = iterator
-        .get_single_partial(&func, 0, &integration_limit, &point)
+        .single_partial_integral(&func, 0, &integration_limit, &point)
         .unwrap();
     assert!(f64::abs(val - 7.0) < 0.00001);
 
@@ -259,7 +249,7 @@ fn test_trapezoidal_integration_2() {
 
     //partial integration for y, known to be 2.0*x*y + y*y*z/2.0, expect a value of ~10.00
     let val = iterator
-        .get_single_partial(&func, 1, &integration_limit, &point)
+        .single_partial_integral(&func, 1, &integration_limit, &point)
         .unwrap();
     assert!(f64::abs(val - 10.0) < 0.00001);
 
@@ -267,7 +257,7 @@ fn test_trapezoidal_integration_2() {
 
     //partial integration for z, known to be 2.0*x*z + y*z*z/2.0, expect a value of ~15.0
     let val = iterator
-        .get_single_partial(&func, 2, &integration_limit, &point)
+        .single_partial_integral(&func, 2, &integration_limit, &point)
         .unwrap();
     assert!(f64::abs(val - 15.0) < 0.00001);
 }
@@ -279,11 +269,12 @@ fn test_trapezoidal_integration_3() {
 
     let integration_limits = [[0.0, 2.0], [0.0, 2.0]];
 
-    let integrator =
-        iterative_integration::IterativeSingle::from_parameters(10, IterativeMethod::Trapezoidal);
+    let integrator = IterativeSingle::from_parameters(10, IterativeMethod::Trapezoidal);
 
     //simple double integration for 6*x, expect a value of ~24.00
-    let val = integrator.get_double(&func, &integration_limits).unwrap();
+    let val = integrator
+        .double_integral(&func, &integration_limits)
+        .unwrap();
     assert!(f64::abs(val - 24.0) < 0.00001);
 }
 
@@ -295,12 +286,11 @@ fn test_trapezoidal_integration_4() {
     let integration_limits = [[0.0, 1.0], [0.0, 2.0]];
     let point = [1.0, 2.0, 3.0];
 
-    let integrator =
-        iterative_integration::IterativeMulti::from_parameters(10, IterativeMethod::Trapezoidal);
+    let integrator = IterativeMulti::from_parameters(10, IterativeMethod::Trapezoidal);
 
     //double partial integration for first x then y, expect a value of ~2.50
     let val = integrator
-        .get_double_partial(&func, [0, 1], &integration_limits, &point)
+        .double_partial_integral(&func, [0, 1], &integration_limits, &point)
         .unwrap();
     assert!(f64::abs(val - 8.0) < 0.00001);
 }
@@ -312,10 +302,10 @@ fn test_error_checking_1() {
 
     let integration_limit = [10.0, 1.0];
 
-    let integrator = iterative_integration::IterativeSingle::default();
+    let integrator = IterativeSingle::default();
 
     //expect failure because integration interval is ill-defined (lower limit is higher than the upper limit)
-    let result = integrator.get_single(&func, &integration_limit);
+    let result = integrator.single_integral(&func, &integration_limit);
     assert!(result.is_err());
     assert!(result.unwrap_err() == IntegrateError::LimitsIllDefined);
 }
@@ -327,11 +317,10 @@ fn test_error_checking_2() {
 
     let integration_limit = [0.0, 1.0];
 
-    let integrator =
-        iterative_integration::IterativeSingle::from_parameters(0, IterativeMethod::Booles);
+    let integrator = IterativeSingle::from_parameters(0, IterativeMethod::Booles);
 
     //expect failure because number of steps is 0
-    let result = integrator.get_single(&func, &integration_limit);
+    let result = integrator.single_integral(&func, &integration_limit);
     assert!(result.is_err());
     assert!(result.unwrap_err() == IntegrateError::IterationsZero);
 }
@@ -346,11 +335,8 @@ fn test_error_checking_3() {
     let integration_limit = [0.0, 2.0];
 
     //Gauss Legendre not valid for n < 1
-    let integrator = gaussian_integration::GaussianSingle::from_parameters(
-        0,
-        GaussianQuadratureMethod::GaussLegendre,
-    );
-    let result = integrator.get_single(&func, &integration_limit);
+    let integrator = GaussianSingle::from_parameters(0, GaussianQuadratureMethod::GaussLegendre);
+    let result = integrator.single_integral(&func, &integration_limit);
     assert!(result.is_err());
     assert!(result.unwrap_err() == IntegrateError::QuadratureOrderOutOfRange);
 }
@@ -363,11 +349,8 @@ fn test_error_checking_4() {
     let integration_limit = [0.0, 2.0];
 
     //Gauss Legendre not valid for n > 30
-    let integrator = gaussian_integration::GaussianSingle::from_parameters(
-        31,
-        GaussianQuadratureMethod::GaussLegendre,
-    );
-    let result = integrator.get_single(&func, &integration_limit);
+    let integrator = GaussianSingle::from_parameters(31, GaussianQuadratureMethod::GaussLegendre);
+    let result = integrator.single_integral(&func, &integration_limit);
     assert!(result.is_err());
     assert!(result.unwrap_err() == IntegrateError::QuadratureOrderOutOfRange);
 }
@@ -379,8 +362,8 @@ fn test_error_checking_5() {
 
     let integration_limit = [0.0, 1.0];
 
-    let integrator = iterative_integration::IterativeSingle::default();
-    let result = integrator.get_single(&func, &integration_limit);
+    let integrator = IterativeSingle::default();
+    let result = integrator.single_integral(&func, &integration_limit);
     assert!(result.is_err());
     assert!(result.unwrap_err() == IntegrateError::NonFinite);
 }
@@ -392,8 +375,8 @@ fn test_error_checking_6() {
 
     let integration_limit = [0.0, 2.0];
 
-    let integrator = gaussian_integration::GaussianSingle::default();
-    let result = integrator.get_single(&func, &integration_limit);
+    let integrator = GaussianSingle::default();
+    let result = integrator.single_integral(&func, &integration_limit);
     assert!(result.is_err());
     assert!(result.unwrap_err() == IntegrateError::NonFinite);
 }
@@ -404,13 +387,12 @@ fn test_gauss_hermite_single() {
     //∫_{-∞}^∞ x² e^{-x²} dx = √π / 2
     let func = |x: f64| -> f64 { x * x };
 
-    let integrator = gaussian_integration::GaussianSingle::from_parameters(
-        5,
-        GaussianQuadratureMethod::GaussHermite,
-    );
+    let integrator = GaussianSingle::from_parameters(5, GaussianQuadratureMethod::GaussHermite);
 
     let integration_limit = [f64::NEG_INFINITY, f64::INFINITY];
-    let val = integrator.get_single(&func, &integration_limit).unwrap();
+    let val = integrator
+        .single_integral(&func, &integration_limit)
+        .unwrap();
 
     let expected = core::f64::consts::PI.sqrt() / 2.0;
     assert!(f64::abs(val - expected) < 1e-10);
@@ -422,13 +404,12 @@ fn test_gauss_laguerre_single() {
     //∫_0^∞ x² e^{-x} dx = 2
     let func = |x: f64| -> f64 { x * x };
 
-    let integrator = gaussian_integration::GaussianSingle::from_parameters(
-        5,
-        GaussianQuadratureMethod::GaussLaguerre,
-    );
+    let integrator = GaussianSingle::from_parameters(5, GaussianQuadratureMethod::GaussLaguerre);
 
     let integration_limit = [0.0, f64::INFINITY];
-    let val = integrator.get_single(&func, &integration_limit).unwrap();
+    let val = integrator
+        .single_integral(&func, &integration_limit)
+        .unwrap();
 
     assert!(f64::abs(val - 2.0) < 1e-9);
 }
@@ -438,10 +419,7 @@ fn test_gauss_hermite_multivariable() {
     //∫∫ x² y² e^{-x²} e^{-y²} dx dy = (√π/2)²
     let func = |args: &[f64; 2]| -> f64 { args[0] * args[0] * args[1] * args[1] };
 
-    let integrator = gaussian_integration::GaussianMulti::from_parameters(
-        5,
-        GaussianQuadratureMethod::GaussHermite,
-    );
+    let integrator = GaussianMulti::from_parameters(5, GaussianQuadratureMethod::GaussHermite);
 
     let integration_limits = [
         [f64::NEG_INFINITY, f64::INFINITY],
@@ -449,7 +427,7 @@ fn test_gauss_hermite_multivariable() {
     ];
     let point = [0.0, 0.0];
     let val = integrator
-        .get([0, 1], &func, &integration_limits, &point)
+        .integrate([0, 1], &func, &integration_limits, &point)
         .unwrap();
 
     let sqrt_pi_half = core::f64::consts::PI.sqrt() / 2.0;
@@ -461,15 +439,12 @@ fn test_gauss_laguerre_multivariable() {
     //∫∫ x² y² e^{-x} e^{-y} dx dy = 2 * 2 = 4
     let func = |args: &[f64; 2]| -> f64 { args[0] * args[0] * args[1] * args[1] };
 
-    let integrator = gaussian_integration::GaussianMulti::from_parameters(
-        5,
-        GaussianQuadratureMethod::GaussLaguerre,
-    );
+    let integrator = GaussianMulti::from_parameters(5, GaussianQuadratureMethod::GaussLaguerre);
 
     let integration_limits = [[0.0, f64::INFINITY], [0.0, f64::INFINITY]];
     let point = [0.0, 0.0];
     let val = integrator
-        .get([0, 1], &func, &integration_limits, &point)
+        .integrate([0, 1], &func, &integration_limits, &point)
         .unwrap();
 
     assert!(f64::abs(val - 4.0) < 1e-8);
@@ -480,10 +455,12 @@ fn test_iterative_infinite_gaussian() {
     //∫_{-∞}^∞ e^{-x²} dx = √π
     let func = |x: f64| -> f64 { f64::exp(-x * x) };
 
-    let integrator = iterative_integration::IterativeSingle::default();
+    let integrator = IterativeSingle::default();
 
     let integration_limit = [f64::NEG_INFINITY, f64::INFINITY];
-    let val = integrator.get_single(&func, &integration_limit).unwrap();
+    let val = integrator
+        .single_integral(&func, &integration_limit)
+        .unwrap();
 
     assert!(f64::abs(val - core::f64::consts::PI.sqrt()) < 1e-3);
 }
@@ -493,10 +470,12 @@ fn test_iterative_semi_infinite_exp() {
     //∫_0^∞ e^{-x} dx = 1
     let func = |x: f64| -> f64 { f64::exp(-x) };
 
-    let integrator = iterative_integration::IterativeSingle::default();
+    let integrator = IterativeSingle::default();
 
     let integration_limit = [0.0, f64::INFINITY];
-    let val = integrator.get_single(&func, &integration_limit).unwrap();
+    let val = integrator
+        .single_integral(&func, &integration_limit)
+        .unwrap();
 
     assert!(f64::abs(val - 1.0) < 1e-3);
 }
@@ -506,10 +485,12 @@ fn test_iterative_semi_infinite_inverse_square() {
     //∫_1^∞ x^{-2} dx = 1
     let func = |x: f64| -> f64 { 1.0 / (x * x) };
 
-    let integrator = iterative_integration::IterativeSingle::default();
+    let integrator = IterativeSingle::default();
 
     let integration_limit = [1.0, f64::INFINITY];
-    let val = integrator.get_single(&func, &integration_limit).unwrap();
+    let val = integrator
+        .single_integral(&func, &integration_limit)
+        .unwrap();
 
     assert!(f64::abs(val - 1.0) < 1e-3);
 }
@@ -519,10 +500,12 @@ fn test_iterative_negative_limits() {
     //∫_{-2}^{1} 2x dx = x² evaluated from -2 to 1 = 1 - 4 = -3
     let func = |x: f64| -> f64 { 2.0 * x };
 
-    let integrator = iterative_integration::IterativeSingle::default();
+    let integrator = IterativeSingle::default();
 
     let integration_limit = [-2.0, 1.0];
-    let val = integrator.get_single(&func, &integration_limit).unwrap();
+    let val = integrator
+        .single_integral(&func, &integration_limit)
+        .unwrap();
 
     assert!(f64::abs(val - (-3.0)) < 1e-9);
 }
@@ -536,15 +519,13 @@ fn test_composite_rule_degree_3_polynomial() {
     let integration_limit = [0.0, 2.0];
 
     //120 is a multiple of 3, so Simpson's 3/8 is exact for cubics here
-    let simpson =
-        iterative_integration::IterativeSingle::from_parameters(120, IterativeMethod::Simpsons);
-    let val = simpson.get_single(&func, &integration_limit).unwrap();
+    let simpson = IterativeSingle::from_parameters(120, IterativeMethod::Simpsons);
+    let val = simpson.single_integral(&func, &integration_limit).unwrap();
     assert!(f64::abs(val - 4.0) < 1e-9);
 
     //120 is a multiple of 4, so Boole's rule is exact too
-    let boole =
-        iterative_integration::IterativeSingle::from_parameters(120, IterativeMethod::Booles);
-    let val = boole.get_single(&func, &integration_limit).unwrap();
+    let boole = IterativeSingle::from_parameters(120, IterativeMethod::Booles);
+    let val = boole.single_integral(&func, &integration_limit).unwrap();
     assert!(f64::abs(val - 4.0) < 1e-9);
 }
 
@@ -571,11 +552,8 @@ fn pairwise_integration_is_accurate_on_long_sum() {
     let exact = core::f64::consts::PI / 4.0;
     let iterations: u64 = 1 << 23;
 
-    let integrator = iterative_integration::IterativeSingle::from_parameters(
-        iterations,
-        IterativeMethod::Trapezoidal,
-    );
-    let pairwise = integrator.get_single(&func, &[0.0, 1.0]).unwrap();
+    let integrator = IterativeSingle::from_parameters(iterations, IterativeMethod::Trapezoidal);
+    let pairwise = integrator.single_integral(&func, &[0.0, 1.0]).unwrap();
     let naive = naive_trapezoidal(iterations, 0.0, 1.0, func);
 
     let pairwise_err = f64::abs(pairwise - exact);
@@ -598,12 +576,9 @@ fn test_booles_integration_f32() {
     //2x integrated over [0, 2] is 4
     let func = |x: f32| -> f32 { 2.0 * x };
 
-    let integrator = iterative_integration::IterativeSingle::<f32>::from_parameters(
-        100,
-        IterativeMethod::Booles,
-    );
+    let integrator = IterativeSingle::<f32>::from_parameters(100, IterativeMethod::Booles);
 
-    let val = integrator.get_single(&func, &[0.0, 2.0]).unwrap();
+    let val = integrator.single_integral(&func, &[0.0, 2.0]).unwrap();
     assert!(f32::abs(val - 4.0) < 1e-3, "got {val}");
 }
 
@@ -612,12 +587,10 @@ fn test_gauss_legendre_integration_f32() {
     //4x^3 - 3x^2 integrated over [0, 2] is 8
     let func = |x: f32| -> f32 { 4.0 * x * x * x - 3.0 * x * x };
 
-    let integrator = gaussian_integration::GaussianSingle::<f32>::from_parameters(
-        4,
-        GaussianQuadratureMethod::GaussLegendre,
-    );
+    let integrator =
+        GaussianSingle::<f32>::from_parameters(4, GaussianQuadratureMethod::GaussLegendre);
 
-    let val = integrator.get_single(&func, &[0.0, 2.0]).unwrap();
+    let val = integrator.single_integral(&func, &[0.0, 2.0]).unwrap();
     assert!(f32::abs(val - 8.0) < 1e-2, "got {val}");
 }
 
@@ -680,29 +653,26 @@ fn iterative_integration_proptest(
         let closed_form = closed_form_from_coeffs(&coeffs, limit);
         let scaled_tol = tolerance_from_coeffs(&coeffs, limit);
 
-        let val = integrator.get_single(&func, &limit).unwrap();
+        let val = integrator.single_integral(&func, &limit).unwrap();
         prop_assert!(f64::abs(val - closed_form) < scaled_tol);
     });
 }
 
 #[test]
 fn proptest_trapezoid_integration_f64() {
-    let iterator =
-        iterative_integration::IterativeSingle::from_parameters(100, IterativeMethod::Trapezoidal);
+    let iterator = IterativeSingle::from_parameters(100, IterativeMethod::Trapezoidal);
     iterative_integration_proptest(1, iterator);
 }
 
 #[test]
 fn proptest_simpsons_integration_f64() {
-    let iterator =
-        iterative_integration::IterativeSingle::from_parameters(120, IterativeMethod::Simpsons);
+    let iterator = IterativeSingle::from_parameters(120, IterativeMethod::Simpsons);
     iterative_integration_proptest(3, iterator);
 }
 
 #[test]
 fn proptest_booles_integration_f64() {
-    let iterator =
-        iterative_integration::IterativeSingle::from_parameters(100, IterativeMethod::Booles);
+    let iterator = IterativeSingle::from_parameters(100, IterativeMethod::Booles);
     iterative_integration_proptest(5, iterator);
 }
 
@@ -785,12 +755,12 @@ fn gauss_integration_proptest(
         let closed_form = gauss_closed_form(quadrature, &coeffs, limit);
         let scaled_tol = gauss_tolerance(quadrature, &coeffs, limit);
 
-        let integrator = gaussian_integration::GaussianSingle::<f64>::from_parameters(
+        let integrator = GaussianSingle::<f64>::from_parameters(
         n,
         quadrature,
         );
 
-        let val = integrator.get_single(&func, &limit).unwrap();
+        let val = integrator.single_integral(&func, &limit).unwrap();
         prop_assert!(f64::abs(val - closed_form) < scaled_tol);
     });
 }
@@ -822,13 +792,10 @@ fn kahan_integration_beats_naive_on_long_sum() {
     let exact = core::f64::consts::PI / 4.0;
     let iterations: u64 = 1 << 23;
 
-    let integrator = iterative_integration::IterativeSingle::from_parameters(
-        iterations,
-        IterativeMethod::Trapezoidal,
-    )
-    .with_kahan_summation();
+    let integrator = IterativeSingle::from_parameters(iterations, IterativeMethod::Trapezoidal)
+        .with_kahan_summation();
 
-    let kahan = integrator.get_single(&func, &[0.0, 1.0]).unwrap();
+    let kahan = integrator.single_integral(&func, &[0.0, 1.0]).unwrap();
     let naive = naive_trapezoidal(iterations, 0.0, 1.0, func);
 
     let kahan_err = f64::abs(kahan - exact);
@@ -844,9 +811,9 @@ fn kahan_integration_beats_naive_on_long_sum() {
 fn iterative_multi_rejects_out_of_range_index() {
     let func = |args: &[f64; 2]| args[0] + args[1];
     let point = [1.0, 2.0];
-    let integrator = iterative_integration::IterativeMulti::default();
+    let integrator = IterativeMulti::default();
     let err = integrator
-        .get([2; 1], &func, &[[0.0, 1.0]; 1], &point)
+        .integrate([2; 1], &func, &[[0.0, 1.0]; 1], &point)
         .unwrap_err();
     assert_eq!(err, IntegrateError::IndexOutOfRange);
 }
@@ -855,9 +822,9 @@ fn iterative_multi_rejects_out_of_range_index() {
 fn gaussian_multi_rejects_out_of_range_index() {
     let func = |args: &[f64; 2]| args[0] + args[1];
     let point = [1.0, 2.0];
-    let integrator = gaussian_integration::GaussianMulti::default();
+    let integrator = GaussianMulti::default();
     let err = integrator
-        .get([2; 1], &func, &[[0.0, 1.0]; 1], &point)
+        .integrate([2; 1], &func, &[[0.0, 1.0]; 1], &point)
         .unwrap_err();
     assert_eq!(err, IntegrateError::IndexOutOfRange);
 }

--- a/crates/multicalc/tests/suite/optimization.rs
+++ b/crates/multicalc/tests/suite/optimization.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use multicalc::error::{LinalgError, SolveError};
-use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
-use multicalc::numerical_derivative::finite_difference::FiniteDifferenceMulti;
-use multicalc::numerical_derivative::jacobian::Jacobian;
+use multicalc::numerical_derivative::AutoDiffMulti;
+use multicalc::numerical_derivative::FiniteDifferenceMulti;
+use multicalc::numerical_derivative::Jacobian;
 use multicalc::optimization::{
     GaussNewton, LevenbergMarquardt, MinimizationReport, TerminationReason,
 };
@@ -391,9 +391,9 @@ fn embedded_artifact_fit_recovers_parameters() {
 // Jacobian of `f` at `x`. A small value confirms the autodiff derivatives the solvers rely on
 // match an independent finite-difference estimate.
 fn check_jacobian<F: VectorFn<N, M>, const N: usize, const M: usize>(f: &F, x: &[f64; N]) -> f64 {
-    let autodiff = Jacobian::<AutoDiffMulti>::default().get(f, x).unwrap();
+    let autodiff = Jacobian::<AutoDiffMulti>::default().evaluate(f, x).unwrap();
     let finite = Jacobian::from_derivator(FiniteDifferenceMulti::<f64>::default())
-        .get(f, x)
+        .evaluate(f, x)
         .unwrap();
     let mut worst = 0.0_f64;
     for m in 0..M {

--- a/crates/multicalc/tests/suite/root_finding.rs
+++ b/crates/multicalc/tests/suite/root_finding.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use multicalc::error::{LinalgError, SolveError};
-use multicalc::numerical_derivative::autodiff::{AutoDiffMulti, AutoDiffSingle};
-use multicalc::numerical_derivative::finite_difference::FiniteDifferenceSingle;
+use multicalc::numerical_derivative::FiniteDifferenceSingle;
+use multicalc::numerical_derivative::{AutoDiffMulti, AutoDiffSingle};
 use multicalc::root_finding::{
     Bisection, Newton, NewtonSystem, RootReport, RootReportN, RootTermination,
 };

--- a/crates/multicalc/tests/suite/vector_field.rs
+++ b/crates/multicalc/tests/suite/vector_field.rs
@@ -1,13 +1,13 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+use multicalc::numerical_derivative::AutoDiffMulti;
 use multicalc::scalar::c;
 use multicalc::scalar_fn_vec;
 
-use multicalc::vector_field::curl;
-use multicalc::vector_field::divergence;
-use multicalc::vector_field::flux_integral;
-use multicalc::vector_field::line_integral;
+use multicalc::vector_field::{
+    curl_2d, curl_3d, divergence_2d, divergence_3d, flux_integral_2d_custom,
+    flux_integral_3d_custom, line_integral_2d_custom, line_integral_3d_custom,
+};
 
 use multicalc::error::IntegrateError;
 
@@ -30,7 +30,7 @@ fn test_line_integral_1() {
     let integration_limit = [0.0, core::f64::consts::TAU];
 
     //line integral of a unit circle curve on our vector field from 0 to 2*pi, expect an answer of -2.0*pi
-    let val = line_integral::get_2d_custom(
+    let val = line_integral_2d_custom(
         &vector_field_matrix,
         &transformation_matrix,
         &integration_limit,
@@ -59,7 +59,7 @@ fn test_line_integral_error_1() {
     let integration_limit = [0.0, core::f64::consts::TAU];
 
     //expect error because number of steps is zero
-    let val = line_integral::get_2d_custom(
+    let val = line_integral_2d_custom(
         &vector_field_matrix,
         &transformation_matrix,
         &integration_limit,
@@ -88,7 +88,7 @@ fn test_line_integral_error_2() {
     let integration_limit = [10.0, 0.0];
 
     //expect error because integration limits are ill-defined (lower limit higher than upper limit)
-    let val = line_integral::get_2d_custom(
+    let val = line_integral_2d_custom(
         &vector_field_matrix,
         &transformation_matrix,
         &integration_limit,
@@ -117,7 +117,7 @@ fn test_flux_integral_1() {
     let integration_limit = [0.0, core::f64::consts::TAU];
 
     //flux integral of a unit circle curve on our vector field from 0 to 2*pi, expect an answer of 0.0
-    let val = flux_integral::get_2d_custom(
+    let val = flux_integral_2d_custom(
         &vector_field_matrix,
         &transformation_matrix,
         &integration_limit,
@@ -154,7 +154,7 @@ fn test_flux_integral_3d_helix() {
     let two_pi = 2.0 * core::f64::consts::PI;
     let integration_limit = [0.0, two_pi];
 
-    let val = flux_integral::get_3d_custom(
+    let val = flux_integral_3d_custom(
         &vector_field_matrix,
         &transformation_matrix,
         &integration_limit,
@@ -173,7 +173,7 @@ fn test_curl_2d_1() {
     let vf = scalar_fn_vec!(|v: &[f64; 2]| [c(2.0) * v[0] * v[1], c(3.0) * v[1].cos()]);
     let point = [1.0, core::f64::consts::PI];
 
-    let val = curl::get_2d(AutoDiffMulti::default(), &vf, &point).unwrap();
+    let val = curl_2d(AutoDiffMulti::default(), &vf, &point).unwrap();
     assert!(f64::abs(val + 2.0) < 1e-12);
 }
 
@@ -183,7 +183,7 @@ fn test_curl_3d_1() {
     let vf = scalar_fn_vec!(|v: &[f64; 3]| [v[1], -v[0], c(2.0) * v[2]]);
     let point = [1.0, 2.0, 3.0];
 
-    let val = curl::get_3d(AutoDiffMulti::default(), &vf, &point).unwrap();
+    let val = curl_3d(AutoDiffMulti::default(), &vf, &point).unwrap();
     assert!(f64::abs(val[0]) < 1e-12);
     assert!(f64::abs(val[1]) < 1e-12);
     assert!(f64::abs(val[2] + 2.0) < 1e-12);
@@ -195,7 +195,7 @@ fn test_divergence_2d_1() {
     let vf = scalar_fn_vec!(|v: &[f64; 2]| [c(2.0) * v[0] * v[1], c(3.0) * v[1].cos()]);
     let point = [1.0, core::f64::consts::PI];
 
-    let val = divergence::get_2d(AutoDiffMulti::default(), &vf, &point).unwrap();
+    let val = divergence_2d(AutoDiffMulti::default(), &vf, &point).unwrap();
     assert!(f64::abs(val - core::f64::consts::TAU) < 1e-12);
 }
 
@@ -205,7 +205,7 @@ fn test_divergence_3d_1() {
     let vf = scalar_fn_vec!(|v: &[f64; 3]| [v[1], -v[0], c(2.0) * v[2]]);
     let point = [0.0, 1.0, 3.0];
 
-    let val = divergence::get_3d(AutoDiffMulti::default(), &vf, &point).unwrap();
+    let val = divergence_3d(AutoDiffMulti::default(), &vf, &point).unwrap();
     assert!(f64::abs(val - 2.0) < 1e-12);
 }
 
@@ -228,7 +228,7 @@ fn test_line_integral_3d_helix() {
     let two_pi = 2.0 * core::f64::consts::PI;
     let integration_limit = [0.0, two_pi];
 
-    let val = line_integral::get_3d_custom(
+    let val = line_integral_3d_custom(
         &vector_field_matrix,
         &transformation_matrix,
         &integration_limit,
@@ -255,7 +255,7 @@ fn test_line_integral_negative_limits() {
 
     let integration_limit = [-2.0, 1.0];
 
-    let val = line_integral::get_2d_custom(
+    let val = line_integral_2d_custom(
         &vector_field_matrix,
         &transformation_matrix,
         &integration_limit,
@@ -272,6 +272,6 @@ fn test_divergence_3d_f32() {
     let vf = scalar_fn_vec!(|v: &[f64; 3]| [v[1], -v[0], c(2.0) * v[2]]);
     let point = [0.0_f32, 1.0, 3.0];
 
-    let val = divergence::get_3d(AutoDiffMulti::<f32>::default(), &vf, &point).unwrap();
+    let val = divergence_3d(AutoDiffMulti::<f32>::default(), &vf, &point).unwrap();
     assert!(f32::abs(val - 2.0) < 1e-6, "got {val}");
 }

--- a/demos/examples/basics/approximation.rs
+++ b/demos/examples/basics/approximation.rs
@@ -5,8 +5,8 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use multicalc::approximation::linear_approximation::LinearApproximator;
-use multicalc::approximation::quadratic_approximation::QuadraticApproximator;
+use multicalc::approximation::LinearApproximator;
+use multicalc::approximation::QuadraticApproximator;
 use multicalc::scalar::{ScalarFnN, c};
 use multicalc::scalar_fn;
 
@@ -16,7 +16,7 @@ fn main() {
     let base = [1.0, 2.0, 3.0];
 
     let linear: LinearApproximator = LinearApproximator::default();
-    let model = linear.get(&f, &base).unwrap();
+    let model = linear.approximate(&f, &base).unwrap();
     // A first-order model is exact at its own expansion point.
     assert!((model.predict(&base) - f.eval(&base)).abs() < 1e-9);
 
@@ -41,7 +41,7 @@ fn main() {
         [1.2, 2.1, 3.2],
         [0.8, 1.9, 2.8],
     ];
-    let metrics = model.get_prediction_metrics(&samples, &f);
+    let metrics = model.prediction_metrics(&samples, &f);
     println!(
         "  over {} points: RMSE = {:.4}, R^2 = {:.5}",
         samples.len(),
@@ -54,7 +54,7 @@ fn main() {
     let base = [0.0, std::f64::consts::FRAC_PI_2, 10.0];
 
     let quadratic: QuadraticApproximator = QuadraticApproximator::default();
-    let model = quadratic.get(&g, &base).unwrap();
+    let model = quadratic.approximate(&g, &base).unwrap();
 
     println!("\nQuadratic model of e^(x/2) + sin(y) + 2z about (0, pi/2, 10)");
     let nearby = [0.1, std::f64::consts::FRAC_PI_2 + 0.1, 10.1];

--- a/demos/examples/basics/avoidance.rs
+++ b/demos/examples/basics/avoidance.rs
@@ -91,10 +91,24 @@ fn main() {
     // 2 m corridor the forward-pointing beams never see past about 2 m — a beam 30° off-centre
     // meets the side wall at 1.0 / sin(30°) — so the robot would crawl at half speed the whole way.
     // Scale against distances the corridor can actually produce instead.
-    let follower = FollowTheGap::<BEAMS, f64>::try_new(2.0 * PI / 3.0, 4.0, 0.50, 0.60, 0.40)
-        .unwrap()
-        .with_speed_scaling(0.30, 1.50)
-        .unwrap();
+    let field_of_view = 2.0 * PI / 3.0;
+    let max_range = 4.0;
+    let robot_radius = 0.50;
+    let clearance = 0.60;
+    let cruise_speed = 0.40;
+    let slowest_clear_distance = 0.30;
+    let fastest_clear_distance = 1.50;
+
+    let follower = FollowTheGap::<BEAMS, f64>::try_new(
+        field_of_view,
+        max_range,
+        robot_radius,
+        clearance,
+        cruise_speed,
+    )
+    .unwrap()
+    .with_speed_scaling(slowest_clear_distance, fastest_clear_distance)
+    .unwrap();
 
     // (1) Drive the corridor.
     let summary = run(&map, &lidar, &follower, SEED);

--- a/demos/examples/basics/curve_fit.rs
+++ b/demos/examples/basics/curve_fit.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use multicalc::LevenbergMarquardt;
-use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+use multicalc::numerical_derivative::AutoDiffMulti;
 use multicalc::scalar::{Numeric, VectorFn};
 
 const A_TRUE: f64 = 100.0;

--- a/demos/examples/basics/curve_fit.rs
+++ b/demos/examples/basics/curve_fit.rs
@@ -32,8 +32,11 @@ fn main() {
     let y: [f64; 8] = core::array::from_fn(|i| A_TRUE * (B_TRUE * i as f64).exp());
     let problem = SensorFit { t, y };
 
+    // Deliberately away from the truth (100, -ln 2), so the fit has work to do.
+    let initial_guess = [80.0, -0.3];
+
     let report = LevenbergMarquardt::<AutoDiffMulti>::default()
-        .minimize(&problem, &[80.0, -0.3])
+        .minimize(&problem, &initial_guess)
         .expect("curve fit did not converge");
 
     let (a, b) = (report.solution[0], report.solution[1]);

--- a/demos/examples/basics/differentiation.rs
+++ b/demos/examples/basics/differentiation.rs
@@ -23,21 +23,22 @@ fn main() {
     let derivator = AutoDiffSingle::default();
     let x = 1.0_f64;
     let (s, c) = (x.sin(), x.cos());
+    let (first_order, second_order, third_order) = (1, 2, 3);
 
     println!("f(x) = x^2 sin(x)  at x = {x}");
     report(
         "f'",
-        derivator.differentiate(1, &f, x).unwrap(),
+        derivator.differentiate(first_order, &f, x).unwrap(),
         2.0 * x * s + x * x * c,
     );
     report(
         "f''",
-        derivator.differentiate(2, &f, x).unwrap(),
+        derivator.differentiate(second_order, &f, x).unwrap(),
         2.0 * s + 4.0 * x * c - x * x * s,
     );
     report(
         "f'''",
-        derivator.differentiate(3, &f, x).unwrap(),
+        derivator.differentiate(third_order, &f, x).unwrap(),
         6.0 * c - 6.0 * x * s - x * x * c,
     );
 
@@ -52,12 +53,18 @@ fn main() {
     let p = [1.0, 2.0, 3.0];
     let (e3, sin2, cos2) = (3.0_f64.exp(), 2.0_f64.sin(), 2.0_f64.cos());
 
+    // Which variable to differentiate by, and in what order. x is index 0, y is 1, z is 2.
+    let x_index = 0;
+    let twice_by_x = [0, 0];
+    let by_x_then_y = [0, 1];
+    let twice_by_x_then_y = [0, 0, 1];
+
     println!("\ng(x, y, z) = y*sin(x) + x*cos(y) + x*y*e^z  at {p:?}");
 
     // a single partial derivative, dg/dx = y*cos(x) + cos(y) + y*e^z
     report(
         "dg/dx",
-        multi.first_partial_derivative(&g, 0, &p).unwrap(),
+        multi.first_partial_derivative(&g, x_index, &p).unwrap(),
         2.0 * c + cos2 + 2.0 * e3,
     );
 
@@ -65,20 +72,20 @@ fn main() {
     // d2g/dx2 = -y*sin(x)
     report(
         "d2g/dx2",
-        multi.differentiate(&g, &[0, 0], &p).unwrap(),
+        multi.differentiate(&g, &twice_by_x, &p).unwrap(),
         -2.0 * s,
     );
     // mixed partial d(dg/dx)/dy = cos(x) - sin(y) + e^z
     report(
         "d2g/dx dy",
-        multi.differentiate(&g, &[0, 1], &p).unwrap(),
+        multi.differentiate(&g, &by_x_then_y, &p).unwrap(),
         c - sin2 + e3,
     );
 
     // third-order mixed partial d2(dg/dy)/dx2 = -sin(x)
     report(
         "d3g/dx2 dy",
-        multi.differentiate(&g, &[0, 0, 1], &p).unwrap(),
+        multi.differentiate(&g, &twice_by_x_then_y, &p).unwrap(),
         -s,
     );
 }

--- a/demos/examples/basics/differentiation.rs
+++ b/demos/examples/basics/differentiation.rs
@@ -5,8 +5,8 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use multicalc::numerical_derivative::autodiff::{AutoDiffMulti, AutoDiffSingle};
-use multicalc::numerical_derivative::derivator::{DerivatorMultiVariable, DerivatorSingleVariable};
+use multicalc::numerical_derivative::{AutoDiffMulti, AutoDiffSingle};
+use multicalc::numerical_derivative::{DerivatorMultiVariable, DerivatorSingleVariable};
 use multicalc::scalar_fn;
 
 fn report(label: &str, value: f64, exact: f64) {
@@ -27,23 +27,23 @@ fn main() {
     println!("f(x) = x^2 sin(x)  at x = {x}");
     report(
         "f'",
-        derivator.get(1, &f, x).unwrap(),
+        derivator.differentiate(1, &f, x).unwrap(),
         2.0 * x * s + x * x * c,
     );
     report(
         "f''",
-        derivator.get(2, &f, x).unwrap(),
+        derivator.differentiate(2, &f, x).unwrap(),
         2.0 * s + 4.0 * x * c - x * x * s,
     );
     report(
         "f'''",
-        derivator.get(3, &f, x).unwrap(),
+        derivator.differentiate(3, &f, x).unwrap(),
         6.0 * c - 6.0 * x * s - x * x * c,
     );
 
     // convenience wrappers exist for the 1st and 2nd derivative
-    let _ = derivator.get_single(&f, x).unwrap();
-    let _ = derivator.get_double(&f, x).unwrap();
+    let _ = derivator.first_derivative(&f, x).unwrap();
+    let _ = derivator.second_derivative(&f, x).unwrap();
 
     // ---- multi variable: g(x, y, z) = y*sin(x) + x*cos(y) + x*y*e^z at (1, 2, 3) ----
     let g =
@@ -57,20 +57,28 @@ fn main() {
     // a single partial derivative, dg/dx = y*cos(x) + cos(y) + y*e^z
     report(
         "dg/dx",
-        multi.get_single_partial(&g, 0, &p).unwrap(),
+        multi.first_partial_derivative(&g, 0, &p).unwrap(),
         2.0 * c + cos2 + 2.0 * e3,
     );
 
     // the derivative order is the number of indices, so no separate "order" argument is needed:
     // d2g/dx2 = -y*sin(x)
-    report("d2g/dx2", multi.get(&g, &[0, 0], &p).unwrap(), -2.0 * s);
+    report(
+        "d2g/dx2",
+        multi.differentiate(&g, &[0, 0], &p).unwrap(),
+        -2.0 * s,
+    );
     // mixed partial d(dg/dx)/dy = cos(x) - sin(y) + e^z
     report(
         "d2g/dx dy",
-        multi.get(&g, &[0, 1], &p).unwrap(),
+        multi.differentiate(&g, &[0, 1], &p).unwrap(),
         c - sin2 + e3,
     );
 
     // third-order mixed partial d2(dg/dy)/dx2 = -sin(x)
-    report("d3g/dx2 dy", multi.get(&g, &[0, 0, 1], &p).unwrap(), -s);
+    report(
+        "d3g/dx2 dy",
+        multi.differentiate(&g, &[0, 0, 1], &p).unwrap(),
+        -s,
+    );
 }

--- a/demos/examples/basics/estimation.rs
+++ b/demos/examples/basics/estimation.rs
@@ -8,12 +8,10 @@
 //! Run with: `cargo run -p multicalc-demos --example estimation`
 //! (or `--no-default-features --features alloc` for the particle-filter section).
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
-
-use multicalc::discretization::q_discrete_white_noise;
-use multicalc::estimation::{CovarianceUpdate, ExtendedKalmanFilter, KalmanFilter, KalmanModel};
-use multicalc::linear_algebra::{Matrix, Vector};
-use multicalc::scalar::{Dual, Numeric, VectorFn};
+use multicalc::{
+    CalcError, CovarianceUpdate, Dual, ExtendedKalmanFilter, KalmanFilter, KalmanModel, Matrix,
+    Numeric, Vector, VectorFn, q_discrete_white_noise,
+};
 
 fn report(label: &str, value: f64, exact: f64) {
     assert!((value - exact).abs() < 1e-9, "{label}: |err| too large");
@@ -138,9 +136,8 @@ impl VectorFn<3, 4> for BeaconRanges {
 /// the room and pulls in as the beacon ranges rule out where the robot cannot be — the kind of
 /// many-hypotheses belief a single Gaussian cannot hold.
 #[cfg(feature = "alloc")]
-fn particle_filter() {
-    use multicalc::estimation::{GaussianLikelihood, ParticleFilter, ResamplingScheme};
-    use multicalc::random::{Pcg32, RandomSource};
+fn particle_filter() -> Result<(), CalcError> {
+    use multicalc::{GaussianLikelihood, ParticleFilter, Pcg32, RandomSource, ResamplingScheme};
 
     let particle_count = 1500;
     let timestep = 1.0;
@@ -159,12 +156,10 @@ fn particle_filter() {
         Matrix::new([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 4.0]]), // wide prior
         Matrix::new([[0.02, 0.0, 0.0], [0.0, 0.02, 0.0], [0.0, 0.0, 0.01]]), // odometry noise
         7,
-    )
-    .unwrap()
+    )?
     .with_resampling(ResamplingScheme::Systematic);
     let sensor =
-        GaussianLikelihood::new(Matrix::<4, 4>::identity().scale(range_noise * range_noise))
-            .unwrap();
+        GaussianLikelihood::new(Matrix::<4, 4>::identity().scale(range_noise * range_noise))?;
 
     // The true pose the robot actually follows; the filter never sees it. Each measurement is the
     // true ranges plus sensor noise, drawn from a seeded generator so the run reproduces exactly.
@@ -180,8 +175,8 @@ fn particle_filter() {
             true_ranges[i] + range_noise * range_generator.standard_normal()
         }));
 
-        filter.predict(&motion).unwrap();
-        filter.update(&BeaconRanges, &sensor, measurement).unwrap();
+        filter.predict(&motion)?;
+        filter.update(&BeaconRanges, &sensor, measurement)?;
 
         let estimate = filter.mean();
         println!(
@@ -223,6 +218,8 @@ fn particle_filter() {
         (1.0..=particle_count as f64 + 1e-6).contains(&filter.effective_sample_size()),
         "effective sample size stays between one and the particle count"
     );
+
+    Ok(())
 }
 
 /// How far the cloud reaches in position: the square root of the summed weighted variance of the x
@@ -239,13 +236,15 @@ fn position_spread<R: multicalc::random::RandomSource>(
     variance.sqrt()
 }
 
-fn main() {
+// Every fallible call below propagates with `?`. The estimation calls return `EstimationError`,
+// which converts into the `CalcError` umbrella on the way out.
+fn main() -> Result<(), CalcError> {
     // (1) Two steps with no process noise, worked by hand: with P0 = I, R = 1 and z = [1, 2],
     // the posterior is x = [5/3, 2/3] and P = [[2/3, 1/3], [1/3, 1/3]].
     let mut filter = tracker::<f64>(Matrix::identity(), Matrix::zeros(), Matrix::new([[1.0]]));
     for z in [1.0, 2.0] {
         filter.predict();
-        filter.update(Vector::new([z])).unwrap();
+        filter.update(Vector::new([z]))?;
     }
     println!("Exact two-step filter (P0 = I, Q = 0, R = 1, z = [1, 2])");
     report("position", filter.state()[0], 5.0 / 3.0);
@@ -270,7 +269,7 @@ fn main() {
     println!("\nTracking a 1 m/s target from x = [0, 0] with a wide prior");
     for (step, z) in measurements.iter().enumerate() {
         filter.predict();
-        filter.update(Vector::new([*z])).unwrap();
+        filter.update(Vector::new([*z]))?;
         println!(
             "  t = {:>2}s  measured {:>5.2}  ->  position {:>6.3}, velocity {:>6.3}  (trace P {:>7.4})",
             step + 1,
@@ -304,7 +303,7 @@ fn main() {
     .with_covariance_update(CovarianceUpdate::Naive);
     for z in measurements.iter() {
         naive.predict();
-        naive.update(Vector::new([*z])).unwrap();
+        naive.update(Vector::new([*z]))?;
     }
     println!("\nJoseph (default) vs naive covariance update");
     report("state agreement", (naive.state()[0] - position).abs(), 0.0);
@@ -323,7 +322,7 @@ fn main() {
     let control_model = Matrix::<2, 1>::new([[0.5], [1.0]]); // [dt²/2; dt] for dt = 1
     for z in [0.4, 2.1, 4.4, 8.2] {
         driven.predict_with_control(control_model, Vector::new([1.0])); // 1 m/s² command
-        driven.update(Vector::new([z])).unwrap();
+        driven.update(Vector::new([z]))?;
     }
     println!("\nDriven filter (1 m/s² command through the control model)");
     println!(
@@ -339,11 +338,11 @@ fn main() {
     // (5) Innovation gating: the normalized innovation squared flags an outlier measurement.
     let mut gated = tracker::<f64>(Matrix::identity(), Matrix::zeros(), Matrix::new([[0.25]]));
     gated.predict();
-    gated.update(Vector::new([1.0])).unwrap();
-    let consistent = gated.normalized_innovation_squared().unwrap();
+    gated.update(Vector::new([1.0]))?;
+    let consistent = gated.normalized_innovation_squared()?;
     gated.predict();
-    gated.update(Vector::new([50.0])).unwrap();
-    let outlier = gated.normalized_innovation_squared().unwrap();
+    gated.update(Vector::new([50.0]))?;
+    let outlier = gated.normalized_innovation_squared()?;
     println!("\nInnovation gating (yᵀ·S⁻¹·y)");
     println!("  consistent measurement: {consistent:.3}");
     println!("  outlier  measurement:   {outlier:.3}");
@@ -357,7 +356,7 @@ fn main() {
     let mut reference = tracker::<f64>(Matrix::identity(), Matrix::zeros(), Matrix::new([[0.25]]));
     reference.predict();
     let prior_position_variance = reference.covariance()[(0, 0)];
-    reference.update(Vector::new([1.0])).unwrap();
+    reference.update(Vector::new([1.0]))?;
     let gain = prior_position_variance / reference.innovation_covariance()[(0, 0)];
 
     let mut differentiated = tracker::<Dual<f64>>(
@@ -366,9 +365,7 @@ fn main() {
         Matrix::new([[Dual::constant(0.25)]]),
     );
     differentiated.predict();
-    differentiated
-        .update(Vector::new([Dual::variable(1.0)]))
-        .unwrap();
+    differentiated.update(Vector::new([Dual::variable(1.0)]))?;
 
     println!("\nAutodiff: d(position)/d(measurement) equals the Kalman gain");
     report("d(position)/dz", differentiated.state()[0].deriv, gain);
@@ -388,9 +385,7 @@ fn main() {
     };
     let uncertainty_before = trace(extended.covariance());
     // From the true pose the landmark is at range 5, bearing atan2(4, 3).
-    extended
-        .update(&landmark, Vector::new([5.0, 4.0_f64.atan2(3.0)]))
-        .unwrap();
+    extended.update(&landmark, Vector::new([5.0, 4.0_f64.atan2(3.0)]))?;
     let uncertainty_after = trace(extended.covariance());
     println!("\nExtended filter: one range/bearing sighting of a landmark at (3, 4)");
     println!("  uncertainty (trace P): {uncertainty_before:.3} -> {uncertainty_after:.3}");
@@ -413,12 +408,10 @@ fn main() {
         Matrix::new([[0.5]]),
     );
     for z in [0.5, 1.0, 1.5, 2.0] {
-        reduced.predict(&ConstantVelocityMotion).unwrap();
-        reduced
-            .update(&PositionMeasurement, Vector::new([z]))
-            .unwrap();
+        reduced.predict(&ConstantVelocityMotion)?;
+        reduced.update(&PositionMeasurement, Vector::new([z]))?;
         linear.predict();
-        linear.update(Vector::new([z])).unwrap();
+        linear.update(Vector::new([z]))?;
     }
     println!("\nExtended filter reduces to the linear filter on linear models");
     report(
@@ -439,9 +432,7 @@ fn main() {
         Matrix::zeros(),
         Matrix::new([[0.05]]),
     );
-    unwrapped
-        .update(&Compass, Vector::new([measurement]))
-        .unwrap();
+    unwrapped.update(&Compass, Vector::new([measurement]))?;
 
     let mut wrapped = ExtendedKalmanFilter::<1, 1>::new(
         Vector::new([3.1]),
@@ -451,9 +442,7 @@ fn main() {
     );
     let predicted = Compass.eval(wrapped.state().as_array())[0];
     let residual = wrap_to_pi(measurement - predicted);
-    wrapped
-        .update_with_residual(&Compass, Vector::new([residual]))
-        .unwrap();
+    wrapped.update_with_residual(&Compass, Vector::new([residual]))?;
 
     println!("\nAngle wrapping near ±π (true heading error ≈ 0.08 rad)");
     println!(
@@ -477,7 +466,10 @@ fn main() {
     // cloud of weighted samples instead of one Gaussian. It is heap-backed, so it lives behind the
     // `alloc` feature; without it, the rest of the example still runs.
     #[cfg(feature = "alloc")]
-    particle_filter();
+    particle_filter()?;
+
     #[cfg(not(feature = "alloc"))]
     println!("\nParticle-filter section needs --features alloc");
+
+    Ok(())
 }

--- a/demos/examples/basics/estimation.rs
+++ b/demos/examples/basics/estimation.rs
@@ -373,19 +373,26 @@ fn main() -> Result<(), CalcError> {
     // (7) The same tracking problem, made nonlinear: a range-and-bearing sighting of a known
     // landmark. The measurement model is written once as a plain function; its Jacobian is taken by
     // automatic differentiation, so there are no hand-derived Jacobians anywhere.
+    let initial_pose = Vector::new([0.0, 0.0, 0.0]); // [x, y, heading] at the origin
+    let initial_covariance = Matrix::<3, 3>::identity(); // a wide, uncertain prior
+    let process_noise = Matrix::zeros();
+    let measurement_noise = Matrix::<2, 2>::identity().scale(0.01); // a precise sensor
+
     let mut extended = ExtendedKalmanFilter::<3, 2>::new(
-        Vector::new([0.0, 0.0, 0.0]), // pose [x, y, heading] at the origin
-        Matrix::<3, 3>::identity(),   // a wide, uncertain prior
-        Matrix::zeros(),
-        Matrix::<2, 2>::identity().scale(0.01), // a precise range/bearing sensor
+        initial_pose,
+        initial_covariance,
+        process_noise,
+        measurement_noise,
     );
     let landmark = LandmarkRangeAndBearing {
         landmark_x: 3.0,
         landmark_y: 4.0,
     };
     let uncertainty_before = trace(extended.covariance());
+
     // From the true pose the landmark is at range 5, bearing atan2(4, 3).
-    extended.update(&landmark, Vector::new([5.0, 4.0_f64.atan2(3.0)]))?;
+    let sighting = Vector::new([5.0, 4.0_f64.atan2(3.0)]);
+    extended.update(&landmark, sighting)?;
     let uncertainty_after = trace(extended.covariance());
     println!("\nExtended filter: one range/bearing sighting of a landmark at (3, 4)");
     println!("  uncertainty (trace P): {uncertainty_before:.3} -> {uncertainty_after:.3}");
@@ -396,17 +403,18 @@ fn main() -> Result<(), CalcError> {
 
     // (8) With linear models the extended filter reproduces the linear one exactly — that identity
     // is what "extended" means. Run the same constant-velocity models through both and compare.
+    let initial_state = Vector::new([0.0, 0.0]);
+    let initial_covariance = Matrix::identity();
+    let process_noise = Matrix::<2, 2>::identity().scale(0.01);
+    let measurement_noise = Matrix::new([[0.5]]);
+
     let mut reduced = ExtendedKalmanFilter::<2, 1>::new(
-        Vector::new([0.0, 0.0]),
-        Matrix::identity(),
-        Matrix::<2, 2>::identity().scale(0.01),
-        Matrix::new([[0.5]]),
+        initial_state,
+        initial_covariance,
+        process_noise,
+        measurement_noise,
     );
-    let mut linear = tracker::<f64>(
-        Matrix::identity(),
-        Matrix::<2, 2>::identity().scale(0.01),
-        Matrix::new([[0.5]]),
-    );
+    let mut linear = tracker::<f64>(initial_covariance, process_noise, measurement_noise);
     for z in [0.5, 1.0, 1.5, 2.0] {
         reduced.predict(&ConstantVelocityMotion)?;
         reduced.update(&PositionMeasurement, Vector::new([z]))?;
@@ -426,19 +434,24 @@ fn main() -> Result<(), CalcError> {
     // exists for.
     let measurement = -3.1; // compass reads just over −π; the state is just under +π
 
+    let initial_heading = Vector::new([3.1]);
+    let heading_covariance = Matrix::new([[0.1]]);
+    let no_process_noise = Matrix::zeros();
+    let compass_noise = Matrix::new([[0.05]]);
+
     let mut unwrapped = ExtendedKalmanFilter::<1, 1>::new(
-        Vector::new([3.1]),
-        Matrix::new([[0.1]]),
-        Matrix::zeros(),
-        Matrix::new([[0.05]]),
+        initial_heading,
+        heading_covariance,
+        no_process_noise,
+        compass_noise,
     );
     unwrapped.update(&Compass, Vector::new([measurement]))?;
 
     let mut wrapped = ExtendedKalmanFilter::<1, 1>::new(
-        Vector::new([3.1]),
-        Matrix::new([[0.1]]),
-        Matrix::zeros(),
-        Matrix::new([[0.05]]),
+        initial_heading,
+        heading_covariance,
+        no_process_noise,
+        compass_noise,
     );
     let predicted = Compass.eval(wrapped.state().as_array())[0];
     let residual = wrap_to_pi(measurement - predicted);

--- a/demos/examples/basics/gaussian_integration.rs
+++ b/demos/examples/basics/gaussian_integration.rs
@@ -45,8 +45,11 @@ fn main() {
 
     // ---- Gauss-Hermite: int_-inf^inf f(x) e^(-x^2) dx ----
     // pass the BARE integrand f(x); the weights already carry the e^(-x^2) factor
-    let hermite = GaussianSingle::from_parameters(5, GaussianQuadratureMethod::GaussHermite);
-    let hermite_m = GaussianMulti::from_parameters(5, GaussianQuadratureMethod::GaussHermite);
+    let node_count = 5;
+    let hermite =
+        GaussianSingle::from_parameters(node_count, GaussianQuadratureMethod::GaussHermite);
+    let hermite_m =
+        GaussianMulti::from_parameters(node_count, GaussianQuadratureMethod::GaussHermite);
     let real_line = [f64::NEG_INFINITY, f64::INFINITY];
     println!("\nGauss-Hermite (bare integrand; weights carry e^(-x^2)):");
     // int x^2 e^(-x^2) = sqrt(pi)/2
@@ -58,14 +61,19 @@ fn main() {
     // multi-variable: int int x^2 y^2 e^(-x^2-y^2) = (sqrt(pi)/2)^2
     report(
         "int int x^2 y^2 e^-x^2-y^2",
-        hermite_m
-            .integrate(
-                [0, 1],
-                &|v: &[f64; 2]| v[0] * v[0] * v[1] * v[1],
-                &[real_line; 2],
-                &[0.0, 0.0],
-            )
-            .unwrap(),
+        {
+            let by_x_then_y = [0, 1];
+            let plane = [real_line; 2];
+            let origin = [0.0, 0.0];
+            hermite_m
+                .integrate(
+                    by_x_then_y,
+                    &|v: &[f64; 2]| v[0] * v[0] * v[1] * v[1],
+                    &plane,
+                    &origin,
+                )
+                .unwrap()
+        },
         (sqrt_pi / 2.0) * (sqrt_pi / 2.0),
     );
 

--- a/demos/examples/basics/gaussian_integration.rs
+++ b/demos/examples/basics/gaussian_integration.rs
@@ -8,11 +8,9 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use multicalc::numerical_integration::gaussian_integration::{GaussianMulti, GaussianSingle};
-use multicalc::numerical_integration::integrator::{
-    IntegratorMultiVariable, IntegratorSingleVariable,
-};
-use multicalc::numerical_integration::mode::GaussianQuadratureMethod;
+use multicalc::numerical_integration::GaussianQuadratureMethod;
+use multicalc::numerical_integration::{GaussianMulti, GaussianSingle};
+use multicalc::numerical_integration::{IntegratorMultiVariable, IntegratorSingleVariable};
 
 fn report(label: &str, value: f64, exact: f64) {
     println!(
@@ -29,7 +27,7 @@ fn main() {
     println!("Gauss-Legendre (finite limits):");
     // int_0^2 (4x^3 - 3x^2) dx = 8  (exact: order 5 handles degree <= 9)
     let poly: f64 = legendre
-        .get_single(&|x| 4.0 * x * x * x - 3.0 * x * x, &[0.0, 2.0])
+        .single_integral(&|x| 4.0 * x * x * x - 3.0 * x * x, &[0.0, 2.0])
         .unwrap();
     assert!(
         (poly - 8.0).abs() < 1e-9,
@@ -40,7 +38,7 @@ fn main() {
     report(
         "int_0^1 (sinx-sqrtx)e^-x",
         legendre
-            .get_single(&|x| (x.sin() - x.sqrt()) * (-x).exp(), &[0.0, 1.0])
+            .single_integral(&|x| (x.sin() - x.sqrt()) * (-x).exp(), &[0.0, 1.0])
             .unwrap(),
         -0.13311916,
     );
@@ -54,14 +52,14 @@ fn main() {
     // int x^2 e^(-x^2) = sqrt(pi)/2
     report(
         "int x^2 e^-x^2",
-        hermite.get_single(&|x| x * x, &real_line).unwrap(),
+        hermite.single_integral(&|x| x * x, &real_line).unwrap(),
         sqrt_pi / 2.0,
     );
     // multi-variable: int int x^2 y^2 e^(-x^2-y^2) = (sqrt(pi)/2)^2
     report(
         "int int x^2 y^2 e^-x^2-y^2",
         hermite_m
-            .get(
+            .integrate(
                 [0, 1],
                 &|v: &[f64; 2]| v[0] * v[0] * v[1] * v[1],
                 &[real_line; 2],
@@ -78,14 +76,14 @@ fn main() {
     // int x^2 e^(-x) = 2
     report(
         "int x^2 e^-x",
-        laguerre.get_single(&|x| x * x, &half_line).unwrap(),
+        laguerre.single_integral(&|x| x * x, &half_line).unwrap(),
         2.0,
     );
     // int (4x^3 - 3x^2) e^(-x) = 18
     report(
         "int (4x^3-3x^2) e^-x",
         laguerre
-            .get_single(&|x| 4.0 * x * x * x - 3.0 * x * x, &half_line)
+            .single_integral(&|x| 4.0 * x * x * x - 3.0 * x * x, &half_line)
             .unwrap(),
         18.0,
     );

--- a/demos/examples/basics/iterative_integration.rs
+++ b/demos/examples/basics/iterative_integration.rs
@@ -8,11 +8,9 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use multicalc::numerical_integration::integrator::{
-    IntegratorMultiVariable, IntegratorSingleVariable,
-};
-use multicalc::numerical_integration::iterative_integration::{IterativeMulti, IterativeSingle};
-use multicalc::numerical_integration::mode::IterativeMethod;
+use multicalc::numerical_integration::IterativeMethod;
+use multicalc::numerical_integration::{IntegratorMultiVariable, IntegratorSingleVariable};
+use multicalc::numerical_integration::{IterativeMulti, IterativeSingle};
 
 fn report(label: &str, value: f64, exact: f64) {
     println!(
@@ -25,7 +23,7 @@ fn main() {
     // ---- single variable: int_0^2 2x dx = 4 ----
     let f = |x: f64| 2.0 * x;
     let integrator = IterativeSingle::default(); // Boole's rule, 120 intervals
-    let two_x = integrator.get_single(&f, &[0.0, 2.0]).unwrap();
+    let two_x = integrator.single_integral(&f, &[0.0, 2.0]).unwrap();
     assert!(
         (two_x - 4.0).abs() < 1e-9,
         "Boole is exact for a linear integrand"
@@ -44,7 +42,9 @@ fn main() {
         ("Trapezoid", IterativeMethod::Trapezoidal),
     ] {
         let solver = IterativeMulti::from_parameters(120, method);
-        let val = solver.get([0, 0, 0], &g, &[[0.0, 1.0]; 3], &point).unwrap();
+        let val = solver
+            .integrate([0, 0, 0], &g, &[[0.0, 1.0]; 3], &point)
+            .unwrap();
         report(name, val, exact);
     }
 
@@ -54,21 +54,21 @@ fn main() {
     report(
         "e^(-x^2)",
         integrator
-            .get_single(&bell, &[f64::NEG_INFINITY, f64::INFINITY])
+            .single_integral(&bell, &[f64::NEG_INFINITY, f64::INFINITY])
             .unwrap(),
         std::f64::consts::PI.sqrt(),
     );
     report(
         "e^(-x)",
         integrator
-            .get_single(&|x| (-x).exp(), &[0.0, f64::INFINITY])
+            .single_integral(&|x| (-x).exp(), &[0.0, f64::INFINITY])
             .unwrap(),
         1.0,
     );
     report(
         "x^(-2)",
         integrator
-            .get_single(&|x| 1.0 / (x * x), &[1.0, f64::INFINITY])
+            .single_integral(&|x| 1.0 / (x * x), &[1.0, f64::INFINITY])
             .unwrap(),
         1.0,
     );
@@ -81,7 +81,7 @@ fn main() {
     report(
         "partial",
         multi
-            .get_single_partial(&h, 0, &[0.0, 1.0], &point)
+            .single_partial_integral(&h, 0, &[0.0, 1.0], &point)
             .unwrap(),
         7.0,
     );

--- a/demos/examples/basics/iterative_integration.rs
+++ b/demos/examples/basics/iterative_integration.rs
@@ -41,10 +41,12 @@ fn main() {
         ("Simpson", IterativeMethod::Simpsons),
         ("Trapezoid", IterativeMethod::Trapezoidal),
     ] {
-        let solver = IterativeMulti::from_parameters(120, method);
-        let val = solver
-            .integrate([0, 0, 0], &g, &[[0.0, 1.0]; 3], &point)
-            .unwrap();
+        let interval_count = 120;
+        let solver = IterativeMulti::from_parameters(interval_count, method);
+
+        let thrice_by_x = [0, 0, 0];
+        let limits = [[0.0, 1.0]; 3];
+        let val = solver.integrate(thrice_by_x, &g, &limits, &point).unwrap();
         report(name, val, exact);
     }
 

--- a/demos/examples/basics/jacobian_hessian.rs
+++ b/demos/examples/basics/jacobian_hessian.rs
@@ -36,10 +36,11 @@ fn main() {
 
     // ---- Hessian of f(x, y) = y*sin(x) + 2*x*e^y ----
     let g = scalar_fn!(|v: &[f64; 2]| v[1] * v[0].sin() + c(2.0) * v[0] * v[1].exp());
+    let hessian_point = [1.0, 2.0];
     let hessian: Hessian = Hessian::default();
-    let result = hessian.evaluate(&g, &[1.0, 2.0]).unwrap();
+    let result = hessian.evaluate(&g, &hessian_point).unwrap();
 
-    println!("\nHessian of y*sin(x) + 2*x*e^y at [1, 2]:");
+    println!("\nHessian of y*sin(x) + 2*x*e^y at {hessian_point:?}:");
     for row in 0..2 {
         println!("  [{:.4}, {:.4}]", result[(row, 0)], result[(row, 1)]);
     }

--- a/demos/examples/basics/jacobian_hessian.rs
+++ b/demos/examples/basics/jacobian_hessian.rs
@@ -4,8 +4,8 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use multicalc::numerical_derivative::hessian::Hessian;
-use multicalc::numerical_derivative::jacobian::Jacobian;
+use multicalc::numerical_derivative::Hessian;
+use multicalc::numerical_derivative::Jacobian;
 use multicalc::scalar::c;
 use multicalc::{scalar_fn, scalar_fn_vec};
 
@@ -15,7 +15,7 @@ fn main() {
     let point = [1.0, 2.0, 3.0];
 
     let jacobian: Jacobian = Jacobian::default();
-    let result = jacobian.get(&f, &point).unwrap();
+    let result = jacobian.evaluate(&f, &point).unwrap();
 
     println!("Jacobian of (x*y*z, x^2 + y^2) at {point:?}:");
     for row in 0..2 {
@@ -37,7 +37,7 @@ fn main() {
     // ---- Hessian of f(x, y) = y*sin(x) + 2*x*e^y ----
     let g = scalar_fn!(|v: &[f64; 2]| v[1] * v[0].sin() + c(2.0) * v[0] * v[1].exp());
     let hessian: Hessian = Hessian::default();
-    let result = hessian.get(&g, &[1.0, 2.0]).unwrap();
+    let result = hessian.evaluate(&g, &[1.0, 2.0]).unwrap();
 
     println!("\nHessian of y*sin(x) + 2*x*e^y at [1, 2]:");
     for row in 0..2 {

--- a/demos/examples/basics/kinematics.rs
+++ b/demos/examples/basics/kinematics.rs
@@ -21,8 +21,9 @@ fn report(label: &str, value: f64, exact: f64) {
 }
 
 fn main() {
-    // A 36 mm wheel radius and a 235 mm track width.
-    let dd = DifferentialDrive::new(0.036_f64, 0.235).unwrap();
+    let wheel_radius = 0.036_f64; // 36 mm
+    let track_width = 0.235; // 235 mm between the wheels
+    let dd = DifferentialDrive::new(wheel_radius, track_width).unwrap();
 
     // (1) Wheel velocities to a body twist. Equal drives straight; opposite spins in place.
     let straight = dd.forward(WheelVelocities::new(10.0, 10.0));
@@ -44,7 +45,8 @@ fn main() {
 
     // (3) Odometry along the exact constant-twist arc, against the closed form for radius v/omega.
     let (v, w, t) = (0.4_f64, 0.9, 1.3);
-    let pose = integrate(SE2::identity(), BodyTwist::new(v, w).integrate_over(t));
+    let start = SE2::identity();
+    let pose = integrate(start, BodyTwist::new(v, w).integrate_over(t));
     let (theta, radius) = (w * t, v / w);
     println!("\nArc of a constant twist (v = 0.4, omega = 0.9) held for 1.3 s");
     report("x [m]", pose.translation()[0], radius * theta.sin());

--- a/demos/examples/basics/lie_groups.rs
+++ b/demos/examples/basics/lie_groups.rs
@@ -21,8 +21,11 @@ fn report(label: &str, value: f64, exact: f64) {
 
 fn main() {
     // (1) SO(3): a 90° rotation about z maps x -> y.
-    let rz = SO3::<f64>::exp(Vector::new([0.0, 0.0, FRAC_PI_2]));
-    let p = rz.act(Vector::new([1.0, 0.0, 0.0]));
+    let quarter_turn_about_z = Vector::new([0.0, 0.0, FRAC_PI_2]);
+    let rz = SO3::<f64>::exp(quarter_turn_about_z);
+
+    let along_x = Vector::new([1.0, 0.0, 0.0]);
+    let p = rz.act(along_x);
     println!("SO(3): 90 deg about z applied to (1, 0, 0)");
     report("x", p[0], 0.0);
     report("y", p[1], 1.0);
@@ -37,15 +40,17 @@ fn main() {
     }
 
     // (3) SE(3): rotate then translate a point.
-    let g = SE3::from_parts(rz, Vector::new([1.0, 2.0, 3.0]));
-    let q = g.act(Vector::new([1.0, 0.0, 0.0]));
+    let translation = Vector::new([1.0, 2.0, 3.0]);
+    let g = SE3::from_parts(rz, translation);
+    let q = g.act(along_x);
     println!("\nSE(3): rotate then translate (1, 0, 0)");
     report("x", q[0], 1.0);
     report("y", q[1], 3.0);
     report("z", q[2], 3.0);
 
     // (4) Geodesic interpolation: midpoint of identity and a 90° rotation is 45°.
-    let mid = SO3::<f64>::identity().interpolate(rz, 0.5);
+    let halfway = 0.5;
+    let mid = SO3::<f64>::identity().interpolate(rz, halfway);
     println!("\nSO(3): slerp midpoint angle about z");
     report("angle (rad)", mid.log()[2], FRAC_PI_2 / 2.0);
 

--- a/demos/examples/basics/linear_algebra.rs
+++ b/demos/examples/basics/linear_algebra.rs
@@ -5,12 +5,10 @@
 //! Latency is illustrative in a debug build; run with `--release` for representative numbers:
 //! `cargo run -p multicalc-demos --release --example linear_algebra`
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
-
 use std::hint::black_box;
 use std::time::Instant;
 
-use multicalc::linear_algebra::{Matrix, Vector};
+use multicalc::{CalcError, Matrix, Vector};
 
 /// Mean wall-clock time per call, in nanoseconds, over `iters` runs.
 fn time<T>(iters: u32, mut f: impl FnMut() -> T) -> (T, f64) {
@@ -54,11 +52,14 @@ fn spd<const N: usize>() -> Matrix<N, N> {
     Matrix::from_fn(|i, j| if i == j { (N + 1) as f64 } else { 1.0 })
 }
 
-fn lu_report<const N: usize>(a: Matrix<N, N>, label: &str) {
+fn lu_report<const N: usize>(a: Matrix<N, N>, label: &str) -> Result<(), CalcError> {
     let x_true = Vector::<N>::from_fn(|i| 1.0 + i as f64);
     let b = a * x_true;
 
-    let (f, ns) = time(50_000, || black_box(a).lu().unwrap());
+    // The factorization is fallible, so the timed closure hands back the `Result` and `?` takes
+    // it from there: a singular matrix stops the demo with a typed error instead of a panic.
+    let (factorization, ns) = time(50_000, || black_box(a).lu());
+    let f = factorization?;
 
     // Reconstruction: row i of P·A is row perm[i] of A, and P·A == L·U.
     let perm = f.permutation();
@@ -67,13 +68,15 @@ fn lu_report<const N: usize>(a: Matrix<N, N>, label: &str) {
 
     let residual = (a * f.solve(b) - b).norm();
     println!("  {label:<14} {ns:>8.1} ns   PA-LU {recon:.1e}   residual {residual:.1e}");
+    Ok(())
 }
 
-fn cholesky_report<const N: usize>(a: Matrix<N, N>, label: &str) {
+fn cholesky_report<const N: usize>(a: Matrix<N, N>, label: &str) -> Result<(), CalcError> {
     let x_true = Vector::<N>::from_fn(|i| 1.0 + i as f64);
     let b = a * x_true;
 
-    let (f, ns) = time(50_000, || black_box(a).cholesky().unwrap());
+    let (factorization, ns) = time(50_000, || black_box(a).cholesky());
+    let f = factorization?;
 
     let l = f.l();
     let recon = max_abs(a, l * l.transpose());
@@ -81,48 +84,56 @@ fn cholesky_report<const N: usize>(a: Matrix<N, N>, label: &str) {
     let x = f.solve(b);
     let residual = (a * x - b).norm();
     // Agreement with the general LU solve on the same system.
-    let lu_x = a.lu().unwrap().solve(b);
+    let lu_x = a.lu()?.solve(b);
     let vs_lu = (0..N).map(|i| (x[i] - lu_x[i]).abs()).fold(0.0, f64::max);
 
     println!(
         "  {label:<14} {ns:>8.1} ns   A-LLt {recon:.1e}   residual {residual:.1e}   vs LU {vs_lu:.1e}"
     );
+    Ok(())
 }
 
-fn inverse4_report(a: Matrix<4, 4>, label: &str) {
-    let (inv, ns) = time(100_000, || black_box(a).inverse().unwrap());
-    let identity_err = max_abs(a * inv, Matrix::<4, 4>::identity());
+fn inverse4_report(a: Matrix<4, 4>, label: &str) -> Result<(), CalcError> {
+    let (inverse, ns) = time(100_000, || black_box(a).inverse());
+    let identity_err = max_abs(a * inverse?, Matrix::<4, 4>::identity());
     println!("  {label:<14} {ns:>8.1} ns   identity err {identity_err:.1e}");
+    Ok(())
 }
 
-fn main() {
+// Every fallible call below propagates with `?`. The error types are per-module — here
+// `LinalgError` — and each converts into the `CalcError` umbrella on the way out, so one return
+// type covers a program that mixes modules.
+fn main() -> Result<(), CalcError> {
     // Sanity: the LU solve residual on a well-conditioned system is tiny.
     {
         let a = general::<4>();
         let x_true = Vector::<4>::from_fn(|i| 1.0 + i as f64);
         let b = a * x_true;
-        let x = a.lu().unwrap().solve(b);
+        let x = a.lu()?.solve(b);
         assert!((a * x - b).norm() < 1e-9, "LU solve residual too large");
     }
 
     println!("LU (any invertible matrix) - decompose + solve:");
-    lu_report(general::<4>(), "general 4x4");
-    lu_report(general::<8>(), "general 8x8");
-    lu_report(hilbert::<6>(), "Hilbert 6x6");
+    lu_report(general::<4>(), "general 4x4")?;
+    lu_report(general::<8>(), "general 8x8")?;
+    lu_report(hilbert::<6>(), "Hilbert 6x6")?;
 
     println!("\nCholesky (symmetric positive-definite) - decompose + solve:");
-    cholesky_report(spd::<4>(), "SPD 4x4");
-    cholesky_report(spd::<8>(), "SPD 8x8");
-    cholesky_report(hilbert::<6>(), "Hilbert 6x6");
-    // Error path: the guard rejects a non-positive-definite matrix before taking a root.
+    cholesky_report(spd::<4>(), "SPD 4x4")?;
+    cholesky_report(spd::<8>(), "SPD 8x8")?;
+    cholesky_report(hilbert::<6>(), "Hilbert 6x6")?;
+
+    // Error path: the guard rejects a non-positive-definite matrix before taking a root. This one
+    // is expected to fail, so it is matched rather than propagated.
     let indefinite = Matrix::<2, 2>::new([[1.0, 2.0], [2.0, 1.0]]);
-    println!(
-        "  {:<14} rejected: {}",
-        "indefinite 2x2",
-        indefinite.cholesky().unwrap_err()
-    );
+    match indefinite.cholesky() {
+        Ok(_) => println!("  {:<14} unexpectedly accepted", "indefinite 2x2"),
+        Err(error) => println!("  {:<14} rejected: {error}", "indefinite 2x2"),
+    }
 
     println!("\nDirect 4x4 inverse:");
-    inverse4_report(general::<4>(), "general 4x4");
-    inverse4_report(hilbert::<4>(), "Hilbert 4x4");
+    inverse4_report(general::<4>(), "general 4x4")?;
+    inverse4_report(hilbert::<4>(), "Hilbert 4x4")?;
+
+    Ok(())
 }

--- a/demos/examples/basics/ode.rs
+++ b/demos/examples/basics/ode.rs
@@ -47,8 +47,15 @@ fn harmonic_oscillator() {
     );
 
     // RK45: adaptive solve to t = 2*pi, then dense-output sampling.
-    let solver = Rk45::default().with_rtol(1e-9).with_atol(1e-12);
-    let yf = solver.solve(&f, 0.0, &y0, core::f64::consts::TAU).unwrap();
+    let relative_tolerance = 1e-9;
+    let absolute_tolerance = 1e-12;
+    let solver = Rk45::default()
+        .with_rtol(relative_tolerance)
+        .with_atol(absolute_tolerance);
+
+    let start_time = 0.0;
+    let one_period = core::f64::consts::TAU;
+    let yf = solver.solve(&f, start_time, &y0, one_period).unwrap();
     let e = exact(core::f64::consts::TAU);
     println!("  RK45 adaptive solve to t = 2*pi (rtol 1e-9)");
     println!(

--- a/demos/examples/basics/optimization_solvers.rs
+++ b/demos/examples/basics/optimization_solvers.rs
@@ -30,8 +30,10 @@ impl VectorFn<2, 3> for LineFit {
 }
 
 fn main() {
+    let initial_guess = [0.0, 0.0];
+
     let report = GaussNewton::<AutoDiffMulti>::default()
-        .minimize(&LineFit, &[0.0, 0.0])
+        .minimize(&LineFit, &initial_guess)
         .expect("gauss-newton did not converge");
 
     let (a, b) = (report.solution[0], report.solution[1]);

--- a/demos/examples/basics/optimization_solvers.rs
+++ b/demos/examples/basics/optimization_solvers.rs
@@ -10,7 +10,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use multicalc::GaussNewton;
-use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+use multicalc::numerical_derivative::AutoDiffMulti;
 use multicalc::scalar::{Numeric, VectorFn};
 
 // Fit y = a + b*t to points on y = 2t + 1; linear residuals converge in one GN step.

--- a/demos/examples/basics/root_finding.rs
+++ b/demos/examples/basics/root_finding.rs
@@ -14,7 +14,9 @@ fn main() -> Result<(), CalcError> {
     // The root 4.965114231744276 fixes the peak of the blackbody spectrum.
     let wien = scalar_fn!(|x| c(-5.0) + x + c(5.0) * (-x).exp());
     let wien_true = 4.965114231744276_f64;
-    let r = Bisection::default().solve(&wien, 1.0, 10.0)?;
+    let lower_bound = 1.0;
+    let upper_bound = 10.0;
+    let r = Bisection::default().solve(&wien, lower_bound, upper_bound)?;
     println!("Bisection  Wien's displacement root on [1, 10]");
     println!(
         "  root = {:.15}   |err| = {:.1e}   ({} iters, {:?})",
@@ -27,7 +29,8 @@ fn main() -> Result<(), CalcError> {
     // ---- Newton: x^2 - 2 = 0, exact derivative via Dual numbers ----
     let f = scalar_fn!(|x| c(-2.0) + x * x);
     let sqrt2 = 2.0_f64.sqrt();
-    let r = Newton::new().solve(&f, 2.0)?;
+    let initial_guess = 2.0;
+    let r = Newton::new().solve(&f, initial_guess)?;
     println!("\nNewton  x^2 - 2 = 0 (exact derivative, x0 = 2)");
     println!(
         "  root = {:.15}   |err| = {:.1e}   ({} iters, {:?})",
@@ -42,8 +45,11 @@ fn main() -> Result<(), CalcError> {
     // backtracking line search halves the step until |f| decreases.
     let g = scalar_fn!(|x| x / (c(1.0) + x * x).sqrt());
     // The plain solve is expected to fail, so its `Result` is printed rather than propagated.
-    let plain = Newton::new().solve(&g, 2.0);
-    let damped = Newton::new().with_backtracking(true).solve(&g, 2.0)?;
+    let use_backtracking = true;
+    let plain = Newton::new().solve(&g, initial_guess);
+    let damped = Newton::new()
+        .with_backtracking(use_backtracking)
+        .solve(&g, initial_guess)?;
     println!("\nDamped Newton  x / sqrt(1 + x^2), root at 0, from x0 = 2");
     println!("  plain Newton  -> {plain:?}");
     println!(

--- a/demos/examples/basics/root_finding.rs
+++ b/demos/examples/basics/root_finding.rs
@@ -5,7 +5,7 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use multicalc::numerical_derivative::autodiff::{AutoDiffMulti, AutoDiffSingle};
+use multicalc::numerical_derivative::{AutoDiffMulti, AutoDiffSingle};
 use multicalc::root_finding::{Bisection, Newton, NewtonSystem};
 use multicalc::scalar::c;
 use multicalc::{scalar_fn, scalar_fn_vec};

--- a/demos/examples/basics/root_finding.rs
+++ b/demos/examples/basics/root_finding.rs
@@ -3,19 +3,18 @@
 //!
 //! Run with: `cargo run -p multicalc-demos --example root_finding`
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
-
-use multicalc::numerical_derivative::{AutoDiffMulti, AutoDiffSingle};
-use multicalc::root_finding::{Bisection, Newton, NewtonSystem};
-use multicalc::scalar::c;
+use multicalc::{Bisection, CalcError, Newton, NewtonSystem, c};
 use multicalc::{scalar_fn, scalar_fn_vec};
 
-fn main() {
+// Every solve below propagates with `?`. A solver that runs out of iterations, or is handed a
+// bracket that does not straddle a root, returns `SolveError`, which converts into the `CalcError`
+// umbrella on the way out.
+fn main() -> Result<(), CalcError> {
     // ---- Bisection: Wien's displacement law, x - 5 + 5*e^-x = 0 ----
     // The root 4.965114231744276 fixes the peak of the blackbody spectrum.
     let wien = scalar_fn!(|x| c(-5.0) + x + c(5.0) * (-x).exp());
     let wien_true = 4.965114231744276_f64;
-    let r = Bisection::default().solve(&wien, 1.0, 10.0).unwrap();
+    let r = Bisection::default().solve(&wien, 1.0, 10.0)?;
     println!("Bisection  Wien's displacement root on [1, 10]");
     println!(
         "  root = {:.15}   |err| = {:.1e}   ({} iters, {:?})",
@@ -28,7 +27,7 @@ fn main() {
     // ---- Newton: x^2 - 2 = 0, exact derivative via Dual numbers ----
     let f = scalar_fn!(|x| c(-2.0) + x * x);
     let sqrt2 = 2.0_f64.sqrt();
-    let r = Newton::<AutoDiffSingle>::default().solve(&f, 2.0).unwrap();
+    let r = Newton::new().solve(&f, 2.0)?;
     println!("\nNewton  x^2 - 2 = 0 (exact derivative, x0 = 2)");
     println!(
         "  root = {:.15}   |err| = {:.1e}   ({} iters, {:?})",
@@ -42,11 +41,9 @@ fn main() {
     // The plain Newton map is x -> -x^3, so from x0 = 2 it diverges. The
     // backtracking line search halves the step until |f| decreases.
     let g = scalar_fn!(|x| x / (c(1.0) + x * x).sqrt());
-    let plain = Newton::<AutoDiffSingle>::default().solve(&g, 2.0);
-    let damped = Newton::<AutoDiffSingle>::default()
-        .with_backtracking(true)
-        .solve(&g, 2.0)
-        .unwrap();
+    // The plain solve is expected to fail, so its `Result` is printed rather than propagated.
+    let plain = Newton::new().solve(&g, 2.0);
+    let damped = Newton::new().with_backtracking(true).solve(&g, 2.0)?;
     println!("\nDamped Newton  x / sqrt(1 + x^2), root at 0, from x0 = 2");
     println!("  plain Newton  -> {plain:?}");
     println!(
@@ -63,9 +60,7 @@ fn main() {
         );
     let x_true = (2.0_f64 + 3.0_f64.sqrt()).sqrt();
     let y_true = (2.0_f64 - 3.0_f64.sqrt()).sqrt();
-    let r = NewtonSystem::<AutoDiffMulti>::default()
-        .solve(&system, &[1.5, 0.8])
-        .unwrap();
+    let r = NewtonSystem::new().solve(&system, &[1.5, 0.8])?;
     let err = (r.root[0] - x_true).abs().max((r.root[1] - y_true).abs());
     assert!(
         err < 1e-9,
@@ -77,4 +72,6 @@ fn main() {
         "  |err| = {err:.1e}   norm(F) = {:.1e}   ({} iters, {:?})",
         r.residual_norm, r.iterations, r.termination
     );
+
+    Ok(())
 }

--- a/demos/examples/basics/vector_field.rs
+++ b/demos/examples/basics/vector_field.rs
@@ -4,18 +4,18 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+use multicalc::numerical_derivative::AutoDiffMulti;
 use multicalc::scalar::c;
 use multicalc::scalar_fn_vec;
-use multicalc::vector_field::{curl, divergence, flux_integral, line_integral};
+use multicalc::vector_field::{curl_2d, divergence_2d, flux_integral_2d, line_integral_2d};
 
 fn main() {
     // ---- curl & divergence of the 2D field (2xy, 3cos y), by autodiff (exact) ----
     let field = scalar_fn_vec!(|v: &[f64; 2]| [c(2.0) * v[0] * v[1], c(3.0) * v[1].cos()]);
     let point = [1.0, std::f64::consts::PI];
 
-    let curl_2d = curl::get_2d(AutoDiffMulti::default(), &field, &point).unwrap();
-    let div_2d = divergence::get_2d(AutoDiffMulti::default(), &field, &point).unwrap();
+    let curl_2d = curl_2d(AutoDiffMulti::default(), &field, &point).unwrap();
+    let div_2d = divergence_2d(AutoDiffMulti::default(), &field, &point).unwrap();
     assert!((curl_2d + 2.0).abs() < 1e-9, "curl");
     assert!((div_2d - std::f64::consts::TAU).abs() < 1e-9, "divergence");
     println!("field (2xy, 3cos y) at {point:?}");
@@ -31,8 +31,8 @@ fn main() {
     let curve: [&dyn Fn(f64) -> f64; 2] = [&(|t: f64| t.cos()), &(|t: f64| t.sin())];
     let limit = [0.0, 2.0 * std::f64::consts::PI];
 
-    let line = line_integral::get_2d(&g, &curve, &limit).unwrap();
-    let flux = flux_integral::get_2d(&g, &curve, &limit).unwrap();
+    let line = line_integral_2d(&g, &curve, &limit).unwrap();
+    let flux = flux_integral_2d(&g, &curve, &limit).unwrap();
     println!("\nfield (y, -x) over the unit circle");
     println!(
         "  line integral = {line:.4}   (exact -2*pi = {:.4})",

--- a/demos/examples/showcase/3d_arm_ik.rs
+++ b/demos/examples/showcase/3d_arm_ik.rs
@@ -15,7 +15,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use multicalc::linear_algebra::Vector;
-use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+use multicalc::numerical_derivative::AutoDiffMulti;
 use multicalc::scalar::{Numeric, VectorFn};
 use multicalc::spatial::{Quaternion, SE3, SO3};
 use multicalc::{LevenbergMarquardt, SolveError};

--- a/demos/examples/showcase/curve_fit_live.rs
+++ b/demos/examples/showcase/curve_fit_live.rs
@@ -32,8 +32,11 @@ fn main() -> Result<(), VizError> {
     let y: [f64; M] = core::array::from_fn(|i| A_TRUE * (B_TRUE * i as f64).exp());
     let problem = SensorFit { t, y };
 
+    // Deliberately away from the truth, so the fit has work to do.
+    let initial_guess = [80.0, -0.3];
+
     let report = LevenbergMarquardt::<AutoDiffMulti>::default()
-        .minimize(&problem, &[80.0, -0.3])
+        .minimize(&problem, &initial_guess)
         .expect("curve fit did not converge");
     let (a, b) = (report.solution[0], report.solution[1]);
     let fit = |tt: f64| a * (b * tt).exp();

--- a/demos/examples/showcase/curve_fit_live.rs
+++ b/demos/examples/showcase/curve_fit_live.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use multicalc::LevenbergMarquardt;
-use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+use multicalc::numerical_derivative::AutoDiffMulti;
 use multicalc::scalar::{Numeric, VectorFn};
 use multicalc_demos::{RerunSink, VizError, VizSink};
 

--- a/demos/examples/showcase/curve_fit_record.rs
+++ b/demos/examples/showcase/curve_fit_record.rs
@@ -31,8 +31,11 @@ fn main() -> Result<(), VizError> {
     let y: [f64; M] = core::array::from_fn(|i| A_TRUE * (B_TRUE * i as f64).exp());
     let problem = SensorFit { t, y };
 
+    // Deliberately away from the truth, so the fit has work to do.
+    let initial_guess = [80.0, -0.3];
+
     let report = LevenbergMarquardt::<AutoDiffMulti>::default()
-        .minimize(&problem, &[80.0, -0.3])
+        .minimize(&problem, &initial_guess)
         .expect("curve fit did not converge");
     let (a, b) = (report.solution[0], report.solution[1]);
     let fit = |tt: f64| a * (b * tt).exp();

--- a/demos/examples/showcase/curve_fit_record.rs
+++ b/demos/examples/showcase/curve_fit_record.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use multicalc::LevenbergMarquardt;
-use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+use multicalc::numerical_derivative::AutoDiffMulti;
 use multicalc::scalar::{Numeric, VectorFn};
 use multicalc_demos::{CsvSink, RerunSink, VizError, VizSink};
 

--- a/demos/examples/showcase/fourier_ferris.rs
+++ b/demos/examples/showcase/fourier_ferris.rs
@@ -16,9 +16,9 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use multicalc::numerical_integration::gaussian_integration::GaussianSingle;
-use multicalc::numerical_integration::integrator::IntegratorSingleVariable;
-use multicalc::numerical_integration::mode::GaussianQuadratureMethod;
+use multicalc::numerical_integration::GaussianQuadratureMethod;
+use multicalc::numerical_integration::GaussianSingle;
+use multicalc::numerical_integration::IntegratorSingleVariable;
 use multicalc_demos::loop_util::{LatencyRing, Pacer, commas};
 use multicalc_demos::{RerunSink, Rgba, VizError, VizSink};
 use std::collections::VecDeque;
@@ -152,8 +152,8 @@ fn compute_coefficients(t: &[f64]) -> (Vec<(i32, Cx)>, f64, u64) {
                 let th = omega * tt;
                 y * th.cos() - x * th.sin()
             };
-            let re = gl.get_single(&seg_re, &[ta, tb]).expect("gl re");
-            let im = gl.get_single(&seg_im, &[ta, tb]).expect("gl im");
+            let re = gl.single_integral(&seg_re, &[ta, tb]).expect("gl re");
+            let im = gl.single_integral(&seg_im, &[ta, tb]).expect("gl im");
             c_gl = c_gl.add(Cx::new(re, im));
             node_evals += 2 * GL_ORDER as u64;
 

--- a/demos/examples/showcase/gradient_marbles.rs
+++ b/demos/examples/showcase/gradient_marbles.rs
@@ -16,8 +16,8 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
-use multicalc::numerical_derivative::jacobian::Jacobian;
+use multicalc::numerical_derivative::AutoDiffMulti;
+use multicalc::numerical_derivative::Jacobian;
 use multicalc::scalar::{Numeric, VectorFn};
 use multicalc_demos::loop_util::{LatencyRing, Pacer, commas};
 use multicalc_demos::{RerunSink, Rgba, VizError, VizSink};
@@ -149,7 +149,7 @@ fn quantile(vals: &[f64], q: f64) -> f64 {
 fn probe_error(jac: &Jacobian, probes: &[[f64; 2]]) -> f64 {
     let mut max_err = 0.0f64;
     for p in probes {
-        let gradient = jac.get(&Himmelblau, p).expect("probe gradient");
+        let gradient = jac.evaluate(&Himmelblau, p).expect("probe gradient");
         let ad = [gradient[(0, 0)], gradient[(0, 1)]];
         let an = himmelblau_grad(p[0], p[1]);
         max_err = max_err
@@ -239,7 +239,7 @@ fn main() -> Result<(), VizError> {
         let t0 = Instant::now();
         for (i, m) in marbles.iter().enumerate() {
             grads[i] = jac
-                .get(&Himmelblau, &m.pos)
+                .evaluate(&Himmelblau, &m.pos)
                 .ok()
                 .map(|j| [j[(0, 0)], j[(0, 1)]]);
         }

--- a/demos/examples/showcase/newton_fractal.rs
+++ b/demos/examples/showcase/newton_fractal.rs
@@ -106,9 +106,11 @@ fn main() -> Result<(), VizError> {
 
     // Built once; solve takes &self. Backtracking stays off (default) — it would smooth away the
     // wild Newton steps that make the filigree.
+    let max_iterations = 24;
+    let residual_tolerance = 1e-13;
     let solver = NewtonSystem::<AutoDiffMulti>::default()
-        .with_max_iterations(24)
-        .with_ftol(1e-13);
+        .with_max_iterations(max_iterations)
+        .with_ftol(residual_tolerance);
 
     let mut basins = CubicBasins {
         roots: roots_at(0.0),

--- a/demos/examples/showcase/newton_fractal.rs
+++ b/demos/examples/showcase/newton_fractal.rs
@@ -18,7 +18,7 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+use multicalc::numerical_derivative::AutoDiffMulti;
 use multicalc::root_finding::NewtonSystem;
 use multicalc::scalar::{Numeric, VectorFn};
 use multicalc_demos::loop_util::{LatencyRing, commas};

--- a/tools/embedded-smoke/src/checks.rs
+++ b/tools/embedded-smoke/src/checks.rs
@@ -17,17 +17,17 @@ use multicalc::control::{FollowTheGap, Pid, pure_pursuit_curvature};
 use multicalc::error::LinalgError;
 use multicalc::estimation::{ExtendedKalmanFilter, KalmanFilter, KalmanModel};
 use multicalc::linear_algebra::{Matrix, Vector};
-use multicalc::numerical_derivative::autodiff::{AutoDiffMulti, AutoDiffSingle};
-use multicalc::numerical_derivative::derivator::DerivatorSingleVariable;
-use multicalc::numerical_derivative::jacobian::Jacobian;
-use multicalc::numerical_integration::gaussian_integration::GaussianSingle;
-use multicalc::numerical_integration::integrator::IntegratorSingleVariable;
-use multicalc::numerical_integration::mode::GaussianQuadratureMethod;
+use multicalc::numerical_derivative::DerivatorSingleVariable;
+use multicalc::numerical_derivative::Jacobian;
+use multicalc::numerical_derivative::{AutoDiffMulti, AutoDiffSingle};
+use multicalc::numerical_integration::GaussianQuadratureMethod;
+use multicalc::numerical_integration::GaussianSingle;
+use multicalc::numerical_integration::IntegratorSingleVariable;
 use multicalc::root_finding::Newton;
 use multicalc::scalar::{Numeric, VectorFn};
 use multicalc::scalar_fn;
 use multicalc::spatial::SE2;
-use multicalc::vector_field::{curl, divergence};
+use multicalc::vector_field::{curl_3d, divergence_3d};
 use multicalc_testkit::problems::{Jac23, Rosenbrock, VField3d, Wien};
 
 use crate::fixtures;
@@ -79,7 +79,9 @@ pub fn lm_fit() -> f64 {
 pub fn autodiff_derivative() -> f64 {
     let f = scalar_fn!(|x| x * x * x);
     let d = AutoDiffSingle::default();
-    let value = d.get(1, &f, black_box(2.0_f64)).expect("derivative");
+    let value = d
+        .differentiate(1, &f, black_box(2.0_f64))
+        .expect("derivative");
     assert_close!("autodiff_derivative", black_box(value), 12.0, 1e-12, 0.0);
     black_box(value)
 }
@@ -90,7 +92,9 @@ pub fn autodiff_derivative() -> f64 {
 pub fn autodiff_derivative_f32() -> f32 {
     let f = scalar_fn!(|x| x * x * x);
     let d = AutoDiffSingle::default();
-    let value: f32 = d.get(1, &f, black_box(2.0_f32)).expect("derivative f32");
+    let value: f32 = d
+        .differentiate(1, &f, black_box(2.0_f32))
+        .expect("derivative f32");
     // f32 tolerance is looser than f64; assert in f32 space directly.
     let ok = (value - 12.0_f32).abs() <= 1e-4;
     if !ok {
@@ -215,7 +219,7 @@ pub fn quadrature_identity() -> f64 {
     let f = |x: f64| 2.0 * x;
     let quad = GaussianSingle::<f64>::from_parameters(4, GaussianQuadratureMethod::GaussLegendre);
     let value = quad
-        .get_single(&f, &black_box([0.0, 2.0]))
+        .single_integral(&f, &black_box([0.0, 2.0]))
         .expect("quadrature");
     assert_close!("quadrature", black_box(value), 4.0, 1e-12, 0.0);
     black_box(value)
@@ -226,7 +230,7 @@ pub fn quadrature_identity() -> f64 {
 #[cfg_attr(not(feature = "full-smoke"), allow(dead_code))]
 pub fn jacobian_identity() -> f64 {
     let j = Jacobian::<AutoDiffMulti>::default()
-        .get(&Jac23, &black_box([1.0, 2.0, 3.0]))
+        .evaluate(&Jac23, &black_box([1.0, 2.0, 3.0]))
         .expect("jacobian");
     let expected = [[6.0, 3.0, 2.0], [2.0, 4.0, 0.0]];
     for r in 0..2 {
@@ -242,12 +246,12 @@ pub fn jacobian_identity() -> f64 {
 #[cfg_attr(not(feature = "full-smoke"), allow(dead_code))]
 pub fn vector_field_identity() -> f64 {
     let point = black_box([1.0, 2.0, 3.0]);
-    let c = curl::get_3d(AutoDiffMulti::default(), &VField3d, &point).expect("curl");
+    let c = curl_3d(AutoDiffMulti::default(), &VField3d, &point).expect("curl");
     let expected_curl = [0.0, 0.0, -2.0];
     for i in 0..3 {
         assert_close!("vfield_curl", black_box(c[i]), expected_curl[i], 1e-12, 0.0);
     }
-    let d = divergence::get_3d(AutoDiffMulti::default(), &VField3d, &point).expect("divergence");
+    let d = divergence_3d(AutoDiffMulti::default(), &VField3d, &point).expect("divergence");
     assert_close!("vfield_div", black_box(d), 2.0, 1e-12, 0.0);
     black_box(d)
 }

--- a/tools/qa/benches/latency.rs
+++ b/tools/qa/benches/latency.rs
@@ -9,12 +9,12 @@ use std::path::PathBuf;
 use criterion::Criterion;
 
 use multicalc::linear_algebra::{Matrix, Vector};
-use multicalc::numerical_derivative::autodiff::{AutoDiffMulti, AutoDiffSingle};
-use multicalc::numerical_derivative::derivator::DerivatorSingleVariable;
-use multicalc::numerical_derivative::jacobian::Jacobian;
-use multicalc::numerical_integration::gaussian_integration::GaussianSingle;
-use multicalc::numerical_integration::integrator::IntegratorSingleVariable;
-use multicalc::numerical_integration::mode::GaussianQuadratureMethod;
+use multicalc::numerical_derivative::DerivatorSingleVariable;
+use multicalc::numerical_derivative::Jacobian;
+use multicalc::numerical_derivative::{AutoDiffMulti, AutoDiffSingle};
+use multicalc::numerical_integration::GaussianQuadratureMethod;
+use multicalc::numerical_integration::GaussianSingle;
+use multicalc::numerical_integration::IntegratorSingleVariable;
 use multicalc::ode::{Rk4, Rk45};
 use multicalc::root_finding::NewtonSystem;
 use multicalc::scalar::{Numeric, VectorFn, c};
@@ -49,7 +49,7 @@ fn bench_derivative(c: &mut Criterion) {
     let f = scalar_fn!(|x| x * x * x.sin());
     let d = AutoDiffSingle::default();
     c.bench_function("derivative", |b| {
-        b.iter(|| d.get(black_box(3), &f, black_box(1.0)).unwrap())
+        b.iter(|| d.differentiate(black_box(3), &f, black_box(1.0)).unwrap())
     });
 }
 
@@ -59,7 +59,7 @@ fn bench_jacobian_small(c: &mut Criterion) {
     let j: Jacobian = Jacobian::default();
     let p = [1.0, 2.0, 3.0];
     c.bench_function("jacobian_small", |b| {
-        b.iter(|| j.get(&f, black_box(&p)).unwrap())
+        b.iter(|| j.evaluate(&f, black_box(&p)).unwrap())
     });
 }
 
@@ -76,7 +76,7 @@ fn bench_jacobian_large(crit: &mut Criterion) {
     let j: Jacobian = Jacobian::default();
     let p = [0.5, 1.0, 1.5, 0.3, 0.8, 1.2];
     crit.bench_function("jacobian_large", |b| {
-        b.iter(|| j.get(&f, black_box(&p)).unwrap())
+        b.iter(|| j.evaluate(&f, black_box(&p)).unwrap())
     });
 }
 
@@ -85,7 +85,7 @@ fn bench_gauss_quad(c: &mut Criterion) {
     let quad = GaussianSingle::from_parameters(16, GaussianQuadratureMethod::GaussLegendre);
     c.bench_function("gauss_quad", |b| {
         b.iter(|| {
-            quad.get_single(
+            quad.single_integral(
                 &|x: f64| (x.sin() - x.sqrt()) * (-x).exp(),
                 black_box(&[0.0, 1.0]),
             )

--- a/tools/qa/src/lib.rs
+++ b/tools/qa/src/lib.rs
@@ -1,3 +1,12 @@
 pub mod load;
 pub mod problems;
 pub mod schema;
+
+// Compiles the workspace README's examples when doctests run, so they cannot drift from the API.
+// It lives here rather than in `multicalc` because that crate is published, and its package would
+// not carry a file from the repository root.
+// Yeah, I know its a hack, but its late and I'm tired so here it stays until I am forced to find a
+// more elegant solution.
+#[cfg(doctest)]
+#[doc = include_str!("../../../README.md")]
+pub struct WorkspaceReadmeExamples;

--- a/tools/qa/tests/calculus.rs
+++ b/tools/qa/tests/calculus.rs
@@ -8,16 +8,16 @@
 //! function-valued case also re-checks `f_at_probe` (the function at its point),
 //! which fails loudly if the Rust and Python formulas ever diverge.
 
-use multicalc::approximation::linear_approximation::LinearApproximator;
-use multicalc::approximation::quadratic_approximation::QuadraticApproximator;
+use multicalc::approximation::LinearApproximator;
+use multicalc::approximation::QuadraticApproximator;
 use multicalc::linear_algebra::Vector;
-use multicalc::numerical_derivative::autodiff::{AutoDiffMulti, AutoDiffSingle};
-use multicalc::numerical_derivative::derivator::{DerivatorMultiVariable, DerivatorSingleVariable};
-use multicalc::numerical_derivative::hessian::Hessian;
-use multicalc::numerical_derivative::jacobian::Jacobian;
+use multicalc::numerical_derivative::Hessian;
+use multicalc::numerical_derivative::Jacobian;
+use multicalc::numerical_derivative::{AutoDiffMulti, AutoDiffSingle};
+use multicalc::numerical_derivative::{DerivatorMultiVariable, DerivatorSingleVariable};
 use multicalc::scalar::{ScalarFn, ScalarFnN, VectorFn};
 use multicalc::scalar_fn;
-use multicalc::vector_field::{curl, divergence, flux_integral, line_integral};
+use multicalc::vector_field::{curl_3d, divergence_3d, flux_integral_2d, line_integral_2d};
 use multicalc_qa::load::*;
 use multicalc_qa::problems::*;
 
@@ -40,7 +40,9 @@ fn calculus() {
                 let point = fx.inputs["point"].as_scalar();
                 let order = fx.inputs["order"].as_int() as usize;
                 let cube = scalar_fn!(|x| x * x * x);
-                let d = AutoDiffSingle::default().get(order, &cube, point).unwrap();
+                let d = AutoDiffSingle::default()
+                    .differentiate(order, &cube, point)
+                    .unwrap();
                 assert_scalar(d, &fx.expected["derivative"], t, "derivative");
                 assert_scalar(
                     cube.eval::<f64>(point),
@@ -58,9 +60,9 @@ fn calculus() {
                     .collect();
                 let d = AutoDiffMulti::default();
                 let val = match axes.as_slice() {
-                    [a] => d.get_single_partial(&G, *a, &point),
-                    [a, b] => d.get(&G, &[*a, *b], &point),
-                    [a, b, c] => d.get(&G, &[*a, *b, *c], &point),
+                    [a] => d.first_partial_derivative(&G, *a, &point),
+                    [a, b] => d.differentiate(&G, &[*a, *b], &point),
+                    [a, b, c] => d.differentiate(&G, &[*a, *b, *c], &point),
                     _ => panic!("unexpected axes {axes:?}"),
                 }
                 .unwrap();
@@ -76,7 +78,7 @@ fn calculus() {
                 "jac_23" => {
                     let p = to_vector::<3>(&fx.inputs["point"]).into_array();
                     let j = Jacobian::<AutoDiffMulti>::default()
-                        .get(&Jac23, &p)
+                        .evaluate(&Jac23, &p)
                         .unwrap();
                     assert_matrix(&j, &fx.expected["jacobian"], t, "jacobian");
                     assert_vector(
@@ -89,7 +91,7 @@ fn calculus() {
                 "jac_66" => {
                     let p = to_vector::<6>(&fx.inputs["point"]).into_array();
                     let j = Jacobian::<AutoDiffMulti>::default()
-                        .get(&Jac66, &p)
+                        .evaluate(&Jac66, &p)
                         .unwrap();
                     assert_matrix(&j, &fx.expected["jacobian"], t, "jacobian");
                     assert_vector(
@@ -104,7 +106,7 @@ fn calculus() {
             "hessian" => {
                 let p = to_vector::<3>(&fx.inputs["point"]).into_array();
                 let h = Hessian::<AutoDiffMulti>::default()
-                    .get(&HessianTarget, &p)
+                    .evaluate(&HessianTarget, &p)
                     .unwrap();
                 assert_matrix(&h, &fx.expected["hessian"], t, "hessian");
                 assert_scalar(
@@ -116,9 +118,9 @@ fn calculus() {
             }
             "curl_div" => {
                 let p = to_vector::<3>(&fx.inputs["point"]).into_array();
-                let c = curl::get_3d(AutoDiffMulti::default(), &VField3d, &p).unwrap();
+                let c = curl_3d(AutoDiffMulti::default(), &VField3d, &p).unwrap();
                 assert_vector(&Vector::new(c), &fx.expected["curl"], t, "curl");
-                let dv = divergence::get_3d(AutoDiffMulti::default(), &VField3d, &p).unwrap();
+                let dv = divergence_3d(AutoDiffMulti::default(), &VField3d, &p).unwrap();
                 assert_scalar(dv, &fx.expected["divergence"], t, "divergence");
                 assert_vector(
                     &Vector::new(VField3d.eval::<f64>(&p)),
@@ -129,28 +131,26 @@ fn calculus() {
             }
             "line_integral" => {
                 let lv = fx.inputs["limits"].as_vector();
-                let val =
-                    line_integral::get_2d(&circle_field(), &circle_transforms(), &[lv[0], lv[1]])
-                        .unwrap();
+                let val = line_integral_2d(&circle_field(), &circle_transforms(), &[lv[0], lv[1]])
+                    .unwrap();
                 assert_scalar(val, &fx.expected["line_integral"], t, "line_integral");
             }
             "flux_integral" => {
                 let lv = fx.inputs["limits"].as_vector();
-                let val =
-                    flux_integral::get_2d(&circle_field(), &circle_transforms(), &[lv[0], lv[1]])
-                        .unwrap();
+                let val = flux_integral_2d(&circle_field(), &circle_transforms(), &[lv[0], lv[1]])
+                    .unwrap();
                 assert_scalar(val, &fx.expected["flux_integral"], t, "flux_integral");
             }
             "approx" => {
                 let p = to_vector::<3>(&fx.inputs["p"]).into_array();
                 let q = to_vector::<3>(&fx.inputs["q"]).into_array();
                 let linear = LinearApproximator::<AutoDiffMulti>::default()
-                    .get(&ApproxTarget, &p)
+                    .approximate(&ApproxTarget, &p)
                     .unwrap()
                     .predict(&q);
                 assert_scalar(linear, &fx.expected["linear_predict"], t, "linear_predict");
                 let quadratic = QuadraticApproximator::<AutoDiffMulti>::default()
-                    .get(&ApproxTarget, &p)
+                    .approximate(&ApproxTarget, &p)
                     .unwrap()
                     .predict(&q);
                 assert_scalar(

--- a/tools/qa/tests/optimization.rs
+++ b/tools/qa/tests/optimization.rs
@@ -8,7 +8,7 @@
 //! quantity), not any library-specific cost scalar.
 
 use multicalc::linear_algebra::Vector;
-use multicalc::numerical_derivative::autodiff::AutoDiffMulti;
+use multicalc::numerical_derivative::AutoDiffMulti;
 use multicalc::optimization::LevenbergMarquardt;
 use multicalc::scalar::VectorFn;
 use multicalc_qa::load::*;

--- a/tools/qa/tests/quadrature.rs
+++ b/tools/qa/tests/quadrature.rs
@@ -7,10 +7,10 @@
 //! registry; the golden is the exact integral. Finite-domain polynomial cases
 //! also run an f32 pass against the f32 tolerance.
 
-use multicalc::numerical_integration::gaussian_integration::GaussianSingle;
-use multicalc::numerical_integration::integrator::IntegratorSingleVariable;
-use multicalc::numerical_integration::iterative_integration::IterativeSingle;
-use multicalc::numerical_integration::mode::{GaussianQuadratureMethod, IterativeMethod};
+use multicalc::numerical_integration::GaussianSingle;
+use multicalc::numerical_integration::IntegratorSingleVariable;
+use multicalc::numerical_integration::IterativeSingle;
+use multicalc::numerical_integration::{GaussianQuadratureMethod, IterativeMethod};
 use multicalc_qa::load::*;
 use multicalc_qa::problems::{integrand_f32, integrand_f64};
 
@@ -46,12 +46,12 @@ fn quadrature() {
         let value = match family {
             "iterative" => {
                 IterativeSingle::<f64>::from_parameters(param as u64, iterative_method(method))
-                    .get_single(&f, &limits)
+                    .single_integral(&f, &limits)
                     .unwrap()
             }
             "gaussian" => {
                 GaussianSingle::<f64>::from_parameters(param as usize, gaussian_method(method))
-                    .get_single(&f, &limits)
+                    .single_integral(&f, &limits)
                     .unwrap()
             }
             other => panic!("unknown family {other}"),
@@ -66,12 +66,12 @@ fn quadrature() {
             let value32 = match family {
                 "iterative" => {
                     IterativeSingle::<f32>::from_parameters(param as u64, iterative_method(method))
-                        .get_single(&f32_fn, &limits32)
+                        .single_integral(&f32_fn, &limits32)
                         .unwrap()
                 }
                 "gaussian" => {
                     GaussianSingle::<f32>::from_parameters(param as usize, gaussian_method(method))
-                        .get_single(&f32_fn, &limits32)
+                        .single_integral(&f32_fn, &limits32)
                         .unwrap()
                 }
                 other => panic!("unknown family {other}"),

--- a/tools/qa/tests/root_finding.rs
+++ b/tools/qa/tests/root_finding.rs
@@ -9,7 +9,7 @@
 //! diverge.
 
 use multicalc::linear_algebra::Vector;
-use multicalc::numerical_derivative::autodiff::{AutoDiffMulti, AutoDiffSingle};
+use multicalc::numerical_derivative::{AutoDiffMulti, AutoDiffSingle};
 use multicalc::root_finding::{Bisection, Newton, NewtonSystem};
 use multicalc::scalar::{ScalarFn, VectorFn};
 use multicalc_qa::load::*;


### PR DESCRIPTION
## What & why

Closes https://github.com/kmolan/multicalc-rust/issues/195 and https://github.com/kmolan/multicalc-rust/issues/196
Cleaner API, better docs and easier to read. Likeability is a jail.
1. Don't have multiple `get` functions everywhere. Make the function names more explicit.
2. Don't just use short variable names, or hardcode values in a function for public facing API. Be more descriptive so users can follow along easily.
3. Rewrite docs to be more explicit. Write a quick start for users to jump in.

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
