### PR TITLE
Tests should be more readable

### DIFF
--- a/crates/multicalc/tests/suite/approximation.rs
+++ b/crates/multicalc/tests/suite/approximation.rs
@@ -7,32 +7,33 @@ use multicalc::scalar_fn;
 use proptest::prelude::*;
 use rand::Rng;
 
+/// A thousand points scattered around `centre` with independent noise in [-0.1, 0.1).
+fn noisy_points_around(centre: [f64; 3]) -> [[f64; 3]; 1000] {
+    let mut points = [[0.0; 3]; 1000];
+    let mut random_generator = rand::thread_rng();
+    for point in &mut points {
+        let noise = random_generator.gen_range(-0.1..0.1);
+        *point = [centre[0] + noise, centre[1] + noise, centre[2] + noise];
+    }
+    points
+}
+
 #[test]
-fn test_linear_approximation_1() {
+fn linear_approximation_is_accurate_near_its_base_point() {
     //function is x + y^2 + z^3, which we want to linearize
-    let function_to_approximate = scalar_fn!(|v: &[f64; 3]| v[0] + v[1].powi(2) + v[2].powi(3));
+    let truth = scalar_fn!(|v: &[f64; 3]| v[0] + v[1].powi(2) + v[2].powi(3));
 
     let point = [1.0, 2.0, 3.0]; //the point we want to linearize around
 
     let approximator = LinearApproximator::<AutoDiffMulti>::default();
 
-    let result = approximator
-        .approximate(&function_to_approximate, &point)
-        .unwrap();
-    assert!(f64::abs(function_to_approximate.eval(&point) - result.predict(&point)) < 1e-9);
+    let model = approximator.approximate(&truth, &point).unwrap();
+    assert!(f64::abs(truth.eval(&point) - model.predict(&point)) < 1e-9);
 
-    //now test the prediction metrics. For prediction, generate a list of 1000 points, all centered around the original point
-    //with random noise between [-0.1, +0.1)
-    let mut prediction_points = [[0.0; 3]; 1000];
-    let mut random_generator = rand::thread_rng();
+    //now test the prediction metrics, over a cloud of points around the one we linearized around
+    let prediction_points = noisy_points_around(point);
 
-    for p in &mut prediction_points {
-        let noise = random_generator.gen_range(-0.1..0.1);
-        *p = [point[0] + noise, point[1] + noise, point[2] + noise];
-    }
-
-    let prediction_metrics =
-        result.prediction_metrics(&prediction_points, &function_to_approximate);
+    let prediction_metrics = model.prediction_metrics(&prediction_points, &truth);
 
     assert!(prediction_metrics.root_mean_squared_error < 0.05);
     assert!(prediction_metrics.mean_absolute_error < 0.05);
@@ -42,33 +43,22 @@ fn test_linear_approximation_1() {
 }
 
 #[test]
-fn test_quadratic_approximation_1() {
+fn quadratic_approximation_is_accurate_near_its_base_point() {
     //function is e^(x/2) + sin(y) + 2.0*z
-    let function_to_approximate =
-        scalar_fn!(|v: &[f64; 3]| (c(0.5) * v[0]).exp() + v[1].sin() + c(2.0) * v[2]);
+    let truth = scalar_fn!(|v: &[f64; 3]| (c(0.5) * v[0]).exp() + v[1].sin() + c(2.0) * v[2]);
 
     let point = [0.0, core::f64::consts::FRAC_PI_2, 10.0]; //the point we want to approximate around
 
     let approximator = QuadraticApproximator::<AutoDiffMulti>::default();
 
-    let result = approximator
-        .approximate(&function_to_approximate, &point)
-        .unwrap();
+    let model = approximator.approximate(&truth, &point).unwrap();
 
-    assert!(f64::abs(function_to_approximate.eval(&point) - result.predict(&point)) < 1e-9);
+    assert!(f64::abs(truth.eval(&point) - model.predict(&point)) < 1e-9);
 
-    //now test the prediction metrics. For prediction, generate a list of 1000 points, all centered around the original point
-    //with random noise between [-0.1, +0.1)
-    let mut prediction_points = [[0.0; 3]; 1000];
-    let mut random_generator = rand::thread_rng();
+    //now test the prediction metrics, over a cloud of points around the one we approximated around
+    let prediction_points = noisy_points_around(point);
 
-    for p in &mut prediction_points {
-        let noise = random_generator.gen_range(-0.1..0.1);
-        *p = [noise, core::f64::consts::FRAC_PI_2 + noise, 10.0 + noise];
-    }
-
-    let prediction_metrics =
-        result.prediction_metrics(&prediction_points, &function_to_approximate);
+    let prediction_metrics = model.prediction_metrics(&prediction_points, &truth);
 
     assert!(prediction_metrics.root_mean_squared_error < 0.01);
     assert!(prediction_metrics.mean_absolute_error < 0.01);
@@ -78,31 +68,28 @@ fn test_quadratic_approximation_1() {
 }
 
 #[test]
-fn test_linear_approximation_exact() {
+fn linear_approximation_is_exact_on_an_affine_truth() {
     //an exactly-linear truth: 2x + 3y - z + 5. The linear approximation is exact
     //everywhere, so the fit is perfect (R² == 1, near-zero error).
-    let function_to_approximate =
-        scalar_fn!(|v: &[f64; 3]| c(5.0) + c(2.0) * v[0] + c(3.0) * v[1] - v[2]);
+    let truth = scalar_fn!(|v: &[f64; 3]| c(5.0) + c(2.0) * v[0] + c(3.0) * v[1] - v[2]);
 
     let point = [1.0, 2.0, 3.0];
 
     let approximator = LinearApproximator::<AutoDiffMulti>::default();
-    let result = approximator
-        .approximate(&function_to_approximate, &point)
-        .unwrap();
+    let model = approximator.approximate(&truth, &point).unwrap();
 
     //prediction matches the truth away from the base point, not just at it
     let elsewhere = [4.0, -1.0, 0.5];
-    assert!(f64::abs(function_to_approximate.eval(&elsewhere) - result.predict(&elsewhere)) < 1e-9);
+    assert!(f64::abs(truth.eval(&elsewhere) - model.predict(&elsewhere)) < 1e-9);
 
     //metrics on a spread of points where the truth genuinely varies
     let mut prediction_points = [[0.0; 3]; 10];
-    for (iter, p) in prediction_points.iter_mut().enumerate() {
-        let s = iter as f64;
-        *p = [1.0 + s, 2.0 - s, 3.0 + 0.5 * s];
+    for (index, prediction_point) in prediction_points.iter_mut().enumerate() {
+        let offset = index as f64;
+        *prediction_point = [1.0 + offset, 2.0 - offset, 3.0 + 0.5 * offset];
     }
 
-    let metrics = result.prediction_metrics(&prediction_points, &function_to_approximate);
+    let metrics = model.prediction_metrics(&prediction_points, &truth);
     assert!(metrics.mean_absolute_error < 1e-9);
     assert!(metrics.root_mean_squared_error < 1e-9);
     assert!(f64::abs(metrics.r_squared - 1.0) < 1e-9);
@@ -122,9 +109,9 @@ fn kahan_metrics_exact_on_affine() {
         .unwrap();
 
     let mut points = [[0.0; 3]; 10];
-    for (i, p) in points.iter_mut().enumerate() {
-        let s = i as f64;
-        *p = [1.0 + s, 2.0 - s, 3.0 + 0.5 * s];
+    for (index, sample) in points.iter_mut().enumerate() {
+        let offset = index as f64;
+        *sample = [1.0 + offset, 2.0 - offset, 3.0 + 0.5 * offset];
     }
 
     let metrics = model.prediction_metrics(&points, &truth);
@@ -137,80 +124,83 @@ fn kahan_metrics_exact_on_affine() {
 
 #[test]
 fn metrics_are_accurate_on_large_point_set() {
-    //truth is x^2, so a linear approximation about `a` has the exact residual -(x - a)^2.
-    //over a large point set this exercises the four running sums inside the metrics; assert the
-    //returned metrics match the closed-form analytic values.
+    //truth is x^2, so a linear approximation about `base_point` has the exact residual
+    //-(x - base_point)^2. over a large point set this exercises the four running sums inside the
+    //metrics; assert the returned metrics match the closed-form analytic values.
     const N: usize = 10_000;
     let truth = scalar_fn!(|v: &[f64; 1]| v[0] * v[0]);
-    let a = 6.0;
+    let base_point = 6.0;
 
     let approximator = LinearApproximator::<AutoDiffMulti>::default();
-    let result = approximator.approximate(&truth, &[a]).unwrap();
+    let model = approximator.approximate(&truth, &[base_point]).unwrap();
 
     let mut prediction_points = [[0.0; 1]; N];
-    for (i, p) in prediction_points.iter_mut().enumerate() {
-        p[0] = 1.0 + i as f64 * 0.001; //x spread over [1.0, 11.0)
+    for (index, point) in prediction_points.iter_mut().enumerate() {
+        point[0] = 1.0 + index as f64 * 0.001; //x spread over [1.0, 11.0)
     }
 
-    let metrics = result.prediction_metrics(&prediction_points, &truth);
+    let metrics = model.prediction_metrics(&prediction_points, &truth);
 
-    //closed-form reference: residual(x) = -(x - a)^2 and y = x^2
-    let n = N as f64;
-    let mut sum_abs = 0.0;
-    let mut ss_res = 0.0;
-    let mut sum_y = 0.0;
-    for p in &prediction_points {
-        let residual_sq = (p[0] - a) * (p[0] - a);
-        sum_abs += residual_sq;
-        ss_res += residual_sq * residual_sq;
-        sum_y += p[0] * p[0];
+    //closed-form reference: residual(x) = -(x - base_point)^2 and y = x^2
+    let count = N as f64;
+    let mut sum_of_absolute_residuals = 0.0;
+    let mut residual_sum_of_squares = 0.0;
+    let mut sum_of_truth = 0.0;
+    for point in &prediction_points {
+        let absolute_residual = (point[0] - base_point) * (point[0] - base_point);
+        sum_of_absolute_residuals += absolute_residual;
+        residual_sum_of_squares += absolute_residual * absolute_residual;
+        sum_of_truth += point[0] * point[0];
     }
-    let mean_y = sum_y / n;
-    let mut ss_tot = 0.0;
-    for p in &prediction_points {
-        let d = p[0] * p[0] - mean_y;
-        ss_tot += d * d;
+    let mean_truth = sum_of_truth / count;
+    let mut total_sum_of_squares = 0.0;
+    for point in &prediction_points {
+        let deviation = point[0] * point[0] - mean_truth;
+        total_sum_of_squares += deviation * deviation;
     }
-    let mae_ref = sum_abs / n;
-    let mse_ref = ss_res / n;
-    let rmse_ref = mse_ref.sqrt();
-    let r2_ref = 1.0 - ss_res / ss_tot;
+    let expected_mean_absolute_error = sum_of_absolute_residuals / count;
+    let expected_mean_squared_error = residual_sum_of_squares / count;
+    let expected_root_mean_squared_error = expected_mean_squared_error.sqrt();
+    let expected_r_squared = 1.0 - residual_sum_of_squares / total_sum_of_squares;
 
-    let close = |got: f64, want: f64| (got - want).abs() <= 1e-8 * want.abs().max(1.0);
+    let within_tolerance = |got: f64, want: f64| (got - want).abs() <= 1e-8 * want.abs().max(1.0);
     assert!(
-        close(metrics.mean_absolute_error, mae_ref),
-        "mae {} vs {mae_ref}",
+        within_tolerance(metrics.mean_absolute_error, expected_mean_absolute_error),
+        "mae {} vs {expected_mean_absolute_error}",
         metrics.mean_absolute_error
     );
     assert!(
-        close(metrics.mean_squared_error, mse_ref),
-        "mse {} vs {mse_ref}",
+        within_tolerance(metrics.mean_squared_error, expected_mean_squared_error),
+        "mse {} vs {expected_mean_squared_error}",
         metrics.mean_squared_error
     );
     assert!(
-        close(metrics.root_mean_squared_error, rmse_ref),
-        "rmse {} vs {rmse_ref}",
+        within_tolerance(
+            metrics.root_mean_squared_error,
+            expected_root_mean_squared_error
+        ),
+        "rmse {} vs {expected_root_mean_squared_error}",
         metrics.root_mean_squared_error
     );
     assert!(
-        close(metrics.r_squared, r2_ref),
-        "r2 {} vs {r2_ref}",
+        within_tolerance(metrics.r_squared, expected_r_squared),
+        "r2 {} vs {expected_r_squared}",
         metrics.r_squared
     );
 }
 
 #[test]
-fn test_linear_approximation_f32() {
+fn linear_approximation_is_exact_on_an_affine_truth_at_f32() {
     //exactly-linear truth 2x + 3y - z + 5
     let truth = scalar_fn!(|v: &[f64; 3]| c(5.0) + c(2.0) * v[0] + c(3.0) * v[1] - v[2]);
 
     let point = [1.0_f32, 2.0, 3.0];
 
     let approximator = LinearApproximator::<AutoDiffMulti<f32>>::default();
-    let result = approximator.approximate(&truth, &point).unwrap();
+    let model = approximator.approximate(&truth, &point).unwrap();
 
     let nearby = [1.05_f32, 2.05, 2.95];
-    let predicted = result.predict(&nearby);
+    let predicted = model.predict(&nearby);
     assert!(
         f32::abs(truth.eval(&nearby) - predicted) < 1e-4,
         "got {predicted}"
@@ -222,8 +212,8 @@ struct Affine2 {
     a: [f64; 2],
 }
 impl ScalarFnN<2> for Affine2 {
-    fn eval<S: Numeric>(&self, p: &[S; 2]) -> S {
-        S::from_f64(self.b) + S::from_f64(self.a[0]) * p[0] + S::from_f64(self.a[1]) * p[1]
+    fn eval<S: Numeric>(&self, point: &[S; 2]) -> S {
+        S::from_f64(self.b) + S::from_f64(self.a[0]) * point[0] + S::from_f64(self.a[1]) * point[1]
     }
 }
 
@@ -233,22 +223,23 @@ struct Quad2 {
     h: [[f64; 2]; 2],
 }
 impl ScalarFnN<2> for Quad2 {
-    fn eval<S: Numeric>(&self, p: &[S; 2]) -> S {
-        let (x, y) = (p[0], p[1]);
-        let c = |v| S::from_f64(v);
-        c(self.c)
-            + c(self.g[0]) * x
-            + c(self.g[1]) * y
+    fn eval<S: Numeric>(&self, point: &[S; 2]) -> S {
+        let x = point[0];
+        let y = point[1];
+        let coefficient = |value| S::from_f64(value);
+        coefficient(self.c)
+            + coefficient(self.g[0]) * x
+            + coefficient(self.g[1]) * y
             + S::HALF
-                * (c(self.h[0][0]) * x * x
-                    + c(self.h[0][1]) * x * y
-                    + c(self.h[1][0]) * y * x
-                    + c(self.h[1][1]) * y * y)
+                * (coefficient(self.h[0][0]) * x * x
+                    + coefficient(self.h[0][1]) * x * y
+                    + coefficient(self.h[1][0]) * y * x
+                    + coefficient(self.h[1][1]) * y * y)
     }
 }
 
-fn approx_tol(scale: f64, mag: f64) -> f64 {
-    1e-9 * scale.max(1.0) * mag.abs().max(1.0)
+fn approx_tol(scale: f64, magnitude: f64) -> f64 {
+    1e-9 * scale.max(1.0) * magnitude.abs().max(1.0)
 }
 
 proptest! {
@@ -261,26 +252,26 @@ proptest! {
         px in -2.0f64..2.0, py in -2.0f64..2.0,
         samples in prop::collection::vec((-2.0f64..2.0, -2.0f64..2.0), 8),
     ) {
-        let f = Affine2 { b, a: [a0, a1] };
+        let affine = Affine2 { b, a: [a0, a1] };
         let point = [px, py];
         let scale = 1.0 + b.abs() + a0.abs() + a1.abs();
-        let tol = approx_tol(scale, 1.0);
+        let tolerance = approx_tol(scale, 1.0);
         let model = LinearApproximator::<AutoDiffMulti>::default()
-            .approximate(&f, &point).unwrap();
+            .approximate(&affine, &point).unwrap();
 
         let mut points = [[0.0; 2]; 8];
-        for (dst, &(x, y)) in points.iter_mut().zip(samples.iter()) {
-            *dst = [x, y];
+        for (slot, &(x, y)) in points.iter_mut().zip(samples.iter()) {
+            *slot = [x, y];
         }
 
-        for p in &points {
-            let err = (model.predict(p) - f.eval(p)).abs();
-            prop_assert!(err < approx_tol(scale, f.eval(p)));
+        for sample in &points {
+            let error = (model.predict(sample) - affine.eval(sample)).abs();
+            prop_assert!(error < approx_tol(scale, affine.eval(sample)));
         }
 
-        let metrics = model.prediction_metrics(&points, &f);
-        prop_assert!(metrics.mean_absolute_error < tol);
-        prop_assert!(metrics.root_mean_squared_error < tol);
+        let metrics = model.prediction_metrics(&points, &affine);
+        prop_assert!(metrics.mean_absolute_error < tolerance);
+        prop_assert!(metrics.root_mean_squared_error < tolerance);
         prop_assert!(
             metrics.r_squared.is_nan()
                 || (metrics.r_squared - 1.0).abs() < 1e-9 * scale
@@ -297,7 +288,7 @@ proptest! {
         px in -2.0f64..2.0, py in -2.0f64..2.0,
         samples in prop::collection::vec((-2.0f64..2.0, -2.0f64..2.0), 8),
     ) {
-        let f = Quad2 {
+        let quadratic = Quad2 {
             c,
             g: [g0, g1],
             h: [[h00, h01], [h01, h11]],
@@ -310,25 +301,25 @@ proptest! {
             + h00.abs()
             + h01.abs()
             + h11.abs();
-        let tol = approx_tol(scale, 1.0);
+        let tolerance = approx_tol(scale, 1.0);
 
         let model = QuadraticApproximator::<AutoDiffMulti>::default()
-            .approximate(&f, &point)
+            .approximate(&quadratic, &point)
             .unwrap();
 
         let mut points = [[0.0; 2]; 8];
-        for (dst, &(x, y)) in points.iter_mut().zip(samples.iter()) {
-            *dst = [x, y];
+        for (slot, &(x, y)) in points.iter_mut().zip(samples.iter()) {
+            *slot = [x, y];
         }
 
-        for p in &points {
-            let err = (model.predict(p) - f.eval(p)).abs();
-            prop_assert!(err < approx_tol(scale, f.eval(p)));
+        for sample in &points {
+            let error = (model.predict(sample) - quadratic.eval(sample)).abs();
+            prop_assert!(error < approx_tol(scale, quadratic.eval(sample)));
         }
 
-        let metrics = model.prediction_metrics(&points, &f);
-        prop_assert!(metrics.mean_absolute_error < tol);
-        prop_assert!(metrics.root_mean_squared_error < tol);
+        let metrics = model.prediction_metrics(&points, &quadratic);
+        prop_assert!(metrics.mean_absolute_error < tolerance);
+        prop_assert!(metrics.root_mean_squared_error < tolerance);
         prop_assert!(
             metrics.r_squared.is_nan()
                 || (metrics.r_squared - 1.0).abs() < 1e-9 * scale

--- a/crates/multicalc/tests/suite/control/derivative_filter.rs
+++ b/crates/multicalc/tests/suite/control/derivative_filter.rs
@@ -8,7 +8,8 @@ use multicalc::scalar::Numeric;
 // ---- steady state -----------------------------------------------------------
 
 fn assert_dc_gain_is_one<T: Numeric>(tolerance: T) {
-    let mut filter = OnePoleLowPass::new(T::from_f64(0.3)).unwrap();
+    let smoothing = T::from_f64(0.3);
+    let mut filter = OnePoleLowPass::new(smoothing).unwrap();
     let input = T::from_f64(5.0);
     for _ in 0..500 {
         filter.filter(input);
@@ -30,8 +31,8 @@ fn dc_gain_is_one_f32() {
 
 fn assert_alpha_one_is_pass_through<T: Numeric>() {
     let mut filter = OnePoleLowPass::new(T::ONE).unwrap();
-    for x in [1.0, -2.0, 3.5, 0.0] {
-        let value = T::from_f64(x);
+    for input in [1.0, -2.0, 3.5, 0.0] {
+        let value = T::from_f64(input);
         assert_eq!(filter.filter(value), value);
     }
 }
@@ -49,7 +50,8 @@ fn alpha_one_is_pass_through_f32() {
 // ---- transient --------------------------------------------------------------
 
 fn assert_step_attenuated_and_monotone<T: Numeric>(tolerance: T) {
-    let mut filter = OnePoleLowPass::new(T::from_f64(0.25)).unwrap();
+    let smoothing = T::from_f64(0.25);
+    let mut filter = OnePoleLowPass::new(smoothing).unwrap();
     filter.filter(T::ZERO); // seed at zero, then step the input to one
     let target = T::ONE;
     let mut previous = T::ZERO;

--- a/crates/multicalc/tests/suite/control/follow_the_gap.rs
+++ b/crates/multicalc/tests/suite/control/follow_the_gap.rs
@@ -9,7 +9,19 @@ use multicalc::error::ControlError;
 // 31 beams over 120°, 4 m range, a 0.5 m robot, a 0.5 m open-space threshold, 0.4 m/s cruise. Beam
 // 15 is the exact centre, and neighbouring beams are (2π/3)/30 = 0.06981… rad apart.
 fn follower() -> FollowTheGap<31, f64> {
-    FollowTheGap::try_new(2.0 * PI / 3.0, 4.0, 0.5, 0.5, 0.4).unwrap()
+    let field_of_view = 2.0 * PI / 3.0;
+    let maximum_range = 4.0;
+    let chassis_width = 0.5;
+    let free_range_threshold = 0.5;
+    let cruise_speed = 0.4;
+    FollowTheGap::try_new(
+        field_of_view,
+        maximum_range,
+        chassis_width,
+        free_range_threshold,
+        cruise_speed,
+    )
+    .unwrap()
 }
 
 #[test]
@@ -140,17 +152,24 @@ fn speed_scales_with_frontal_clearance() {
     // The "ahead" half-angle defaults to field_of_view / 4 = π/6 ≈ 0.5236 rad, covering beams
     // 8..=22. Every case stays above the 0.5 m open-space threshold, so this checks speed scaling,
     // not the blocked path.
-    let follower = follower().with_speed_scaling(1.0, 3.0).unwrap();
-    for (frontal, expected) in [(1.0, 0.0), (2.0, 0.2), (3.0, 0.4)] {
+    let stopping_distance = 1.0;
+    let clear_distance = 3.0;
+    let follower = follower()
+        .with_speed_scaling(stopping_distance, clear_distance)
+        .unwrap();
+    for (frontal_range, expected) in [(1.0, 0.0), (2.0, 0.2), (3.0, 0.4)] {
         let mut ranges = [4.0; 31];
         for range in ranges.iter_mut().take(23).skip(8) {
-            *range = frontal;
+            *range = frontal_range;
         }
         let output = follower.compute(&ranges, 0.0).unwrap();
-        assert!(!output.is_blocked(), "frontal {frontal} m must not block");
+        assert!(
+            !output.is_blocked(),
+            "frontal {frontal_range} m must not block"
+        );
         assert!(
             (output.body_twist().linear() - expected).abs() < 1e-12,
-            "frontal {frontal} m gave {}",
+            "frontal {frontal_range} m gave {}",
             output.body_twist().linear()
         );
     }
@@ -249,8 +268,19 @@ fn beam_angle_spans_the_field_of_view() {
 
 #[test]
 fn clear_scan_runs_at_f32() {
-    let follower: FollowTheGap<31, f32> =
-        FollowTheGap::try_new(2.0 * core::f32::consts::PI / 3.0, 4.0, 0.5, 0.5, 0.4).unwrap();
+    let field_of_view = 2.0 * core::f32::consts::PI / 3.0;
+    let maximum_range = 4.0;
+    let chassis_width = 0.5;
+    let free_range_threshold = 0.5;
+    let cruise_speed = 0.4;
+    let follower: FollowTheGap<31, f32> = FollowTheGap::try_new(
+        field_of_view,
+        maximum_range,
+        chassis_width,
+        free_range_threshold,
+        cruise_speed,
+    )
+    .unwrap();
     let output = follower.compute(&[4.0_f32; 31], 0.0).unwrap();
     assert!(output.heading().abs() < 1e-6);
     assert!((output.body_twist().linear() - 0.4).abs() < 1e-6);

--- a/crates/multicalc/tests/suite/control/pid.rs
+++ b/crates/multicalc/tests/suite/control/pid.rs
@@ -5,15 +5,19 @@ use multicalc::control::Pid;
 use multicalc::error::ControlError;
 use multicalc::scalar::{Dual, Numeric};
 
-// A scalar first-order plant `x_next = x + dt * output` driven to a setpoint.
+// A scalar first-order plant `x_next = x + timestep * output` driven to a setpoint.
 fn assert_drives_to_setpoint<T: Numeric>(tolerance: T) {
-    let dt = T::from_f64(0.01);
-    let mut controller = Pid::new(T::from_f64(2.0), T::from_f64(1.0), T::ZERO, dt).unwrap();
+    let proportional_gain = T::from_f64(2.0);
+    let integral_gain = T::from_f64(1.0);
+    let derivative_gain = T::ZERO;
+    let timestep = T::from_f64(0.01);
+    let mut controller =
+        Pid::new(proportional_gain, integral_gain, derivative_gain, timestep).unwrap();
     let setpoint = T::ONE;
     let mut measurement = T::ZERO;
     for _ in 0..3000 {
         let output = controller.update(setpoint, measurement);
-        measurement += dt * output;
+        measurement += timestep * output;
     }
     assert!((measurement - setpoint).abs() < tolerance);
 }
@@ -30,39 +34,54 @@ fn drives_measurement_to_setpoint_f32() {
 
 #[test]
 fn output_never_exceeds_limits() {
-    let dt = 0.01_f64;
-    let mut controller = Pid::new(50.0, 10.0, 0.0, dt)
+    let proportional_gain = 50.0_f64;
+    let integral_gain = 10.0;
+    let derivative_gain = 0.0;
+    let timestep = 0.01;
+    let minimum = -1.0;
+    let maximum = 1.0;
+    let mut controller = Pid::new(proportional_gain, integral_gain, derivative_gain, timestep)
         .unwrap()
-        .with_output_limits(-1.0, 1.0)
+        .with_output_limits(minimum, maximum)
         .unwrap();
     let mut measurement = 0.0;
     for _ in 0..500 {
         let output = controller.update(5.0, measurement);
         assert!((-1.0..=1.0).contains(&output));
-        measurement += dt * output;
+        measurement += timestep * output;
     }
 }
 
 #[test]
 fn conditional_integration_bounds_the_integral() {
-    let dt = 0.01_f64;
-    let mut controller = Pid::new(1.0, 5.0, 0.0, dt)
+    let proportional_gain = 1.0_f64;
+    let integral_gain = 5.0;
+    let derivative_gain = 0.0;
+    let timestep = 0.01;
+    let minimum = -1.0;
+    let maximum = 1.0;
+    let mut controller = Pid::new(proportional_gain, integral_gain, derivative_gain, timestep)
         .unwrap()
-        .with_output_limits(-1.0, 1.0)
+        .with_output_limits(minimum, maximum)
         .unwrap();
     // A setpoint the saturated plant can never reach. The naive integral would grow like
-    // error * dt * steps ≈ 1e5; conditional integration freezes it while saturated instead.
+    // error * timestep * steps ≈ 1e5; conditional integration freezes it while saturated instead.
     let mut measurement = 0.0;
     for _ in 0..10_000 {
         let output = controller.update(1000.0, measurement);
-        measurement += dt * output;
+        measurement += timestep * output;
     }
     assert!(controller.integral().abs() < 1.0);
 }
 
 #[test]
 fn zero_gains_give_zero_command() {
-    let mut controller = Pid::new(0.0_f64, 0.0, 0.0, 0.01).unwrap();
+    let proportional_gain = 0.0_f64;
+    let integral_gain = 0.0;
+    let derivative_gain = 0.0;
+    let timestep = 0.01;
+    let mut controller =
+        Pid::new(proportional_gain, integral_gain, derivative_gain, timestep).unwrap();
     for (setpoint, measurement) in [(1.0, 0.0), (5.0, 2.0), (-3.0, 1.0)] {
         assert_eq!(controller.update(setpoint, measurement), 0.0);
     }
@@ -70,7 +89,12 @@ fn zero_gains_give_zero_command() {
 
 #[test]
 fn reset_zeroes_the_integral() {
-    let mut controller = Pid::new(1.0_f64, 1.0, 0.0, 0.01).unwrap();
+    let proportional_gain = 1.0_f64;
+    let integral_gain = 1.0;
+    let derivative_gain = 0.0;
+    let timestep = 0.01;
+    let mut controller =
+        Pid::new(proportional_gain, integral_gain, derivative_gain, timestep).unwrap();
     for _ in 0..100 {
         controller.update(1.0, 0.0);
     }
@@ -97,33 +121,44 @@ fn new_rejects_non_finite_and_non_positive_timestep() {
 
 #[test]
 fn output_limits_reject_inverted_and_nan_but_allow_infinities() {
+    let minimum = 1.0;
+    let maximum = -1.0;
     assert_eq!(
         Pid::new(1.0_f64, 0.0, 0.0, 0.01)
             .unwrap()
-            .with_output_limits(1.0, -1.0)
+            .with_output_limits(minimum, maximum)
             .err(),
         Some(ControlError::InvalidOutputLimits)
     );
+
+    let minimum = f64::NAN;
+    let maximum = 1.0;
     assert_eq!(
         Pid::new(1.0_f64, 0.0, 0.0, 0.01)
             .unwrap()
-            .with_output_limits(f64::NAN, 1.0)
+            .with_output_limits(minimum, maximum)
             .err(),
         Some(ControlError::NonFinite)
     );
+
+    let minimum = f64::NEG_INFINITY;
+    let maximum = f64::INFINITY;
     assert!(
         Pid::new(1.0_f64, 0.0, 0.0, 0.01)
             .unwrap()
-            .with_output_limits(f64::NEG_INFINITY, f64::INFINITY)
+            .with_output_limits(minimum, maximum)
             .is_ok()
     );
 }
 
 // One `update` step (after seeding the derivative history), as a function of the setpoint.
 fn output_of_one_step<T: Numeric>(setpoint: T) -> T {
-    let dt = T::from_f64(0.01);
+    let proportional_gain = T::from_f64(2.0);
+    let integral_gain = T::from_f64(0.5);
+    let derivative_gain = T::from_f64(0.1);
+    let timestep = T::from_f64(0.01);
     let mut controller =
-        Pid::new(T::from_f64(2.0), T::from_f64(0.5), T::from_f64(0.1), dt).unwrap();
+        Pid::new(proportional_gain, integral_gain, derivative_gain, timestep).unwrap();
     controller.update(setpoint, T::ZERO);
     controller.update(setpoint, T::from_f64(0.3))
 }
@@ -132,9 +167,9 @@ fn output_of_one_step<T: Numeric>(setpoint: T) -> T {
 fn output_setpoint_derivative_matches_finite_difference() {
     let setpoint = 1.0_f64;
     let autodiff = output_of_one_step(Dual::variable(setpoint)).deriv;
-    let h = 1e-6;
+    let step = 1e-6;
     let finite_difference =
-        (output_of_one_step(setpoint + h) - output_of_one_step(setpoint - h)) / (2.0 * h);
+        (output_of_one_step(setpoint + step) - output_of_one_step(setpoint - step)) / (2.0 * step);
     assert!(
         (autodiff - finite_difference).abs() < 1e-6,
         "autodiff {autodiff}, finite difference {finite_difference}"

--- a/crates/multicalc/tests/suite/control/pure_pursuit.rs
+++ b/crates/multicalc/tests/suite/control/pure_pursuit.rs
@@ -69,7 +69,9 @@ fn non_positive_lookahead_and_non_finite_point_are_errors() {
 
 #[test]
 fn to_body_twist_uses_speed_and_curvature() {
-    let twist = Curvature::new(0.5_f64).to_body_twist(2.0);
+    let curvature = Curvature::new(0.5_f64);
+    let forward_speed = 2.0;
+    let twist = curvature.to_body_twist(forward_speed);
     assert_eq!(twist.linear(), 2.0);
     assert_eq!(twist.angular(), 1.0);
 }
@@ -89,9 +91,10 @@ fn curvature_of_lateral<T: Numeric>(lateral: T) -> T {
 fn curvature_derivative_matches_finite_difference() {
     let lateral = 0.5_f64;
     let autodiff = curvature_of_lateral(Dual::variable(lateral)).deriv;
-    let h = 1e-6;
-    let finite_difference =
-        (curvature_of_lateral(lateral + h) - curvature_of_lateral(lateral - h)) / (2.0 * h);
+    let step = 1e-6;
+    let finite_difference = (curvature_of_lateral(lateral + step)
+        - curvature_of_lateral(lateral - step))
+        / (2.0 * step);
     assert!(
         (autodiff - finite_difference).abs() < 1e-7,
         "autodiff {autodiff}, finite difference {finite_difference}"

--- a/crates/multicalc/tests/suite/discretization.rs
+++ b/crates/multicalc/tests/suite/discretization.rs
@@ -7,85 +7,91 @@ use multicalc::linear_algebra::Matrix;
 use multicalc::scalar::Dual;
 use proptest::prelude::*;
 
-fn mat3(a: [[f64; 3]; 3]) -> Matrix<3, 3> {
-    Matrix::new(a)
+fn matrix3(entries: [[f64; 3]; 3]) -> Matrix<3, 3> {
+    Matrix::new(entries)
 }
 
 #[test]
 fn expm_zero_is_identity() {
-    let e = Matrix::<4, 4>::zeros().expm().unwrap();
-    for i in 0..4 {
-        for j in 0..4 {
-            let want = if i == j { 1.0 } else { 0.0 };
-            assert!((e[(i, j)] - want).abs() < 1e-12);
+    let exponential = Matrix::<4, 4>::zeros().expm().unwrap();
+    for row in 0..4 {
+        for column in 0..4 {
+            let expected = if row == column { 1.0 } else { 0.0 };
+            assert!((exponential[(row, column)] - expected).abs() < 1e-12);
         }
     }
 }
 
 #[test]
 fn expm_diagonal_is_elementwise_exp() {
-    let d = mat3([[0.5, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 2.0]]);
-    let e = d.expm().unwrap();
-    for (i, x) in [0.5_f64, -1.0, 2.0].into_iter().enumerate() {
-        assert!((e[(i, i)] - x.exp()).abs() < 1e-10);
+    let diagonal = matrix3([[0.5, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 2.0]]);
+    let exponential = diagonal.expm().unwrap();
+    for (index, entry) in [0.5_f64, -1.0, 2.0].into_iter().enumerate() {
+        assert!((exponential[(index, index)] - entry.exp()).abs() < 1e-10);
     }
 }
 
 #[test]
 fn expm_derivative_finite_and_correct() {
     // d/dx expm(x·M)|_{x=0} = M. One Dual through expm; compare to central FD.
-    let m = mat3([[0.1, 0.4, -0.2], [0.0, -0.3, 0.5], [0.2, 0.1, 0.05]]);
-    let ad = Matrix::<3, 3, Dual<f64>>::from_fn(|i, j| Dual::new(0.0, m[(i, j)]))
-        .expm()
-        .unwrap();
-    for i in 0..3 {
-        for j in 0..3 {
-            let cell = ad[(i, j)];
+    let generator = matrix3([[0.1, 0.4, -0.2], [0.0, -0.3, 0.5], [0.2, 0.1, 0.05]]);
+    let autodiff =
+        Matrix::<3, 3, Dual<f64>>::from_fn(|row, column| Dual::new(0.0, generator[(row, column)]))
+            .expm()
+            .unwrap();
+    for row in 0..3 {
+        for column in 0..3 {
+            let cell = autodiff[(row, column)];
             assert!(cell.deriv.is_finite());
-            assert!((cell.deriv - m[(i, j)]).abs() < 1e-9);
+            assert!((cell.deriv - generator[(row, column)]).abs() < 1e-9);
         }
     }
 }
 
 #[test]
 fn zoh_double_integrator() {
-    let a = Matrix::<2, 2>::new([[0.0, 1.0], [0.0, 0.0]]);
-    let b = Matrix::<2, 1>::new([[0.0], [1.0]]);
-    let dt = 0.1;
-    let (f, g) = zoh::<2, 1, 3, f64>(a, b, dt).unwrap();
-    let want_f = [[1.0, dt], [0.0, 1.0]];
-    for (i, row) in want_f.iter().enumerate() {
-        for (j, &want) in row.iter().enumerate() {
-            assert!((f[(i, j)] - want).abs() < 1e-9);
+    let state_matrix = Matrix::<2, 2>::new([[0.0, 1.0], [0.0, 0.0]]);
+    let input_matrix = Matrix::<2, 1>::new([[0.0], [1.0]]);
+    let timestep = 0.1;
+    let (discrete_state, discrete_input) =
+        zoh::<2, 1, 3, f64>(state_matrix, input_matrix, timestep).unwrap();
+    let expected_state = [[1.0, timestep], [0.0, 1.0]];
+    for (row, entries) in expected_state.iter().enumerate() {
+        for (column, &expected) in entries.iter().enumerate() {
+            assert!((discrete_state[(row, column)] - expected).abs() < 1e-9);
         }
     }
-    assert!((g[(0, 0)] - dt * dt / 2.0).abs() < 1e-9);
-    assert!((g[(1, 0)] - dt).abs() < 1e-9);
+    assert!((discrete_input[(0, 0)] - timestep * timestep / 2.0).abs() < 1e-9);
+    assert!((discrete_input[(1, 0)] - timestep).abs() < 1e-9);
 }
 
 #[test]
 fn van_loan_qd_symmetric_and_f_matches_expm() {
-    let a = mat3([[-0.5, 0.2, 0.0], [0.1, -0.3, 0.4], [0.0, 0.2, -0.6]]);
-    let qc = mat3([[0.2, 0.0, 0.0], [0.0, 0.3, 0.0], [0.0, 0.0, 0.1]]);
-    let dt = 0.05;
-    let (f, qd) = van_loan::<3, 6, f64>(a, qc, dt).unwrap();
-    let f_ref = a.scale(dt).expm().unwrap();
-    for i in 0..3 {
-        for j in 0..3 {
-            assert!((f[(i, j)] - f_ref[(i, j)]).abs() < 1e-9);
-            assert!((qd[(i, j)] - qd[(j, i)]).abs() < 1e-10);
+    let state_matrix = matrix3([[-0.5, 0.2, 0.0], [0.1, -0.3, 0.4], [0.0, 0.2, -0.6]]);
+    let continuous_noise = matrix3([[0.2, 0.0, 0.0], [0.0, 0.3, 0.0], [0.0, 0.0, 0.1]]);
+    let timestep = 0.05;
+    let (discrete_state, discrete_noise) =
+        van_loan::<3, 6, f64>(state_matrix, continuous_noise, timestep).unwrap();
+    let expected_from_expm = state_matrix.scale(timestep).expm().unwrap();
+    for row in 0..3 {
+        for column in 0..3 {
+            assert!(
+                (discrete_state[(row, column)] - expected_from_expm[(row, column)]).abs() < 1e-9
+            );
+            assert!((discrete_noise[(row, column)] - discrete_noise[(column, row)]).abs() < 1e-10);
         }
     }
 }
 
 #[test]
 fn qdwn_matches_closed_form() {
-    let (dt, var) = (0.1, 2.0);
-    let q = q_discrete_white_noise::<2, f64>(dt, var);
-    assert!((q[(0, 0)] - var * dt.powi(4) / 4.0).abs() < 1e-15);
-    assert!((q[(0, 1)] - var * dt.powi(3) / 2.0).abs() < 1e-15);
-    assert!((q[(1, 0)] - var * dt.powi(3) / 2.0).abs() < 1e-15);
-    assert!((q[(1, 1)] - var * dt * dt).abs() < 1e-15);
+    let timestep = 0.1;
+    let variance = 2.0;
+    let noise = q_discrete_white_noise::<2, f64>(timestep, variance);
+    assert!((noise[(0, 0)] - variance * timestep.powi(4) / 4.0).abs() < 1e-15);
+    assert!((noise[(0, 1)] - variance * timestep.powi(3) / 2.0).abs() < 1e-15);
+    assert!((noise[(1, 0)] - variance * timestep.powi(3) / 2.0).abs() < 1e-15);
+    assert!((noise[(1, 1)] - variance * timestep * timestep).abs() < 1e-15);
 }
 
 proptest! {
@@ -93,12 +99,12 @@ proptest! {
     fn expm_times_neg_expm_is_identity(
         v in prop::collection::vec(-0.6f64..0.6, 9)
     ) {
-        let a = Matrix::<3, 3>::from_fn(|i, j| v[i * 3 + j]);
-        let prod = a.expm().unwrap() * a.scale(-1.0).expm().unwrap();
-        for i in 0..3 {
-            for j in 0..3 {
-                let want = if i == j { 1.0 } else { 0.0 };
-                prop_assert!((prod[(i, j)] - want).abs() < 1e-9);
+        let matrix = Matrix::<3, 3>::from_fn(|row, column| v[row * 3 + column]);
+        let product = matrix.expm().unwrap() * matrix.scale(-1.0).expm().unwrap();
+        for row in 0..3 {
+            for column in 0..3 {
+                let expected = if row == column { 1.0 } else { 0.0 };
+                prop_assert!((product[(row, column)] - expected).abs() < 1e-9);
             }
         }
     }

--- a/crates/multicalc/tests/suite/estimation/extended_kalman_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/extended_kalman_filter.rs
@@ -9,6 +9,8 @@ use multicalc::scalar::{Dual, Numeric, VectorFn};
 use multicalc_testkit::tol::{Tol, assert_matrix_close, assert_vector_close};
 use proptest::prelude::*;
 
+use crate::support::{symmetric_positive_definite, trace};
+
 /// Unicycle motion: [x, y, heading] driven by a forward and an angular velocity over one step.
 struct UnicycleMotion {
     timestep: f64,
@@ -72,17 +74,6 @@ impl VectorFn<3, 3> for NonFiniteMotion {
     }
 }
 
-/// A symmetric positive-definite matrix from arbitrary entries as `M·Mᵀ`, ridged so the
-/// factorization is well conditioned rather than merely non-singular.
-fn symmetric_positive_definite<const N: usize>(entries: &[f64]) -> Matrix<N, N> {
-    let m = Matrix::<N, N>::from_fn(|row, column| entries[row * N + column]);
-    m * m.transpose() + Matrix::<N, N>::identity().scale(0.25)
-}
-
-fn trace<const N: usize>(m: Matrix<N, N>) -> f64 {
-    (0..N).map(|i| m[(i, i)]).sum()
-}
-
 // ----- Agreement with the linear filter -----
 
 /// Given linear models, the extended filter must reproduce the linear filter exactly: its Jacobians
@@ -118,13 +109,13 @@ fn extended_filter_with_linear_models_matches_linear_filter() {
         linear.update(measurement).unwrap();
     }
 
-    let t = Tol {
+    let tolerance = Tol {
         abs: 1e-12,
         rel: 0.0,
     };
-    assert_vector_close(&extended.state(), &linear.state(), t);
+    assert_vector_close(&extended.state(), &linear.state(), tolerance);
     assert_matrix_close(extended.covariance(), linear.covariance(), 1e-12);
-    assert_vector_close(&extended.innovation(), &linear.innovation(), t);
+    assert_vector_close(&extended.innovation(), &linear.innovation(), tolerance);
     assert_matrix_close(
         extended.innovation_covariance(),
         linear.innovation_covariance(),
@@ -330,8 +321,8 @@ proptest! {
         let predicted = Vector::new(model.eval(seamed.state().as_array()));
         seamed.update_with_residual(&model, measurement - predicted).unwrap();
 
-        let t = Tol { abs: 1e-12, rel: 0.0 };
-        assert_vector_close(&direct.state(), &seamed.state(), t);
+        let tolerance = Tol { abs: 1e-12, rel: 0.0 };
+        assert_vector_close(&direct.state(), &seamed.state(), tolerance);
         assert_matrix_close(direct.covariance(), seamed.covariance(), 1e-12);
     }
 
@@ -381,8 +372,8 @@ proptest! {
         joseph.update(&model, measurement).unwrap();
         naive.update(&model, measurement).unwrap();
 
-        let t = Tol { abs: 1e-9, rel: 1e-9 };
-        assert_vector_close(&joseph.state(), &naive.state(), t);
+        let tolerance = Tol { abs: 1e-9, rel: 1e-9 };
+        assert_vector_close(&joseph.state(), &naive.state(), tolerance);
         assert_matrix_close(joseph.covariance(), naive.covariance(), 1e-9);
     }
 }

--- a/crates/multicalc/tests/suite/estimation/kalman_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/kalman_filter.rs
@@ -7,6 +7,8 @@ use multicalc::scalar::{Dual, Numeric};
 use multicalc_testkit::tol::{Tol, assert_matrix_close, assert_vector_close};
 use proptest::prelude::*;
 
+use crate::support::{symmetric_positive_definite, trace};
+
 /// A constant-velocity tracker over a 1 s step: position integrates velocity, position is measured.
 fn constant_velocity_filter<T: Numeric>(
     initial_covariance: Matrix<2, 2, T>,
@@ -25,17 +27,6 @@ fn constant_velocity_filter<T: Numeric>(
     )
 }
 
-/// Builds a symmetric positive-definite matrix from arbitrary entries as `M·Mᵀ`, ridged so the
-/// factorization is well conditioned rather than merely non-singular.
-fn symmetric_positive_definite<const N: usize>(entries: &[f64]) -> Matrix<N, N> {
-    let m = Matrix::<N, N>::from_fn(|row, column| entries[row * N + column]);
-    m * m.transpose() + Matrix::<N, N>::identity().scale(0.25)
-}
-
-fn trace<const N: usize>(m: Matrix<N, N>) -> f64 {
-    (0..N).map(|i| m[(i, i)]).sum()
-}
-
 // ----- Goldens -----
 
 /// Two steps of a noiseless-process constant-velocity tracker, worked by hand:
@@ -50,17 +41,21 @@ fn constant_velocity_two_steps_matches_hand_computation() {
         filter.update(Vector::new([measurement])).unwrap();
     }
 
-    let t = Tol {
+    let tolerance = Tol {
         abs: 1e-12,
         rel: 0.0,
     };
-    assert_vector_close(&filter.state(), &Vector::new([5.0 / 3.0, 2.0 / 3.0]), t);
+    assert_vector_close(
+        &filter.state(),
+        &Vector::new([5.0 / 3.0, 2.0 / 3.0]),
+        tolerance,
+    );
     assert_matrix_close(
         filter.covariance(),
         Matrix::new([[2.0 / 3.0, 1.0 / 3.0], [1.0 / 3.0, 1.0 / 3.0]]),
         1e-12,
     );
-    assert_vector_close(&filter.innovation(), &Vector::new([1.0]), t);
+    assert_vector_close(&filter.innovation(), &Vector::new([1.0]), tolerance);
     assert_matrix_close(filter.innovation_covariance(), Matrix::new([[3.0]]), 1e-12);
 }
 
@@ -139,8 +134,8 @@ proptest! {
             filter.update(Vector::new([measurement])).unwrap();
         }
 
-        let t = Tol { abs: 1e-9, rel: 1e-9 };
-        assert_vector_close(&joseph.state(), &naive.state(), t);
+        let tolerance = Tol { abs: 1e-9, rel: 1e-9 };
+        assert_vector_close(&joseph.state(), &naive.state(), tolerance);
         assert_matrix_close(joseph.covariance(), naive.covariance(), 1e-9);
     }
 

--- a/crates/multicalc/tests/suite/estimation/particle_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/particle_filter.rs
@@ -22,14 +22,14 @@ impl VectorFn<2, 2> for MeasureBoth {
     }
 }
 
-/// Constant velocity: position moves by `dt · velocity`, velocity holds.
+/// Constant velocity: position moves by `timestep · velocity`, velocity holds.
 struct ConstantVelocity {
-    dt: f64,
+    timestep: f64,
 }
 impl VectorFn<2, 2> for ConstantVelocity {
     fn eval<S: Numeric>(&self, state: &[S; 2]) -> [S; 2] {
-        let dt = S::from_f64(self.dt);
-        [state[0] + dt * state[1], state[1]]
+        let timestep = S::from_f64(self.timestep);
+        [state[0] + timestep * state[1], state[1]]
     }
 }
 
@@ -51,12 +51,14 @@ fn small_noise() -> Matrix<2, 2> {
 
 #[test]
 fn weights_normalize_after_update() {
+    let particle_count = 500;
+    let seed = 1;
     let mut filter = ParticleFilter::<2, 2>::new(
-        500,
+        particle_count,
         Vector::new([0.0, 0.0]),
         identity_covariance(),
         small_noise(),
-        1,
+        seed,
     )
     .unwrap();
     let sensor = GaussianLikelihood::new(Matrix::new([[0.1, 0.0], [0.0, 0.1]])).unwrap();
@@ -66,26 +68,27 @@ fn weights_normalize_after_update() {
         .update(&MeasureBoth, &sensor, Vector::new([0.3, -0.2]))
         .unwrap();
 
-    let total: f64 = filter.weights().iter().sum();
+    let weight_sum: f64 = filter.weights().iter().sum();
     assert!(
-        (total - 1.0).abs() < 1e-12,
-        "weights should sum to one, got {total}"
+        (weight_sum - 1.0).abs() < 1e-12,
+        "weights should sum to one, got {weight_sum}"
     );
     assert!(
-        filter.weights().iter().all(|&w| w >= 0.0),
+        filter.weights().iter().all(|&weight| weight >= 0.0),
         "weights should be non-negative"
     );
 }
 
 #[test]
 fn effective_sample_size_stays_in_bounds() {
-    let count = 400;
+    let particle_count = 400;
+    let seed = 2;
     let mut filter = ParticleFilter::<2, 2>::new(
-        count,
+        particle_count,
         Vector::new([0.0, 0.0]),
         identity_covariance(),
         small_noise(),
-        2,
+        seed,
     )
     .unwrap();
     let sensor = GaussianLikelihood::new(Matrix::new([[0.2, 0.0], [0.0, 0.2]])).unwrap();
@@ -95,32 +98,37 @@ fn effective_sample_size_stays_in_bounds() {
         filter
             .update(&MeasureBoth, &sensor, Vector::new([0.5, 0.5]))
             .unwrap();
-        let ess = filter.effective_sample_size();
-        assert!(ess >= 1.0, "effective sample size below one: {ess}");
+        let effective_sample_size = filter.effective_sample_size();
         assert!(
-            ess <= count as f64 + 1e-6,
-            "effective sample size above count: {ess}"
+            effective_sample_size >= 1.0,
+            "effective sample size below one: {effective_sample_size}"
+        );
+        assert!(
+            effective_sample_size <= particle_count as f64 + 1e-6,
+            "effective sample size above count: {effective_sample_size}"
         );
     }
 
     // A fresh resample restores uniform weights, so the effective sample size returns to the count.
     filter.resample();
-    let ess = filter.effective_sample_size();
+    let effective_sample_size = filter.effective_sample_size();
     assert!(
-        (ess - count as f64).abs() < 1e-9,
-        "resampled cloud should have full sample size: {ess}"
+        (effective_sample_size - particle_count as f64).abs() < 1e-9,
+        "resampled cloud should have full sample size: {effective_sample_size}"
     );
 }
 
 #[test]
 fn same_seed_reproduces_estimate() {
+    let particle_count = 300;
+    let seed = 42;
     let build = || {
         ParticleFilter::<2, 2>::new(
-            300,
+            particle_count,
             Vector::new([0.0, 0.0]),
             identity_covariance(),
             small_noise(),
-            42,
+            seed,
         )
         .unwrap()
     };
@@ -153,8 +161,10 @@ fn every_scheme_covers_heavy_particles() {
     ];
     let weights = [0.1_f64, 0.7, 0.2];
 
+    let seed = 5;
+
     for scheme in schemes {
-        let mut random = Pcg32::new(5);
+        let mut random = Pcg32::new(seed);
         let mut counts = [0usize; 3];
         let mut indices = [0usize; 3];
         for _ in 0..10_000 {
@@ -173,12 +183,14 @@ fn every_scheme_covers_heavy_particles() {
 
 #[test]
 fn incompatible_measurement_degenerates() {
+    let particle_count = 200;
+    let seed = 3;
     let mut filter = ParticleFilter::<2, 2>::new(
-        200,
+        particle_count,
         Vector::new([0.0, 0.0]),
         small_noise(),
         small_noise(),
-        3,
+        seed,
     )
     .unwrap();
 
@@ -193,12 +205,14 @@ fn incompatible_measurement_degenerates() {
 fn non_positive_definite_noise_is_rejected() {
     let not_positive_definite = Matrix::new([[1.0, 2.0], [2.0, 1.0]]);
 
+    let particle_count = 100;
+    let seed = 4;
     let filter = ParticleFilter::<2, 2>::new(
-        100,
+        particle_count,
         Vector::new([0.0, 0.0]),
         identity_covariance(),
         not_positive_definite,
-        4,
+        seed,
     );
     assert_eq!(filter.err(), Some(EstimationError::NotPositiveDefinite));
 
@@ -208,19 +222,21 @@ fn non_positive_definite_noise_is_rejected() {
 
 #[test]
 fn zero_particle_count_is_rejected() {
+    let particle_count = 0;
+    let seed = 4;
     let filter = ParticleFilter::<2, 2>::new(
-        0,
+        particle_count,
         Vector::new([0.0, 0.0]),
         identity_covariance(),
         small_noise(),
-        4,
+        seed,
     );
     assert_eq!(filter.err(), Some(EstimationError::WeightsDegenerate));
 }
 
 #[test]
 fn converges_to_kalman_on_linear_gaussian_model() {
-    let dt = 1.0;
+    let timestep = 1.0;
     let process_noise = Matrix::new([[0.01, 0.0], [0.0, 0.01]]);
     let measurement_noise = Matrix::new([[0.09]]);
     let measurement_standard_deviation = 0.3;
@@ -230,24 +246,27 @@ fn converges_to_kalman_on_linear_gaussian_model() {
         Vector::new([0.0, 0.0]),
         identity_covariance(),
         KalmanModel {
-            state_transition: Matrix::new([[1.0, dt], [0.0, 1.0]]),
+            state_transition: Matrix::new([[1.0, timestep], [0.0, 1.0]]),
             measurement_model: Matrix::new([[1.0, 0.0]]),
             process_noise,
             measurement_noise,
         },
     );
+    let particle_count = 20_000;
+    let seed = 7;
     let mut particle = ParticleFilter::<2, 1>::new(
-        20_000,
+        particle_count,
         Vector::new([0.0, 0.0]),
         identity_covariance(),
         process_noise,
-        7,
+        seed,
     )
     .unwrap();
     let sensor = GaussianLikelihood::new(measurement_noise).unwrap();
 
-    let process = ConstantVelocity { dt };
-    let mut measurement_random = Pcg32::new(99);
+    let process = ConstantVelocity { timestep };
+    let measurement_seed = 99;
+    let mut measurement_random = Pcg32::new(measurement_seed);
     let mut truth = [0.0_f64, 1.0];
 
     for _ in 0..40 {
@@ -292,13 +311,15 @@ fn closure_update_matches_the_model_update() {
     let measurement = Vector::new([0.3, -0.2]);
     let noise = 0.1;
 
+    let particle_count = 1000;
+    let seed = 11;
     let build = || {
         ParticleFilter::<2, 2>::new(
-            1000,
+            particle_count,
             Vector::new([0.0, 0.0]),
             identity_covariance(),
             small_noise(),
-            11,
+            seed,
         )
         .unwrap()
     };
@@ -318,9 +339,9 @@ fn closure_update_matches_the_model_update() {
         through_closure
             .update_with_log_weights(|particle| {
                 // The Gaussian log-weight for isotropic noise: −½ · |measurement − particle|² / σ².
-                let dx = measurement[0] - particle[0];
-                let dy = measurement[1] - particle[1];
-                -0.5 * (dx * dx + dy * dy) / noise
+                let offset_x = measurement[0] - particle[0];
+                let offset_y = measurement[1] - particle[1];
+                -0.5 * (offset_x * offset_x + offset_y * offset_y) / noise
             })
             .unwrap();
     }
@@ -336,12 +357,14 @@ fn closure_update_matches_the_model_update() {
 
 #[test]
 fn a_closure_that_favours_one_region_moves_the_mean() {
+    let particle_count = 2000;
+    let seed = 22;
     let mut filter = ParticleFilter::<2, 2>::new(
-        2000,
+        particle_count,
         Vector::new([0.0, 0.0]),
         identity_covariance(),
         small_noise(),
-        22,
+        seed,
     )
     .unwrap();
 
@@ -350,9 +373,9 @@ fn a_closure_that_favours_one_region_moves_the_mean() {
         filter.predict(&Stationary).unwrap();
         filter
             .update_with_log_weights(|particle| {
-                let dx = target[0] - particle[0];
-                let dy = target[1] - particle[1];
-                -0.5 * (dx * dx + dy * dy) / 0.05
+                let offset_x = target[0] - particle[0];
+                let offset_y = target[1] - particle[1];
+                -0.5 * (offset_x * offset_x + offset_y * offset_y) / 0.05
             })
             .unwrap();
     }
@@ -366,13 +389,14 @@ fn a_closure_that_favours_one_region_moves_the_mean() {
 
 #[test]
 fn a_zero_score_closure_leaves_the_weights_uniform() {
-    let count = 500;
+    let particle_count = 500;
+    let seed = 33;
     let mut filter = ParticleFilter::<2, 2>::new(
-        count,
+        particle_count,
         Vector::new([0.0, 0.0]),
         identity_covariance(),
         small_noise(),
-        33,
+        seed,
     )
     .unwrap();
 
@@ -380,9 +404,9 @@ fn a_zero_score_closure_leaves_the_weights_uniform() {
     // effective sample size stays at the full count.
     filter.update_with_log_weights(|_| 0.0).unwrap();
 
-    let ess = filter.effective_sample_size();
+    let effective_sample_size = filter.effective_sample_size();
     assert!(
-        (ess - count as f64).abs() < 1e-9,
-        "a flat score should leave the full sample size: {ess}"
+        (effective_sample_size - particle_count as f64).abs() < 1e-9,
+        "a flat score should leave the full sample size: {effective_sample_size}"
     );
 }

--- a/crates/multicalc/tests/suite/gaussian_tables.rs
+++ b/crates/multicalc/tests/suite/gaussian_tables.rs
@@ -6,7 +6,7 @@ use multicalc::numerical_integration::GaussianQuadratureMethod;
 use proptest::prelude::*;
 
 #[test]
-fn lookup() {
+fn node_count_matches_the_requested_order() {
     assert_eq!(
         nodes(GaussianQuadratureMethod::GaussLegendre, 4)
             .unwrap()
@@ -19,7 +19,7 @@ fn lookup() {
 
 proptest! {
     #[test]
-    fn proptest_lookup(order in 1..=MAX_ORDER) {
+    fn proptest_every_order_returns_that_many_nodes(order in 1..=MAX_ORDER) {
         prop_assert_eq!(
             nodes(GaussianQuadratureMethod::GaussLegendre, order)
                 .unwrap()

--- a/crates/multicalc/tests/suite/kinematics/differential_drive.rs
+++ b/crates/multicalc/tests/suite/kinematics/differential_drive.rs
@@ -24,24 +24,24 @@ fn assert_exact(got: f64, want: f64, scale: f64, what: &str) {
     );
 }
 
-fn rand_geometry(rng: &mut StdRng) -> DifferentialDrive<f64> {
+fn random_geometry(rng: &mut StdRng) -> DifferentialDrive<f64> {
     DifferentialDrive::new(rng.gen_range(0.01..0.5), rng.gen_range(0.05..1.0)).unwrap()
 }
 
-fn rand_wheels(rng: &mut StdRng) -> WheelVelocities<f64> {
+fn random_wheels(rng: &mut StdRng) -> WheelVelocities<f64> {
     WheelVelocities::new(rng.gen_range(-20.0..20.0), rng.gen_range(-20.0..20.0))
 }
 
-fn rand_body_twist(rng: &mut StdRng) -> BodyTwist<f64> {
+fn random_body_twist(rng: &mut StdRng) -> BodyTwist<f64> {
     BodyTwist::new(rng.gen_range(-5.0..5.0), rng.gen_range(-5.0..5.0))
 }
 
 /// Error scales for reconstructing a body pair from the wheel pair it maps to. Recovering the
-/// linear term cancels the two wheel terms and rescales by `r`; the angular term does the same and
-/// then divides by `b`, which amplifies by `1/b` for a narrow track.
-fn body_scales(dd: DifferentialDrive<f64>, w: WheelVelocities<f64>) -> (f64, f64) {
-    let linear = w.left().abs().max(w.right().abs()) * dd.wheel_radius();
-    (linear, linear / dd.wheelbase())
+/// linear term cancels the two wheel terms and rescales by the wheel radius; the angular term does
+/// the same and then divides by the wheelbase, which amplifies by `1/wheelbase` for a narrow track.
+fn body_scales(drive: DifferentialDrive<f64>, wheels: WheelVelocities<f64>) -> (f64, f64) {
+    let linear = wheels.left().abs().max(wheels.right().abs()) * drive.wheel_radius();
+    (linear, linear / drive.wheelbase())
 }
 
 // ---- round trips ------------------------------------------------------------
@@ -50,12 +50,12 @@ fn body_scales(dd: DifferentialDrive<f64>, w: WheelVelocities<f64>) -> (f64, f64
 fn wheels_to_body_to_wheels_round_trip() {
     let mut rng = StdRng::seed_from_u64(0x9966_1234);
     for _ in 0..1000 {
-        let dd = rand_geometry(&mut rng);
-        let w = rand_wheels(&mut rng);
-        let back = dd.inverse(dd.forward(w));
-        let scale = w.left().abs().max(w.right().abs());
-        assert_exact(back.left(), w.left(), scale, "left");
-        assert_exact(back.right(), w.right(), scale, "right");
+        let drive = random_geometry(&mut rng);
+        let wheels = random_wheels(&mut rng);
+        let recovered = drive.inverse(drive.forward(wheels));
+        let scale = wheels.left().abs().max(wheels.right().abs());
+        assert_exact(recovered.left(), wheels.left(), scale, "left");
+        assert_exact(recovered.right(), wheels.right(), scale, "right");
     }
 }
 
@@ -63,13 +63,18 @@ fn wheels_to_body_to_wheels_round_trip() {
 fn body_twist_to_wheels_to_body_twist_round_trip() {
     let mut rng = StdRng::seed_from_u64(0x9966_5678);
     for _ in 0..1000 {
-        let dd = rand_geometry(&mut rng);
-        let c = rand_body_twist(&mut rng);
-        let w = dd.inverse(c);
-        let back = dd.forward(w);
-        let (linear_scale, angular_scale) = body_scales(dd, w);
-        assert_exact(back.linear(), c.linear(), linear_scale, "linear");
-        assert_exact(back.angular(), c.angular(), angular_scale, "angular");
+        let drive = random_geometry(&mut rng);
+        let body = random_body_twist(&mut rng);
+        let wheels = drive.inverse(body);
+        let recovered = drive.forward(wheels);
+        let (linear_scale, angular_scale) = body_scales(drive, wheels);
+        assert_exact(recovered.linear(), body.linear(), linear_scale, "linear");
+        assert_exact(
+            recovered.angular(),
+            body.angular(),
+            angular_scale,
+            "angular",
+        );
     }
 }
 
@@ -77,13 +82,13 @@ fn body_twist_to_wheels_to_body_twist_round_trip() {
 fn wheel_rotations_round_trip() {
     let mut rng = StdRng::seed_from_u64(0x9966_abcd);
     for _ in 0..1000 {
-        let dd = rand_geometry(&mut rng);
-        let w = rand_wheels(&mut rng);
-        let d = WheelRotations::new(w.left(), w.right());
-        let back = dd.inverse_arc(dd.forward_arc(d));
-        let scale = d.left().abs().max(d.right().abs());
-        assert_exact(back.left(), d.left(), scale, "left");
-        assert_exact(back.right(), d.right(), scale, "right");
+        let drive = random_geometry(&mut rng);
+        let wheels = random_wheels(&mut rng);
+        let rotations = WheelRotations::new(wheels.left(), wheels.right());
+        let recovered = drive.inverse_arc(drive.forward_arc(rotations));
+        let scale = rotations.left().abs().max(rotations.right().abs());
+        assert_exact(recovered.left(), rotations.left(), scale, "left");
+        assert_exact(recovered.right(), rotations.right(), scale, "right");
     }
 }
 
@@ -91,15 +96,15 @@ fn wheel_rotations_round_trip() {
 fn body_arc_round_trip() {
     let mut rng = StdRng::seed_from_u64(0x9966_ef01);
     for _ in 0..1000 {
-        let dd = rand_geometry(&mut rng);
-        let c = rand_body_twist(&mut rng);
-        let d = BodyArc::new(c.linear(), c.angular());
-        let w = dd.inverse_arc(d);
-        let back = dd.forward_arc(w);
+        let drive = random_geometry(&mut rng);
+        let body = random_body_twist(&mut rng);
+        let arc = BodyArc::new(body.linear(), body.angular());
+        let wheels = drive.inverse_arc(arc);
+        let recovered = drive.forward_arc(wheels);
         let (linear_scale, angular_scale) =
-            body_scales(dd, WheelVelocities::new(w.left(), w.right()));
-        assert_exact(back.linear(), d.linear(), linear_scale, "linear");
-        assert_exact(back.angular(), d.angular(), angular_scale, "angular");
+            body_scales(drive, WheelVelocities::new(wheels.left(), wheels.right()));
+        assert_exact(recovered.linear(), arc.linear(), linear_scale, "linear");
+        assert_exact(recovered.angular(), arc.angular(), angular_scale, "angular");
     }
 }
 
@@ -107,29 +112,35 @@ fn body_arc_round_trip() {
 
 #[test]
 fn straight_line_has_zero_angular() {
-    let dd = DifferentialDrive::new(0.036_f64, 0.235).unwrap();
-    for x in [0.0, 1.0, -3.5, 20.0] {
-        assert_eq!(dd.forward(WheelVelocities::new(x, x)).angular(), 0.0);
+    let drive = DifferentialDrive::new(0.036_f64, 0.235).unwrap();
+    for speed in [0.0, 1.0, -3.5, 20.0] {
+        assert_eq!(
+            drive.forward(WheelVelocities::new(speed, speed)).angular(),
+            0.0
+        );
     }
 }
 
 #[test]
 fn spin_in_place_has_zero_linear() {
-    let dd = DifferentialDrive::new(0.036_f64, 0.235).unwrap();
-    for x in [0.0, 1.0, -3.5, 20.0] {
-        assert_eq!(dd.forward(WheelVelocities::new(-x, x)).linear(), 0.0);
+    let drive = DifferentialDrive::new(0.036_f64, 0.235).unwrap();
+    for speed in [0.0, 1.0, -3.5, 20.0] {
+        assert_eq!(
+            drive.forward(WheelVelocities::new(-speed, speed)).linear(),
+            0.0
+        );
     }
 }
 
 #[test]
 fn known_values() {
-    let dd = DifferentialDrive::new(0.036_f64, 0.235).unwrap();
+    let drive = DifferentialDrive::new(0.036_f64, 0.235).unwrap();
 
-    let straight = dd.forward(WheelVelocities::new(10.0, 10.0));
+    let straight = drive.forward(WheelVelocities::new(10.0, 10.0));
     assert!((straight.linear() - 0.36).abs() < TOL);
     assert!((straight.angular() - 0.0).abs() < TOL);
 
-    let turning = dd.forward(WheelVelocities::new(0.0, 10.0));
+    let turning = drive.forward(WheelVelocities::new(0.0, 10.0));
     assert!((turning.linear() - 0.18).abs() < TOL);
     assert!((turning.angular() - 0.36 / 0.235).abs() < TOL);
 }
@@ -189,15 +200,15 @@ fn new_rejects_infinite() {
 
 #[test]
 fn to_tangent_has_zero_lateral() {
-    let xi = BodyTwist::new(1.0, 2.0).to_tangent();
-    assert_eq!(xi, Vector::new([1.0, 0.0, 2.0]));
+    let tangent = BodyTwist::new(1.0, 2.0).to_tangent();
+    assert_eq!(tangent, Vector::new([1.0, 0.0, 2.0]));
 }
 
 #[test]
 fn project_tangent_discards_lateral() {
-    let c = BodyTwist::project_tangent(Vector::new([1.0, 9.9, 2.0]));
-    assert_eq!(c.linear(), 1.0);
-    assert_eq!(c.angular(), 2.0);
+    let body = BodyTwist::project_tangent(Vector::new([1.0, 9.9, 2.0]));
+    assert_eq!(body.linear(), 1.0);
+    assert_eq!(body.angular(), 2.0);
 }
 
 #[test]
@@ -216,9 +227,9 @@ fn project_round_trips_only_without_slip() {
 
 #[test]
 fn integrate_over_scales_both() {
-    let d = BodyTwist::new(2.0, 4.0).integrate_over(0.5);
-    assert_eq!(d.linear(), 1.0);
-    assert_eq!(d.angular(), 2.0);
+    let arc = BodyTwist::new(2.0, 4.0).integrate_over(0.5);
+    assert_eq!(arc.linear(), 1.0);
+    assert_eq!(arc.angular(), 2.0);
 }
 
 // ---- the travel seam --------------------------------------------------------
@@ -227,12 +238,14 @@ fn integrate_over_scales_both() {
 fn travel_converters_round_trip() {
     let mut rng = StdRng::seed_from_u64(0x9966_2222);
     for _ in 0..1000 {
-        let dd = rand_geometry(&mut rng);
-        let (a, b) = (rng.gen_range(-5.0..5.0), rng.gen_range(-5.0..5.0));
-        let (left, right) = dd.wheel_travel(dd.wheel_rotations_from_travel(a, b));
-        let scale = a.abs().max(b.abs());
-        assert_exact(left, a, scale, "left travel");
-        assert_exact(right, b, scale, "right travel");
+        let drive = random_geometry(&mut rng);
+        let left_travel = rng.gen_range(-5.0..5.0);
+        let right_travel = rng.gen_range(-5.0..5.0);
+        let (left, right) =
+            drive.wheel_travel(drive.wheel_rotations_from_travel(left_travel, right_travel));
+        let scale = left_travel.abs().max(right_travel.abs());
+        assert_exact(left, left_travel, scale, "left travel");
+        assert_exact(right, right_travel, scale, "right travel");
     }
 }
 
@@ -240,16 +253,16 @@ fn travel_converters_round_trip() {
 
 #[test]
 fn round_trips_hold_at_f32() {
-    let dd = DifferentialDrive::new(0.036_f32, 0.235).unwrap();
+    let drive = DifferentialDrive::new(0.036_f32, 0.235).unwrap();
     let bound = 8.0 * f32::EPSILON;
 
-    let w = WheelVelocities::new(1.5_f32, -2.5);
-    let back = dd.inverse(dd.forward(w));
-    assert!((back.left() - w.left()).abs() <= bound * 2.5);
-    assert!((back.right() - w.right()).abs() <= bound * 2.5);
+    let wheels = WheelVelocities::new(1.5_f32, -2.5);
+    let recovered = drive.inverse(drive.forward(wheels));
+    assert!((recovered.left() - wheels.left()).abs() <= bound * 2.5);
+    assert!((recovered.right() - wheels.right()).abs() <= bound * 2.5);
 
-    let c = BodyTwist::new(0.3_f32, 0.9);
-    let back = dd.forward(dd.inverse(c));
-    assert!((back.linear() - c.linear()).abs() <= bound * 0.9);
-    assert!((back.angular() - c.angular()).abs() <= bound * 0.9);
+    let body = BodyTwist::new(0.3_f32, 0.9);
+    let recovered = drive.forward(drive.inverse(body));
+    assert!((recovered.linear() - body.linear()).abs() <= bound * 0.9);
+    assert!((recovered.angular() - body.angular()).abs() <= bound * 0.9);
 }

--- a/crates/multicalc/tests/suite/kinematics/odometry.rs
+++ b/crates/multicalc/tests/suite/kinematics/odometry.rs
@@ -16,7 +16,7 @@ const TOL: f64 = 1e-14;
 
 // ---- helpers ----------------------------------------------------------------
 
-fn rand_pose(rng: &mut StdRng) -> SE2<f64> {
+fn random_pose(rng: &mut StdRng) -> SE2<f64> {
     SE2::from_parts(
         SO2::exp(rng.gen_range(-2.5..2.5)),
         Vector::new([rng.gen_range(-3.0..3.0), rng.gen_range(-3.0..3.0)]),
@@ -30,9 +30,9 @@ fn rand_pose(rng: &mut StdRng) -> SE2<f64> {
 /// the `qa` suite, so this chains through to an external reference.
 #[test]
 fn arc_matches_rk45() {
-    let tf = 2.0;
-    for (v, w) in [(0.4, 0.0), (0.4, 0.9), (0.4, -0.9), (0.0, 0.9)] {
-        let rate = BodyTwist::new(v, w);
+    let final_time = 2.0;
+    for (linear_speed, angular_speed) in [(0.4, 0.0), (0.4, 0.9), (0.4, -0.9), (0.0, 0.9)] {
+        let rate = BodyTwist::new(linear_speed, angular_speed);
         let solved = Rk45::<f64>::default()
             .with_rtol(1e-12)
             .with_atol(1e-14)
@@ -40,30 +40,30 @@ fn arc_matches_rk45() {
                 &Unicycle::new(rate).field(),
                 0.0,
                 &Vector::new([0.0, 0.0, 0.0]),
-                tf,
+                final_time,
             )
             .unwrap();
 
-        let arc = integrate(SE2::identity(), rate.integrate_over(tf));
-        let t = arc.translation();
-        let s = solved;
+        let arc = integrate(SE2::identity(), rate.integrate_over(final_time));
+        let arc_translation = arc.translation();
+        let solved_state = solved;
         assert!(
-            (t[0] - s[0]).abs() < 1e-9,
-            "(v={v}, w={w}) x: arc {} vs rk45 {}",
-            t[0],
-            s[0]
+            (arc_translation[0] - solved_state[0]).abs() < 1e-9,
+            "(v={linear_speed}, w={angular_speed}) x: arc {} vs rk45 {}",
+            arc_translation[0],
+            solved_state[0]
         );
         assert!(
-            (t[1] - s[1]).abs() < 1e-9,
-            "(v={v}, w={w}) y: arc {} vs rk45 {}",
-            t[1],
-            s[1]
+            (arc_translation[1] - solved_state[1]).abs() < 1e-9,
+            "(v={linear_speed}, w={angular_speed}) y: arc {} vs rk45 {}",
+            arc_translation[1],
+            solved_state[1]
         );
         assert!(
-            (arc.rotation().log() - s[2]).abs() < 1e-12,
-            "(v={v}, w={w}) heading: arc {} vs rk45 {}",
+            (arc.rotation().log() - solved_state[2]).abs() < 1e-12,
+            "(v={linear_speed}, w={angular_speed}) heading: arc {} vs rk45 {}",
             arc.rotation().log(),
-            s[2]
+            solved_state[2]
         );
     }
 }
@@ -74,33 +74,49 @@ fn arc_matches_rk45() {
 fn one_big_step_equals_many_small_steps() {
     let rate = BodyTwist::new(0.4, 0.9);
     let total = 2.0;
-    let n = 1000;
+    let step_count = 1000;
 
-    let one = integrate(SE2::identity(), rate.integrate_over(total));
+    let one_step = integrate(SE2::identity(), rate.integrate_over(total));
 
-    let small = rate.integrate_over(total / f64::from(n));
-    let mut many = SE2::identity();
-    for _ in 0..n {
-        many = integrate(many, small);
+    let small_increment = rate.integrate_over(total / f64::from(step_count));
+    let mut many_steps = SE2::identity();
+    for _ in 0..step_count {
+        many_steps = integrate(many_steps, small_increment);
     }
 
-    let (a, b) = (one.translation(), many.translation());
-    assert!((a[0] - b[0]).abs() < TOL, "x: {} vs {}", a[0], b[0]);
-    assert!((a[1] - b[1]).abs() < TOL, "y: {} vs {}", a[1], b[1]);
-    assert!((one.rotation().log() - many.rotation().log()).abs() < TOL);
+    let one_step_translation = one_step.translation();
+    let many_step_translation = many_steps.translation();
+    assert!(
+        (one_step_translation[0] - many_step_translation[0]).abs() < TOL,
+        "x: {} vs {}",
+        one_step_translation[0],
+        many_step_translation[0]
+    );
+    assert!(
+        (one_step_translation[1] - many_step_translation[1]).abs() < TOL,
+        "y: {} vs {}",
+        one_step_translation[1],
+        many_step_translation[1]
+    );
+    assert!((one_step.rotation().log() - many_steps.rotation().log()).abs() < TOL);
 }
 
 #[test]
 fn arc_matches_closed_form() {
-    let (v, w, t) = (0.4_f64, 0.9, 1.3);
-    let theta = w * t;
-    let radius = v / w;
+    let linear_speed = 0.4_f64;
+    let angular_speed = 0.9;
+    let time = 1.3;
+    let heading_change = angular_speed * time;
+    let radius = linear_speed / angular_speed;
 
-    let arc = integrate(SE2::identity(), BodyTwist::new(v, w).integrate_over(t));
-    let p = arc.translation();
-    assert!((p[0] - radius * theta.sin()).abs() < TOL);
-    assert!((p[1] - radius * (1.0 - theta.cos())).abs() < TOL);
-    assert!((arc.rotation().log() - theta).abs() < TOL);
+    let arc = integrate(
+        SE2::identity(),
+        BodyTwist::new(linear_speed, angular_speed).integrate_over(time),
+    );
+    let translation = arc.translation();
+    assert!((translation[0] - radius * heading_change.sin()).abs() < TOL);
+    assert!((translation[1] - radius * (1.0 - heading_change.cos())).abs() < TOL);
+    assert!((arc.rotation().log() - heading_change).abs() < TOL);
 }
 
 // ---- degenerate motions -----------------------------------------------------
@@ -108,22 +124,23 @@ fn arc_matches_closed_form() {
 #[test]
 fn zero_angular_is_straight_line() {
     let pose = integrate(SE2::identity(), BodyArc::new(0.5_f64, 0.0));
-    let t = pose.translation();
-    assert!(t[0].is_finite() && t[1].is_finite());
-    assert_eq!(t[0], 0.5);
-    assert_eq!(t[1], 0.0);
+    let translation = pose.translation();
+    assert!(translation[0].is_finite() && translation[1].is_finite());
+    assert_eq!(translation[0], 0.5);
+    assert_eq!(translation[1], 0.0);
     assert_eq!(pose.rotation().log(), 0.0);
 }
 
 #[test]
 fn zero_linear_is_pure_rotation() {
     let mut rng = StdRng::seed_from_u64(0x0d0_1111);
-    let start = rand_pose(&mut rng);
+    let start = random_pose(&mut rng);
     let pose = integrate(start, BodyArc::new(0.0, 0.7));
 
-    let (a, b) = (start.translation(), pose.translation());
-    assert_eq!(a[0], b[0]);
-    assert_eq!(a[1], b[1]);
+    let start_translation = start.translation();
+    let end_translation = pose.translation();
+    assert_eq!(start_translation[0], end_translation[0]);
+    assert_eq!(start_translation[1], end_translation[1]);
 }
 
 // ---- conventions ------------------------------------------------------------
@@ -132,30 +149,33 @@ fn zero_linear_is_pure_rotation() {
 fn is_right_perturbation() {
     let mut rng = StdRng::seed_from_u64(0x0d0_2222);
     for _ in 0..100 {
-        let p = rand_pose(&mut rng);
-        let d = BodyArc::new(rng.gen_range(-1.0..1.0), rng.gen_range(-1.0..1.0));
-        let got = integrate(p, d);
-        let want = p * SE2::exp(Vector::new([d.linear(), 0.0, d.angular()]));
+        let pose = random_pose(&mut rng);
+        let increment = BodyArc::new(rng.gen_range(-1.0..1.0), rng.gen_range(-1.0..1.0));
+        let got = integrate(pose, increment);
+        let want = pose * SE2::exp(Vector::new([increment.linear(), 0.0, increment.angular()]));
         assert_eq!(got, want);
     }
 }
 
 #[test]
 fn identity_start_equals_exp() {
-    let d = BodyArc::new(0.3, -0.4);
-    let got = integrate(SE2::identity(), d);
+    let increment = BodyArc::new(0.3, -0.4);
+    let got = integrate(SE2::identity(), increment);
     let want = SE2::exp(Vector::new([0.3, 0.0, -0.4]));
     assert_eq!(got, want);
 }
 
 #[test]
 fn odometry_step_matches_integrate() {
-    let dd = DifferentialDrive::new(0.036_f64, 0.235).unwrap();
+    let drive = DifferentialDrive::new(0.036_f64, 0.235).unwrap();
     let mut rng = StdRng::seed_from_u64(0x0d0_3333);
     for _ in 0..100 {
-        let p = rand_pose(&mut rng);
-        let d = WheelRotations::new(rng.gen_range(-1.0..1.0), rng.gen_range(-1.0..1.0));
-        assert_eq!(dd.odometry_step(p, d), integrate(p, dd.forward_arc(d)));
+        let pose = random_pose(&mut rng);
+        let increment = WheelRotations::new(rng.gen_range(-1.0..1.0), rng.gen_range(-1.0..1.0));
+        assert_eq!(
+            drive.odometry_step(pose, increment),
+            integrate(pose, drive.forward_arc(increment))
+        );
     }
 }
 
@@ -165,23 +185,35 @@ fn odometry_step_matches_integrate() {
 /// change is the point: it exercises both curvature directions and must return to the start.
 #[test]
 fn figure_eight_closes() {
-    let dd = DifferentialDrive::new(0.036_f64, 0.235).unwrap();
-    let (v, w) = (0.36, 0.9);
-    let n = 2000;
-    let dt = (2.0 * PI / w) / f64::from(n);
+    let drive = DifferentialDrive::new(0.036_f64, 0.235).unwrap();
+    let linear_speed = 0.36;
+    let angular_speed = 0.9;
+    let step_count = 2000;
+    let timestep = (2.0 * PI / angular_speed) / f64::from(step_count);
 
     let mut pose = SE2::identity();
     for sign in [1.0, -1.0] {
-        let rates = dd.inverse(BodyTwist::new(v, w * sign));
-        let d = WheelRotations::new(rates.left() * dt, rates.right() * dt);
-        for _ in 0..n {
-            pose = dd.odometry_step(pose, d);
+        let wheel_rates = drive.inverse(BodyTwist::new(linear_speed, angular_speed * sign));
+        let increment = WheelRotations::new(
+            wheel_rates.left() * timestep,
+            wheel_rates.right() * timestep,
+        );
+        for _ in 0..step_count {
+            pose = drive.odometry_step(pose, increment);
         }
     }
 
-    let t = pose.translation();
-    assert!(t[0].abs() < 1e-9, "x did not close: {}", t[0]);
-    assert!(t[1].abs() < 1e-9, "y did not close: {}", t[1]);
+    let translation = pose.translation();
+    assert!(
+        translation[0].abs() < 1e-9,
+        "x did not close: {}",
+        translation[0]
+    );
+    assert!(
+        translation[1].abs() < 1e-9,
+        "y did not close: {}",
+        translation[1]
+    );
     assert!(
         pose.rotation().log().abs() < 1e-9,
         "heading did not close: {}",

--- a/crates/multicalc/tests/suite/kinematics/unicycle.rs
+++ b/crates/multicalc/tests/suite/kinematics/unicycle.rs
@@ -10,22 +10,22 @@ use multicalc::spatial::SE2;
 // ---- helpers ----------------------------------------------------------------
 
 /// The three outputs of one odometry increment from the identity: `[x, y, θ]`.
-fn arc_outputs<T: Numeric>(ds: T, dtheta: T) -> [T; 3] {
-    let pose = integrate(SE2::identity(), BodyArc::new(ds, dtheta));
-    let t = pose.translation();
-    [t[0], t[1], pose.rotation().log()]
+fn arc_outputs<T: Numeric>(arc_length: T, heading_change: T) -> [T; 3] {
+    let pose = integrate(SE2::identity(), BodyArc::new(arc_length, heading_change));
+    let translation = pose.translation();
+    [translation[0], translation[1], pose.rotation().log()]
 }
 
-fn rk4_to(rate: BodyTwist<f64>, dt: f64, tf: f64) -> Vector<3, f64> {
-    let f = Unicycle::new(rate).field();
-    let n = (tf / dt).round() as usize;
-    let mut y = Vector::new([0.0, 0.0, 0.0]);
-    let mut t = 0.0;
-    for _ in 0..n {
-        y = Rk4::step(&f, t, &y, dt);
-        t += dt;
+fn rk4_to(rate: BodyTwist<f64>, timestep: f64, final_time: f64) -> Vector<3, f64> {
+    let field = Unicycle::new(rate).field();
+    let step_count = (final_time / timestep).round() as usize;
+    let mut state = Vector::new([0.0, 0.0, 0.0]);
+    let mut time = 0.0;
+    for _ in 0..step_count {
+        state = Rk4::step(&field, time, &state, timestep);
+        time += timestep;
     }
-    y
+    state
 }
 
 // ---- convergence ------------------------------------------------------------
@@ -33,16 +33,16 @@ fn rk4_to(rate: BodyTwist<f64>, dt: f64, tf: f64) -> Vector<3, f64> {
 #[test]
 fn rk4_of_field_converges_to_integrate() {
     let rate = BodyTwist::new(0.4, 0.9);
-    let tf = 1.0;
+    let final_time = 1.0;
 
-    let truth = integrate(SE2::identity(), rate.integrate_over(tf)).translation();
-    let err = |dt: f64| {
-        let y = rk4_to(rate, dt, tf);
-        ((y[0] - truth[0]).powi(2) + (y[1] - truth[1]).powi(2)).sqrt()
+    let truth = integrate(SE2::identity(), rate.integrate_over(final_time)).translation();
+    let translation_error = |timestep: f64| {
+        let state = rk4_to(rate, timestep, final_time);
+        ((state[0] - truth[0]).powi(2) + (state[1] - truth[1]).powi(2)).sqrt()
     };
 
-    let coarse = err(0.1);
-    let fine = err(0.05);
+    let coarse = translation_error(0.1);
+    let fine = translation_error(0.05);
     let ratio = coarse / fine;
     assert!(
         ratio >= 8.0,
@@ -54,35 +54,36 @@ fn rk4_of_field_converges_to_integrate() {
 
 #[test]
 fn dual_matches_finite_differences() {
-    let p0 = [0.4_f64, 0.3];
-    let h = 1e-6;
+    let start = [0.4_f64, 0.3];
+    let step = 1e-6;
 
-    for k in 0..2 {
-        let ds = if k == 0 {
-            Dual::variable(p0[0])
+    for variable_index in 0..2 {
+        let arc_length = if variable_index == 0 {
+            Dual::variable(start[0])
         } else {
-            Dual::constant(p0[0])
+            Dual::constant(start[0])
         };
-        let dtheta = if k == 1 {
-            Dual::variable(p0[1])
+        let heading_change = if variable_index == 1 {
+            Dual::variable(start[1])
         } else {
-            Dual::constant(p0[1])
+            Dual::constant(start[1])
         };
-        let out = arc_outputs(ds, dtheta);
+        let outputs = arc_outputs(arc_length, heading_change);
 
-        let mut plus = p0;
-        let mut minus = p0;
-        plus[k] += h;
-        minus[k] -= h;
-        let fp = arc_outputs(plus[0], plus[1]);
-        let fm = arc_outputs(minus[0], minus[1]);
+        let mut plus = start;
+        let mut minus = start;
+        plus[variable_index] += step;
+        minus[variable_index] -= step;
+        let outputs_at_plus = arc_outputs(plus[0], plus[1]);
+        let outputs_at_minus = arc_outputs(minus[0], minus[1]);
 
-        for i in 0..3 {
-            let fd = (fp[i] - fm[i]) / (2.0 * h);
+        for output_index in 0..3 {
+            let finite_difference =
+                (outputs_at_plus[output_index] - outputs_at_minus[output_index]) / (2.0 * step);
             assert!(
-                (out[i].deriv - fd).abs() < 1e-6,
-                "k={k} i={i}: dual {} vs fd {fd}",
-                out[i].deriv
+                (outputs[output_index].deriv - finite_difference).abs() < 1e-6,
+                "variable {variable_index} output {output_index}: dual {} vs finite difference {finite_difference}",
+                outputs[output_index].deriv
             );
         }
     }
@@ -92,32 +93,33 @@ fn dual_matches_finite_differences() {
 /// produces NaN for, in both the value and the derivative.
 #[test]
 fn dual_finite_at_exactly_zero_angular() {
-    let ds = 0.4_f64;
+    let arc_length = 0.4_f64;
     // A wider step than the usual 1e-6: `(1−cosθ)/θ` and `sinθ/θ` cancel catastrophically as θ→0,
     // and that error grows as h shrinks. At 1e-6 the finite difference is the inaccurate side (~1e-5
     // off); 1e-4 balances it against truncation and lands near 1e-9. θ = ±1e-4 is still outside the
     // Taylor branch, so the comparison remains meaningful.
-    let h = 1e-4;
+    let step = 1e-4;
 
-    let out = arc_outputs(Dual::constant(ds), Dual::variable(0.0));
-    for (i, o) in out.iter().enumerate() {
+    let outputs = arc_outputs(Dual::constant(arc_length), Dual::variable(0.0));
+    for (output_index, output) in outputs.iter().enumerate() {
         assert!(
-            o.value.is_finite() && o.deriv.is_finite(),
-            "i={i}: value {} deriv {} must be finite",
-            o.value,
-            o.deriv
+            output.value.is_finite() && output.deriv.is_finite(),
+            "output {output_index}: value {} deriv {} must be finite",
+            output.value,
+            output.deriv
         );
     }
 
     // The finite differences straddle the branch, sampling just outside it.
-    let fp = arc_outputs(ds, h);
-    let fm = arc_outputs(ds, -h);
-    for i in 0..3 {
-        let fd = (fp[i] - fm[i]) / (2.0 * h);
+    let outputs_at_plus = arc_outputs(arc_length, step);
+    let outputs_at_minus = arc_outputs(arc_length, -step);
+    for output_index in 0..3 {
+        let finite_difference =
+            (outputs_at_plus[output_index] - outputs_at_minus[output_index]) / (2.0 * step);
         assert!(
-            (out[i].deriv - fd).abs() < 1e-6,
-            "i={i}: dual {} vs fd {fd}",
-            out[i].deriv
+            (outputs[output_index].deriv - finite_difference).abs() < 1e-6,
+            "output {output_index}: dual {} vs finite difference {finite_difference}",
+            outputs[output_index].deriv
         );
     }
 }
@@ -125,34 +127,35 @@ fn dual_finite_at_exactly_zero_angular() {
 #[test]
 fn odometry_step_jacobian_autodiff_vs_fd() {
     // Headings stay well away from ±π, where `SO2::log` wraps and the Jacobian is meaningless.
-    for p0 in [[0.3_f64, -0.2, 0.4, 0.1, 0.05], [0.3, -0.2, 0.4, 0.1, 0.0]] {
+    for start in [[0.3_f64, -0.2, 0.4, 0.1, 0.05], [0.3, -0.2, 0.4, 0.1, 0.0]] {
         // Wide enough to stay clear of the θ→0 cancellation in the `V(θ)` block; see
         // `dual_finite_at_exactly_zero_angular`.
-        let h = 1e-4;
-        for k in 0..5 {
+        let step = 1e-4;
+        for variable_index in 0..5 {
             let mut input = [Dual::constant(0.0); 5];
-            for (j, slot) in input.iter_mut().enumerate() {
-                *slot = if j == k {
-                    Dual::variable(p0[j])
+            for (index, slot) in input.iter_mut().enumerate() {
+                *slot = if index == variable_index {
+                    Dual::variable(start[index])
                 } else {
-                    Dual::constant(p0[j])
+                    Dual::constant(start[index])
                 };
             }
-            let out = OdometryStep.eval(&input);
+            let outputs = OdometryStep.eval(&input);
 
-            let mut plus = p0;
-            let mut minus = p0;
-            plus[k] += h;
-            minus[k] -= h;
-            let fp = OdometryStep.eval(&plus);
-            let fm = OdometryStep.eval(&minus);
+            let mut plus = start;
+            let mut minus = start;
+            plus[variable_index] += step;
+            minus[variable_index] -= step;
+            let outputs_at_plus = OdometryStep.eval(&plus);
+            let outputs_at_minus = OdometryStep.eval(&minus);
 
-            for i in 0..3 {
-                let fd = (fp[i] - fm[i]) / (2.0 * h);
+            for output_index in 0..3 {
+                let finite_difference =
+                    (outputs_at_plus[output_index] - outputs_at_minus[output_index]) / (2.0 * step);
                 assert!(
-                    (out[i].deriv - fd).abs() < 1e-6,
-                    "p0={p0:?} k={k} i={i}: dual {} vs fd {fd}",
-                    out[i].deriv
+                    (outputs[output_index].deriv - finite_difference).abs() < 1e-6,
+                    "start={start:?} variable {variable_index} output {output_index}: dual {} vs finite difference {finite_difference}",
+                    outputs[output_index].deriv
                 );
             }
         }

--- a/crates/multicalc/tests/suite/linear_algebra/cholesky.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/cholesky.rs
@@ -7,26 +7,23 @@ fn cholesky_reconstructs_spd() {
     cholesky_reconstructs(Matrix::<2, 2>::new([[4.0, 2.0], [2.0, 3.0]]), 1e-12);
 
     // A matrix with a known exact factor: L = [[2,0,0],[6,1,0],[-8,5,3]].
-    let a = Matrix::<3, 3>::new([
+    let known_factor = Matrix::<3, 3>::new([
         [4.0, 12.0, -16.0],
         [12.0, 37.0, -43.0],
         [-16.0, -43.0, 98.0],
     ]);
-    cholesky_reconstructs(a, 1e-12);
-    assert_matrix_close(
-        a.cholesky().unwrap().l(),
-        Matrix::new([[2.0, 0.0, 0.0], [6.0, 1.0, 0.0], [-8.0, 5.0, 3.0]]),
-        1e-12,
-    );
+    cholesky_reconstructs(known_factor, 1e-12);
+    let expected = Matrix::new([[2.0, 0.0, 0.0], [6.0, 1.0, 0.0], [-8.0, 5.0, 3.0]]);
+    assert_matrix_close(known_factor.cholesky().unwrap().l(), expected, 1e-12);
 
     // An M·Mᵀ product is symmetric positive-definite for full-rank M.
-    let m = Matrix::<4, 4>::new([
+    let lower_factor_source = Matrix::<4, 4>::new([
         [2.0, 0.0, 0.0, 0.0],
         [1.0, 3.0, 0.0, 0.0],
         [-1.0, 2.0, 4.0, 0.0],
         [0.0, 1.0, -2.0, 5.0],
     ]);
-    cholesky_reconstructs(m * m.transpose(), 1e-12);
+    cholesky_reconstructs(lower_factor_source * lower_factor_source.transpose(), 1e-12);
 
     // The same code at f32.
     cholesky_reconstructs(
@@ -66,52 +63,53 @@ fn cholesky_rejects_non_pd() {
 #[test]
 fn cholesky_solves() {
     // Single RHS on a 3x3 SPD system: exact solution, matches LU, tiny residual.
-    let a = Matrix::<3, 3>::new([[2.0, 1.0, 0.0], [1.0, 2.0, 1.0], [0.0, 1.0, 2.0]]);
-    let x_exact = Vector::new([1.0, -2.0, 3.0]);
-    let b = a * x_exact;
-    let x = a.cholesky().unwrap().solve(b);
-    for i in 0..3 {
-        assert!((x[i] - x_exact[i]).abs() < 1e-12);
+    let tridiagonal = Matrix::<3, 3>::new([[2.0, 1.0, 0.0], [1.0, 2.0, 1.0], [0.0, 1.0, 2.0]]);
+    let exact_solution = Vector::new([1.0, -2.0, 3.0]);
+    let right_hand_side = tridiagonal * exact_solution;
+    let solution = tridiagonal.cholesky().unwrap().solve(right_hand_side);
+    for index in 0..3 {
+        assert!((solution[index] - exact_solution[index]).abs() < 1e-12);
     }
-    assert!((a * x - b).norm() < 1e-12);
-    let lu_x = a.lu().unwrap().solve(b);
-    for i in 0..3 {
-        assert!((x[i] - lu_x[i]).abs() < 1e-12);
+    assert!((tridiagonal * solution - right_hand_side).norm() < 1e-12);
+    let lu_solution = tridiagonal.lu().unwrap().solve(right_hand_side);
+    for index in 0..3 {
+        assert!((solution[index] - lu_solution[index]).abs() < 1e-12);
     }
 
     // Multiple RHS: A·X == B, and each column agrees with a single-RHS solve.
-    let s = Matrix::<2, 2>::new([[4.0, 2.0], [2.0, 3.0]]);
-    let f = s.cholesky().unwrap();
-    let rhs = Matrix::<2, 3>::new([[8.0, 6.0, 4.0], [8.0, 5.0, 3.0]]);
-    let xm = f.solve_matrix(rhs);
-    assert_matrix_close(s * xm, rhs, 1e-12);
-    for c in 0..3 {
-        let single = f.solve(Vector::from_fn(|r| rhs[(r, c)]));
-        for r in 0..2 {
-            assert!((xm[(r, c)] - single[r]).abs() < 1e-12);
+    let small_spd = Matrix::<2, 2>::new([[4.0, 2.0], [2.0, 3.0]]);
+    let factorization = small_spd.cholesky().unwrap();
+    let right_hand_sides = Matrix::<2, 3>::new([[8.0, 6.0, 4.0], [8.0, 5.0, 3.0]]);
+    let matrix_solution = factorization.solve_matrix(right_hand_sides);
+    assert_matrix_close(small_spd * matrix_solution, right_hand_sides, 1e-12);
+    for column in 0..3 {
+        let single_column_solution =
+            factorization.solve(Vector::from_fn(|row| right_hand_sides[(row, column)]));
+        for row in 0..2 {
+            assert!((matrix_solution[(row, column)] - single_column_solution[row]).abs() < 1e-12);
         }
     }
 }
 
 #[test]
 fn cholesky_determinant_matches() {
-    let a = Matrix::<3, 3>::new([
+    let known_factor = Matrix::<3, 3>::new([
         [4.0, 12.0, -16.0],
         [12.0, 37.0, -43.0],
         [-16.0, -43.0, 98.0],
     ]);
-    let det = a.cholesky().unwrap().determinant();
+    let determinant = known_factor.cholesky().unwrap().determinant();
     // (2·1·3)² == 36.
-    assert!((det - 36.0).abs() < 1e-9);
-    assert!((det - a.determinant()).abs() < 1e-9);
-    assert!((det - a.lu().unwrap().determinant()).abs() < 1e-9);
+    assert!((determinant - 36.0).abs() < 1e-9);
+    assert!((determinant - known_factor.determinant()).abs() < 1e-9);
+    assert!((determinant - known_factor.lu().unwrap().determinant()).abs() < 1e-9);
 }
 
 #[test]
 fn cholesky_inverse_matches_lu() {
-    let a = Matrix::<3, 3>::new([[2.0, 1.0, 0.0], [1.0, 2.0, 1.0], [0.0, 1.0, 2.0]]);
-    let inv = a.cholesky().unwrap().inverse();
-    assert_identity(inv * a, 1e-12);
-    assert_identity(a * inv, 1e-12);
-    assert_matrix_close(inv, a.lu().unwrap().inverse(), 1e-12);
+    let tridiagonal = Matrix::<3, 3>::new([[2.0, 1.0, 0.0], [1.0, 2.0, 1.0], [0.0, 1.0, 2.0]]);
+    let inverse = tridiagonal.cholesky().unwrap().inverse();
+    assert_identity(inverse * tridiagonal, 1e-12);
+    assert_identity(tridiagonal * inverse, 1e-12);
+    assert_matrix_close(inverse, tridiagonal.lu().unwrap().inverse(), 1e-12);
 }

--- a/crates/multicalc/tests/suite/linear_algebra/lu.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/lu.rs
@@ -32,24 +32,26 @@ fn lu_reconstructs_pivoted_matrix() {
 #[test]
 fn lu_determinant_matches_direct() {
     // Cross-check against the direct determinant, including the pivot-sign handling.
-    let a = Matrix::<3, 3>::new([[2.0, 1.0, 1.0], [4.0, 3.0, 3.0], [8.0, 7.0, 9.0]]);
-    assert!((a.lu().unwrap().determinant() - a.determinant()).abs() < 1e-12);
+    let pivoted = Matrix::<3, 3>::new([[2.0, 1.0, 1.0], [4.0, 3.0, 3.0], [8.0, 7.0, 9.0]]);
+    assert!((pivoted.lu().unwrap().determinant() - pivoted.determinant()).abs() < 1e-12);
 
-    let b = Matrix::<4, 4>::new([
+    let non_symmetric = Matrix::<4, 4>::new([
         [1.0, 2.0, 3.0, 4.0],
         [2.0, 1.0, 0.0, 1.0],
         [0.0, 3.0, 1.0, 2.0],
         [1.0, 0.0, 2.0, 1.0],
     ]);
-    assert!((b.lu().unwrap().determinant() - b.determinant()).abs() < 1e-12);
-    assert!((b.lu().unwrap().determinant() + 20.0).abs() < 1e-12);
+    assert!(
+        (non_symmetric.lu().unwrap().determinant() - non_symmetric.determinant()).abs() < 1e-12
+    );
+    assert!((non_symmetric.lu().unwrap().determinant() + 20.0).abs() < 1e-12);
 }
 
 #[test]
 fn lu_rejects_singular() {
     // A zero column: the pivot search turns up only zeros.
-    let zero_col = Matrix::<3, 3>::new([[1.0, 0.0, 2.0], [3.0, 0.0, 4.0], [5.0, 0.0, 6.0]]);
-    assert_eq!(zero_col.lu().err(), Some(LinalgError::Singular));
+    let zero_column = Matrix::<3, 3>::new([[1.0, 0.0, 2.0], [3.0, 0.0, 4.0], [5.0, 0.0, 6.0]]);
+    assert_eq!(zero_column.lu().err(), Some(LinalgError::Singular));
 
     // Dependent rows drive a pivot to zero during elimination.
     let dependent = Matrix::<2, 2>::new([[1.0, 2.0], [2.0, 4.0]]);
@@ -58,25 +60,26 @@ fn lu_rejects_singular() {
 
 #[test]
 fn lu_solves() {
-    let a = Matrix::<3, 3>::new([[2.0, 1.0, 1.0], [4.0, 3.0, 3.0], [8.0, 7.0, 9.0]]);
-    let f = a.lu().unwrap();
+    let matrix = Matrix::<3, 3>::new([[2.0, 1.0, 1.0], [4.0, 3.0, 3.0], [8.0, 7.0, 9.0]]);
+    let factorization = matrix.lu().unwrap();
 
     // Single RHS: A·x = b has the exact solution x = [1, 2, 3], with a tiny residual.
-    let b = Vector::new([7.0, 19.0, 49.0]);
-    let x = f.solve(b);
-    assert!((x[0] - 1.0).abs() < 1e-12);
-    assert!((x[1] - 2.0).abs() < 1e-12);
-    assert!((x[2] - 3.0).abs() < 1e-12);
-    assert!((a * x - b).norm() < 1e-12);
+    let right_hand_side = Vector::new([7.0, 19.0, 49.0]);
+    let solution = factorization.solve(right_hand_side);
+    assert!((solution[0] - 1.0).abs() < 1e-12);
+    assert!((solution[1] - 2.0).abs() < 1e-12);
+    assert!((solution[2] - 3.0).abs() < 1e-12);
+    assert!((matrix * solution - right_hand_side).norm() < 1e-12);
 
     // Multiple RHS: A·X == B, and each column agrees with a single-RHS solve.
-    let rhs = Matrix::<3, 2>::new([[7.0, 4.0], [19.0, 10.0], [49.0, 26.0]]);
-    let xm = f.solve_matrix(rhs);
-    assert_matrix_close(a * xm, rhs, 1e-12);
-    for c in 0..2 {
-        let single = f.solve(Vector::from_fn(|r| rhs[(r, c)]));
-        for r in 0..3 {
-            assert!((xm[(r, c)] - single[r]).abs() < 1e-12);
+    let right_hand_sides = Matrix::<3, 2>::new([[7.0, 4.0], [19.0, 10.0], [49.0, 26.0]]);
+    let matrix_solution = factorization.solve_matrix(right_hand_sides);
+    assert_matrix_close(matrix * matrix_solution, right_hand_sides, 1e-12);
+    for column in 0..2 {
+        let single_column_solution =
+            factorization.solve(Vector::from_fn(|row| right_hand_sides[(row, column)]));
+        for row in 0..3 {
+            assert!((matrix_solution[(row, column)] - single_column_solution[row]).abs() < 1e-12);
         }
     }
 }
@@ -85,58 +88,55 @@ fn lu_solves() {
 fn lu_inverse_matches_reference_5x5() {
     // A non-symmetric 5×5; reference inverse from an exact rational solve. The direct inverse is
     // covered in matrix.rs; this guards the LU inverse on a larger, non-symmetric system.
-    let a = Matrix::<5, 5>::new([
+    let matrix = Matrix::<5, 5>::new([
         [5.0, 1.0, 0.0, 2.0, 1.0],
         [1.0, 6.0, 2.0, 0.0, 1.0],
         [3.0, 2.0, 7.0, 1.0, 0.0],
         [2.0, 0.0, 1.0, 8.0, 2.0],
         [1.0, 4.0, 0.0, 2.0, 9.0],
     ]);
-    assert!((a.lu().unwrap().determinant() - 10406.0).abs() < 1e-9);
+    assert!((matrix.lu().unwrap().determinant() - 10406.0).abs() < 1e-9);
 
-    let inv = a.lu().unwrap().inverse();
-    assert_matrix_close(
-        inv,
-        Matrix::new([
-            [
-                0.2200653469152412,
-                -0.03757447626369402,
-                0.01864309052469729,
-                -0.055352681145492987,
-                -0.007976167595617912,
-            ],
-            [
-                -0.005573707476455891,
-                0.20488179896213723,
-                -0.06073419181241591,
-                0.01537574476263694,
-                -0.025562175667883914,
-            ],
-            [
-                -0.08687295790889871,
-                -0.04804920238324044,
-                0.15683259657889678,
-                -0.0017297712857966558,
-                0.01537574476263694,
-            ],
-            [
-                -0.04093792043052085,
-                0.039304247549490676,
-                -0.032289064001537575,
-                0.14741495291178167,
-                -0.032577359215837015,
-            ],
-            [
-                -0.012877186238708437,
-                -0.09561791274264847,
-                0.032096867192004615,
-                -0.03344224485873534,
-                0.13059773207764752,
-            ],
-        ]),
-        1e-12,
-    );
-    assert_identity(a * inv, 1e-12);
+    let inverse = matrix.lu().unwrap().inverse();
+    let expected = Matrix::new([
+        [
+            0.2200653469152412,
+            -0.03757447626369402,
+            0.01864309052469729,
+            -0.055352681145492987,
+            -0.007976167595617912,
+        ],
+        [
+            -0.005573707476455891,
+            0.20488179896213723,
+            -0.06073419181241591,
+            0.01537574476263694,
+            -0.025562175667883914,
+        ],
+        [
+            -0.08687295790889871,
+            -0.04804920238324044,
+            0.15683259657889678,
+            -0.0017297712857966558,
+            0.01537574476263694,
+        ],
+        [
+            -0.04093792043052085,
+            0.039304247549490676,
+            -0.032289064001537575,
+            0.14741495291178167,
+            -0.032577359215837015,
+        ],
+        [
+            -0.012877186238708437,
+            -0.09561791274264847,
+            0.032096867192004615,
+            -0.03344224485873534,
+            0.13059773207764752,
+        ],
+    ]);
+    assert_matrix_close(inverse, expected, 1e-12);
+    assert_identity(matrix * inverse, 1e-12);
 }
 
 // ----- property: P·A = L·U on random matrices -----
@@ -150,18 +150,20 @@ fn lu_inverse_matches_reference_5x5() {
 /// mild, but a near-zero pivot still leaves the reconstruction too ill-conditioned for a fixed
 /// tolerance not to flake.
 fn check_lu_property<const N: usize>(entries: Vec<f64>) -> Result<(), TestCaseError> {
-    let a = Matrix::<N, N>::try_from_row_slice(&entries).expect("N*N entries");
-    let scale = max_abs(a).max(1.0);
+    let matrix = Matrix::<N, N>::try_from_row_slice(&entries).expect("N*N entries");
+    let scale = max_abs(matrix).max(1.0);
 
-    let lu = a.lu();
+    let lu = matrix.lu();
     prop_assume!(lu.is_ok());
-    let f = lu.unwrap();
+    let factorization = lu.unwrap();
 
-    let min_pivot = (0..N).fold(f64::MAX, |acc, i| acc.min(f.u()[(i, i)].abs()));
+    let min_pivot = (0..N).fold(f64::MAX, |smallest, index| {
+        smallest.min(factorization.u()[(index, index)].abs())
+    });
     prop_assume!(min_pivot >= 1e-6 * scale);
 
-    let tol = N as f64 * scale * f64::EPSILON * 1e3;
-    lu_reconstructs(a, tol);
+    let tolerance = N as f64 * scale * f64::EPSILON * 1e3;
+    lu_reconstructs(matrix, tolerance);
     Ok(())
 }
 

--- a/crates/multicalc/tests/suite/linear_algebra/matrix.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/matrix.rs
@@ -6,30 +6,30 @@ use multicalc_testkit::tol::{assert_identity, assert_matrix_close};
 
 #[test]
 fn matrix_arithmetic() {
-    let a = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
-    let b = Matrix::new([[5.0, 6.0], [7.0, 8.0]]);
+    let left = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
+    let right = Matrix::new([[5.0, 6.0], [7.0, 8.0]]);
 
-    assert_eq!(a + b, Matrix::new([[6.0, 8.0], [10.0, 12.0]]));
-    assert_eq!(b - a, Matrix::new([[4.0, 4.0], [4.0, 4.0]]));
-    assert_eq!(-a, Matrix::new([[-1.0, -2.0], [-3.0, -4.0]]));
-    assert_eq!(a * 2.0, a.scale(2.0));
+    assert_eq!(left + right, Matrix::new([[6.0, 8.0], [10.0, 12.0]]));
+    assert_eq!(right - left, Matrix::new([[4.0, 4.0], [4.0, 4.0]]));
+    assert_eq!(-left, Matrix::new([[-1.0, -2.0], [-3.0, -4.0]]));
+    assert_eq!(left * 2.0, left.scale(2.0));
 
-    let mut c = a;
-    c += b;
-    assert_eq!(c, a + b);
-    c -= b;
-    assert_eq!(c, a);
+    let mut accumulated = left;
+    accumulated += right;
+    assert_eq!(accumulated, left + right);
+    accumulated -= right;
+    assert_eq!(accumulated, left);
 }
 
 #[test]
 fn try_row_column() {
-    let m = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
+    let matrix = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
 
-    assert_eq!(m.try_row(1), Some(Vector::new([3.0, 4.0])));
-    assert_eq!(m.try_row(2), None);
+    assert_eq!(matrix.try_row(1), Some(Vector::new([3.0, 4.0])));
+    assert_eq!(matrix.try_row(2), None);
 
-    assert_eq!(m.try_column(0), Some(Vector::new([1.0, 3.0])));
-    assert_eq!(m.try_column(2), None);
+    assert_eq!(matrix.try_column(0), Some(Vector::new([1.0, 3.0])));
+    assert_eq!(matrix.try_column(2), None);
 
     let empty: Matrix<0, 3> = Matrix::zeros();
     assert_eq!(empty.try_column(0), Some(Vector::<0, f64>::zeros()));
@@ -38,66 +38,70 @@ fn try_row_column() {
 
 #[test]
 fn matrix_multiply() {
-    let a = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
-    let b = Matrix::new([[5.0, 6.0], [7.0, 8.0]]);
-    let id: Matrix<2, 2> = Matrix::identity();
+    let left = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
+    let right = Matrix::new([[5.0, 6.0], [7.0, 8.0]]);
+    let identity: Matrix<2, 2> = Matrix::identity();
 
-    assert_eq!(a * id, a);
-    assert_eq!(id * a, a);
-    assert_eq!((a * b) * a, a * (b * a)); // associativity
+    assert_eq!(left * identity, left);
+    assert_eq!(identity * left, left);
+    assert_eq!((left * right) * left, left * (right * left)); // associativity
 
     // non-square 2x3 * 3x2
-    let p = Matrix::new([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
-    let q = Matrix::new([[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]]);
-    assert_eq!(p * q, Matrix::new([[58.0, 64.0], [139.0, 154.0]]));
+    let wide = Matrix::new([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+    let tall = Matrix::new([[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]]);
+    assert_eq!(wide * tall, Matrix::new([[58.0, 64.0], [139.0, 154.0]]));
 
     // matrix x vector
-    assert_eq!(a * Vector::new([1.0, 1.0]), Vector::new([3.0, 7.0]));
+    assert_eq!(left * Vector::new([1.0, 1.0]), Vector::new([3.0, 7.0]));
 }
 
 #[test]
 fn matrix_transpose() {
-    let m = Matrix::new([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]); // 2x3
+    let matrix = Matrix::new([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]); // 2x3
     assert_eq!(
-        m.transpose(),
+        matrix.transpose(),
         Matrix::new([[1.0, 4.0], [2.0, 5.0], [3.0, 6.0]])
     ); // 3x2
-    assert_eq!(m.transpose().transpose(), m); // involution
+    assert_eq!(matrix.transpose().transpose(), matrix); // involution
 
-    let a = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
-    let b = Matrix::new([[5.0, 6.0], [7.0, 8.0]]);
-    assert_eq!((a * b).transpose(), b.transpose() * a.transpose());
+    let left = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
+    let right = Matrix::new([[5.0, 6.0], [7.0, 8.0]]);
+    assert_eq!(
+        (left * right).transpose(),
+        right.transpose() * left.transpose()
+    );
 }
 
 // ----- determinant & inverse (specialized) -----
 
 #[test]
 fn matrix_determinant() {
-    let id2: Matrix<2, 2> = Matrix::identity();
-    let id3: Matrix<3, 3> = Matrix::identity();
-    assert_eq!(id2.determinant(), 1.0);
-    assert_eq!(id3.determinant(), 1.0);
+    let identity_2x2: Matrix<2, 2> = Matrix::identity();
+    let identity_3x3: Matrix<3, 3> = Matrix::identity();
+    assert_eq!(identity_2x2.determinant(), 1.0);
+    assert_eq!(identity_3x3.determinant(), 1.0);
 
     assert_eq!(Matrix::new([[1.0, 2.0], [3.0, 4.0]]).determinant(), -2.0);
-    assert_eq!(
-        Matrix::new([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 10.0]]).determinant(),
-        -3.0
-    );
+
+    let three_by_three = Matrix::new([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 10.0]]);
+    let expected = -3.0;
+    assert_eq!(three_by_three.determinant(), expected);
+
     assert_eq!(Matrix::new([[1.0, 2.0], [2.0, 4.0]]).determinant(), 0.0); // singular
 }
 
 #[test]
 fn matrix_inverse() {
-    let id2: Matrix<2, 2> = Matrix::identity();
-    let id3: Matrix<3, 3> = Matrix::identity();
-    assert_eq!(id2.inverse(), Ok(id2));
-    assert_eq!(id3.inverse(), Ok(id3));
+    let identity_2x2: Matrix<2, 2> = Matrix::identity();
+    let identity_3x3: Matrix<3, 3> = Matrix::identity();
+    assert_eq!(identity_2x2.inverse(), Ok(identity_2x2));
+    assert_eq!(identity_3x3.inverse(), Ok(identity_3x3));
 
-    let a = Matrix::new([[4.0, 7.0], [2.0, 6.0]]);
-    assert_identity(a * a.inverse().unwrap(), 1e-12);
+    let invertible_2x2 = Matrix::new([[4.0, 7.0], [2.0, 6.0]]);
+    assert_identity(invertible_2x2 * invertible_2x2.inverse().unwrap(), 1e-12);
 
-    let b = Matrix::new([[1.0, 2.0, 3.0], [0.0, 1.0, 4.0], [5.0, 6.0, 0.0]]);
-    assert_identity(b * b.inverse().unwrap(), 1e-12);
+    let invertible_3x3 = Matrix::new([[1.0, 2.0, 3.0], [0.0, 1.0, 4.0], [5.0, 6.0, 0.0]]);
+    assert_identity(invertible_3x3 * invertible_3x3.inverse().unwrap(), 1e-12);
 
     // singular -> Err(SingularMatrix)
     let singular2 = Matrix::new([[1.0, 2.0], [2.0, 4.0]]);
@@ -107,13 +111,14 @@ fn matrix_inverse() {
     assert_eq!(singular3.inverse(), Err(LinalgError::Singular));
 
     // Near-singular: det is tiny but nonzero under exact compare.
-    let near2 = Matrix::new([[1.0, 1.0], [1.0, 1.0 + f64::EPSILON]]);
-    assert_ne!(near2.determinant(), 0.0);
-    assert_eq!(near2.inverse(), Err(LinalgError::Singular));
+    let near_singular_2x2 = Matrix::new([[1.0, 1.0], [1.0, 1.0 + f64::EPSILON]]);
+    assert_ne!(near_singular_2x2.determinant(), 0.0);
+    assert_eq!(near_singular_2x2.inverse(), Err(LinalgError::Singular));
 
-    let near3 = Matrix::new([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, f64::EPSILON]]);
-    assert_ne!(near3.determinant(), 0.0);
-    assert_eq!(near3.inverse(), Err(LinalgError::Singular));
+    let near_singular_3x3 =
+        Matrix::new([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, f64::EPSILON]]);
+    assert_ne!(near_singular_3x3.determinant(), 0.0);
+    assert_eq!(near_singular_3x3.inverse(), Err(LinalgError::Singular));
 
     // Tiny but full-rank still inverts (scaled threshold, not absolute eps).
     let tiny = Matrix::<2, 2>::identity().scale(1e-8);
@@ -132,50 +137,44 @@ fn matrix_4x4_determinant_and_inverse() {
     assert_eq!(upper.determinant(), 120.0);
 
     // Reference determinant and inverse from an exact rational solve.
-    let a = Matrix::<4, 4>::new([
+    let symmetric = Matrix::<4, 4>::new([
         [4.0, 3.0, 2.0, 1.0],
         [3.0, 4.0, 3.0, 2.0],
         [2.0, 3.0, 4.0, 3.0],
         [1.0, 2.0, 3.0, 4.0],
     ]);
-    assert_eq!(a.determinant(), 20.0);
+    assert_eq!(symmetric.determinant(), 20.0);
 
-    let inv = a.inverse().unwrap();
-    assert_matrix_close(
-        inv,
-        Matrix::new([
-            [0.6, -0.5, 0.0, 0.1],
-            [-0.5, 1.0, -0.5, 0.0],
-            [0.0, -0.5, 1.0, -0.5],
-            [0.1, 0.0, -0.5, 0.6],
-        ]),
-        1e-12,
-    );
-    assert_identity(a * inv, 1e-12);
+    let inverse = symmetric.inverse().unwrap();
+    let expected = Matrix::new([
+        [0.6, -0.5, 0.0, 0.1],
+        [-0.5, 1.0, -0.5, 0.0],
+        [0.0, -0.5, 1.0, -0.5],
+        [0.1, 0.0, -0.5, 0.6],
+    ]);
+    assert_matrix_close(inverse, expected, 1e-12);
+    assert_identity(symmetric * inverse, 1e-12);
 
     // A non-symmetric matrix, so its (non-symmetric) inverse catches any transpose error in
     // the adjugate. Reference from an exact rational solve.
-    let b = Matrix::<4, 4>::new([
+    let non_symmetric = Matrix::<4, 4>::new([
         [1.0, 2.0, 3.0, 4.0],
         [2.0, 1.0, 0.0, 1.0],
         [0.0, 3.0, 1.0, 2.0],
         [1.0, 0.0, 2.0, 1.0],
     ]);
-    assert_eq!(b.determinant(), -20.0);
+    assert_eq!(non_symmetric.determinant(), -20.0);
 
-    let b_inv = b.inverse().unwrap();
-    assert_matrix_close(
-        b_inv,
-        Matrix::new([
-            [-0.15, 0.45, -0.05, 0.25],
-            [-0.35, 0.05, 0.55, 0.25],
-            [-0.25, -0.25, 0.25, 0.75],
-            [0.65, 0.05, -0.45, -0.75],
-        ]),
-        1e-12,
-    );
-    assert_identity(b * b_inv, 1e-12);
-    assert_identity(b_inv * b, 1e-12);
+    let non_symmetric_inverse = non_symmetric.inverse().unwrap();
+    let expected = Matrix::new([
+        [-0.15, 0.45, -0.05, 0.25],
+        [-0.35, 0.05, 0.55, 0.25],
+        [-0.25, -0.25, 0.25, 0.75],
+        [0.65, 0.05, -0.45, -0.75],
+    ]);
+    assert_matrix_close(non_symmetric_inverse, expected, 1e-12);
+    assert_identity(non_symmetric * non_symmetric_inverse, 1e-12);
+    assert_identity(non_symmetric_inverse * non_symmetric, 1e-12);
 
     // Rows in arithmetic progression are rank-deficient.
     let singular = Matrix::<4, 4>::new([
@@ -188,28 +187,31 @@ fn matrix_4x4_determinant_and_inverse() {
     assert_eq!(singular.inverse(), Err(LinalgError::Singular));
 
     // The same code at f32 round-trips to the identity.
-    let af = Matrix::<4, 4, f32>::new([
+    let single_precision = Matrix::<4, 4, f32>::new([
         [4.0, 3.0, 2.0, 1.0],
         [3.0, 4.0, 3.0, 2.0],
         [2.0, 3.0, 4.0, 3.0],
         [1.0, 2.0, 3.0, 4.0],
     ]);
-    assert_identity(af * af.inverse().unwrap(), 1e-5_f32);
+    assert_identity(
+        single_precision * single_precision.inverse().unwrap(),
+        1e-5_f32,
+    );
 
     // Near-singular: det is tiny but nonzero under exact compare.
-    let near4 = Matrix::<4, 4>::new([
+    let near_singular_4x4 = Matrix::<4, 4>::new([
         [1.0, 0.0, 0.0, 0.0],
         [0.0, 1.0, 0.0, 0.0],
         [0.0, 0.0, 1.0, 0.0],
         [1.0, 1.0, 1.0, f64::EPSILON],
     ]);
-    assert_ne!(near4.determinant(), 0.0);
-    assert_eq!(near4.inverse(), Err(LinalgError::Singular));
+    assert_ne!(near_singular_4x4.determinant(), 0.0);
+    assert_eq!(near_singular_4x4.inverse(), Err(LinalgError::Singular));
 }
 
 #[test]
 fn matrix_5x5_determinant_and_inverse() {
-    let a = Matrix::<5, 5>::new([
+    let subject = Matrix::<5, 5>::new([
         [1.0, 2.0, 3.0, 4.0, 0.0],
         [2.0, 1.0, 0.0, 1.0, 2.0],
         [0.0, 3.0, 1.0, 2.0, 1.0],
@@ -217,9 +219,10 @@ fn matrix_5x5_determinant_and_inverse() {
         [3.0, 1.0, 0.0, 3.0, 1.0],
     ]);
 
-    assert!((a.determinant() - -27.0).abs() < 1e-12);
+    assert!((subject.determinant() - -27.0).abs() < 1e-12);
 
-    let b = Matrix::<5, 5>::new([
+    // Each row is the running sum of the row above it.
+    let cumulative_sums = Matrix::<5, 5>::new([
         [1.0, 1.0, 1.0, 1.0, 1.0],
         [1.0, 2.0, 3.0, 4.0, 5.0],
         [1.0, 3.0, 6.0, 10.0, 15.0],
@@ -227,31 +230,28 @@ fn matrix_5x5_determinant_and_inverse() {
         [1.0, 5.0, 15.0, 35.0, 70.0],
     ]);
 
-    assert_matrix_close(
-        b.inverse().unwrap(),
-        Matrix::<5, 5>::new([
-            [5.0, -10.0, 10.0, -5.0, 1.0],
-            [-10.0, 30.0, -35.0, 19.0, -4.0],
-            [10.0, -35.0, 46.0, -27.0, 6.0],
-            [-5.0, 19.0, -27.0, 17.0, -4.0],
-            [1.0, -4.0, 6.0, -4.0, 1.0],
-        ]),
-        1e-12,
-    );
+    let expected = Matrix::<5, 5>::new([
+        [5.0, -10.0, 10.0, -5.0, 1.0],
+        [-10.0, 30.0, -35.0, 19.0, -4.0],
+        [10.0, -35.0, 46.0, -27.0, 6.0],
+        [-5.0, 19.0, -27.0, 17.0, -4.0],
+        [1.0, -4.0, 6.0, -4.0, 1.0],
+    ]);
+    assert_matrix_close(cumulative_sums.inverse().unwrap(), expected, 1e-12);
 }
 
 #[test]
 fn matrix_solve_agrees_with_lu() {
-    let a = Matrix::<3, 3>::new([[2.0, 1.0, 1.0], [4.0, 3.0, 3.0], [8.0, 7.0, 9.0]]);
-    let b = Vector::new([7.0, 19.0, 49.0]);
-    let x = a.solve(b).unwrap();
+    let matrix = Matrix::<3, 3>::new([[2.0, 1.0, 1.0], [4.0, 3.0, 3.0], [8.0, 7.0, 9.0]]);
+    let right_hand_side = Vector::new([7.0, 19.0, 49.0]);
+    let solution = matrix.solve(right_hand_side).unwrap();
 
     // The convenience solver matches an explicit LU solve.
-    let lu_x = a.lu().unwrap().solve(b);
-    for i in 0..3 {
-        assert!((x[i] - lu_x[i]).abs() < 1e-12);
+    let lu_solution = matrix.lu().unwrap().solve(right_hand_side);
+    for index in 0..3 {
+        assert!((solution[index] - lu_solution[index]).abs() < 1e-12);
     }
-    assert!((a * x - b).norm() < 1e-12);
+    assert!((matrix * solution - right_hand_side).norm() < 1e-12);
 
     // A singular system is rejected.
     let singular = Matrix::<2, 2>::new([[1.0, 2.0], [2.0, 4.0]]);
@@ -265,12 +265,12 @@ fn matrix_solve_agrees_with_lu() {
 
 #[test]
 fn genericity_f32() {
-    let a = Vector::<3, f32>::new([1.0, 2.0, 2.0]);
-    let b = Vector::<3, f32>::new([2.0, 0.0, 1.0]);
-    assert!((a.norm() - 3.0).abs() < 1e-6);
-    assert!((a.dot(b) - 4.0).abs() < 1e-6);
+    let first = Vector::<3, f32>::new([1.0, 2.0, 2.0]);
+    let second = Vector::<3, f32>::new([2.0, 0.0, 1.0]);
+    assert!((first.norm() - 3.0).abs() < 1e-6);
+    assert!((first.dot(second) - 4.0).abs() < 1e-6);
 
-    let m = Matrix::<2, 2, f32>::new([[1.0, 2.0], [3.0, 4.0]]);
-    let id: Matrix<2, 2, f32> = Matrix::identity();
-    assert_eq!(m * id, m);
+    let matrix = Matrix::<2, 2, f32>::new([[1.0, 2.0], [3.0, 4.0]]);
+    let identity: Matrix<2, 2, f32> = Matrix::identity();
+    assert_eq!(matrix * identity, matrix);
 }

--- a/crates/multicalc/tests/suite/linear_algebra/qr.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/qr.rs
@@ -8,9 +8,9 @@ use proptest::test_runner::TestCaseError;
 
 #[test]
 fn qr_rejects_underdetermined() {
-    let a = Matrix::<2, 3>::new([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+    let matrix = Matrix::<2, 3>::new([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
     assert!(matches!(
-        PivotedQr::decompose(a),
+        PivotedQr::decompose(matrix),
         Err(LinalgError::Underdetermined)
     ));
 }
@@ -18,13 +18,13 @@ fn qr_rejects_underdetermined() {
 #[test]
 fn qr_solves_square_system() {
     // A x = b with the exact solution x = [1, 1, 1].
-    let a = Matrix::<3, 3>::new([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 10.0]]);
-    let b = Vector::new([6.0, 15.0, 25.0]);
-    let x = PivotedQr::decompose(a)
+    let matrix = Matrix::<3, 3>::new([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 10.0]]);
+    let right_hand_side = Vector::new([6.0, 15.0, 25.0]);
+    let solution = PivotedQr::decompose(matrix)
         .unwrap()
-        .solve_least_squares(b)
+        .solve_least_squares(right_hand_side)
         .unwrap();
-    for value in x.into_array() {
+    for value in solution.into_array() {
         assert!((value - 1.0).abs() < 1e-12);
     }
 }
@@ -32,26 +32,26 @@ fn qr_solves_square_system() {
 #[test]
 fn qr_solves_overdetermined_least_squares() {
     // Fit y = m t + c to three non-collinear points; least-squares gives m = 0.5, c = 7/6.
-    let a = Matrix::<3, 2>::new([[0.0, 1.0], [1.0, 1.0], [2.0, 1.0]]);
-    let b = Vector::new([1.0, 2.0, 2.0]);
-    let x = PivotedQr::decompose(a)
+    let matrix = Matrix::<3, 2>::new([[0.0, 1.0], [1.0, 1.0], [2.0, 1.0]]);
+    let right_hand_side = Vector::new([1.0, 2.0, 2.0]);
+    let solution = PivotedQr::decompose(matrix)
         .unwrap()
-        .solve_least_squares(b)
+        .solve_least_squares(right_hand_side)
         .unwrap();
-    assert!((x[0] - 0.5).abs() < 1e-12);
-    assert!((x[1] - 7.0 / 6.0).abs() < 1e-12);
+    assert!((solution[0] - 0.5).abs() < 1e-12);
+    assert!((solution[1] - 7.0 / 6.0).abs() < 1e-12);
 }
 
 #[test]
 fn qr_solve_rejects_rank_deficient() {
-    let b = Vector::new([1.0, 2.0, 3.0]);
+    let right_hand_side = Vector::new([1.0, 2.0, 3.0]);
 
     // The middle column is zero, so R has an exactly-zero diagonal entry.
-    let zero_col = Matrix::<3, 3>::new([[1.0, 0.0, 2.0], [3.0, 0.0, 4.0], [5.0, 0.0, 6.0]]);
+    let zero_column = Matrix::<3, 3>::new([[1.0, 0.0, 2.0], [3.0, 0.0, 4.0], [5.0, 0.0, 6.0]]);
     assert!(matches!(
-        PivotedQr::decompose(zero_col)
+        PivotedQr::decompose(zero_column)
             .unwrap()
-            .solve_least_squares(b),
+            .solve_least_squares(right_hand_side),
         Err(LinalgError::Singular)
     ));
 
@@ -61,7 +61,7 @@ fn qr_solve_rejects_rank_deficient() {
     assert!(matches!(
         PivotedQr::decompose(dependent)
             .unwrap()
-            .solve_least_squares(b),
+            .solve_least_squares(right_hand_side),
         Err(LinalgError::Singular)
     ));
 }
@@ -70,66 +70,78 @@ fn qr_solve_rejects_rank_deficient() {
 
 // A full-rank 4x3 problem reused across the damped-solve tests.
 fn sample_problem() -> (Matrix<4, 3>, Vector<4>) {
-    let j = Matrix::<4, 3>::new([
+    let jacobian = Matrix::<4, 3>::new([
         [1.0, 2.0, 0.0],
         [0.0, 1.0, 3.0],
         [2.0, 1.0, 1.0],
         [1.0, 0.0, 2.0],
     ]);
-    let b = Vector::new([1.0, 2.0, 3.0, 4.0]);
-    (j, b)
+    let right_hand_side = Vector::new([1.0, 2.0, 3.0, 4.0]);
+    (jacobian, right_hand_side)
 }
 
 #[test]
 fn damped_solve_satisfies_normal_equations() {
-    let (j, b) = sample_problem();
-    let diag = [1.0, 0.5, 2.0];
-    let dls = PivotedQr::decompose(j).unwrap().into_damped(b);
-    let (x, _) = dls.solve_with_diagonal(&diag);
+    let (jacobian, right_hand_side) = sample_problem();
+    let diagonal = [1.0, 0.5, 2.0];
+    let damped = PivotedQr::decompose(jacobian)
+        .unwrap()
+        .into_damped(right_hand_side);
+    let (solution, _) = damped.solve_with_diagonal(&diagonal);
 
     // x must satisfy (JᵀJ + D²) x = Jᵀb.
-    let jtj = j.transpose() * j;
-    let jtb = j.transpose() * b;
-    let lhs =
-        Matrix::<3, 3>::from_fn(|r, c| jtj[(r, c)] + if r == c { diag[r] * diag[r] } else { 0.0 })
-            * x;
-    for i in 0..3 {
-        assert!((lhs[i] - jtb[i]).abs() < 1e-12);
+    let normal_matrix = jacobian.transpose() * jacobian;
+    let normal_right_hand_side = jacobian.transpose() * right_hand_side;
+    let left_side = Matrix::<3, 3>::from_fn(|row, column| {
+        normal_matrix[(row, column)]
+            + if row == column {
+                diagonal[row] * diagonal[row]
+            } else {
+                0.0
+            }
+    }) * solution;
+    for index in 0..3 {
+        assert!((left_side[index] - normal_right_hand_side[index]).abs() < 1e-12);
     }
 }
 
 #[test]
 fn damped_zero_diagonal_matches_least_squares() {
-    let (j, b) = sample_problem();
-    let qr = PivotedQr::decompose(j).unwrap();
-    let expected = qr.solve_least_squares(b).unwrap();
-    let (x, _) = qr.into_damped(b).solve_with_zero_diagonal();
-    for i in 0..3 {
-        assert!((x[i] - expected[i]).abs() < 1e-12);
+    let (jacobian, right_hand_side) = sample_problem();
+    let qr = PivotedQr::decompose(jacobian).unwrap();
+    let expected = qr.solve_least_squares(right_hand_side).unwrap();
+    let (solution, _) = qr.into_damped(right_hand_side).solve_with_zero_diagonal();
+    for index in 0..3 {
+        assert!((solution[index] - expected[index]).abs() < 1e-12);
     }
 }
 
 #[test]
 fn damped_accessors() {
-    let (j, b) = sample_problem();
-    let dls = PivotedQr::decompose(j).unwrap().into_damped(b);
+    let (jacobian, right_hand_side) = sample_problem();
+    let damped = PivotedQr::decompose(jacobian)
+        .unwrap()
+        .into_damped(right_hand_side);
 
     // max_a_t_b_scaled: max over columns of |Jᵀb|ₗ / (b_norm · ‖columnₗ‖).
-    let b_norm = b.norm();
-    let jtb = j.transpose() * b;
+    let b_norm = right_hand_side.norm();
+    let normal_right_hand_side = jacobian.transpose() * right_hand_side;
     let mut expected = 0.0_f64;
-    for l in 0..3 {
-        let scaled = (jtb[l] / b_norm / Vector::<4>::from_fn(|r| j[(r, l)]).norm()).abs();
+    for column in 0..3 {
+        let scaled = (normal_right_hand_side[column]
+            / b_norm
+            / Vector::<4>::from_fn(|row| jacobian[(row, column)]).norm())
+        .abs();
         expected = expected.max(scaled);
     }
-    assert!((dls.max_a_t_b_scaled(b_norm) - expected).abs() < 1e-12);
+    assert!((damped.max_a_t_b_scaled(b_norm) - expected).abs() < 1e-12);
 
     // a_x_norm(x) is ‖J x‖.
-    let x = Vector::new([1.0, -2.0, 0.5]);
-    assert!((dls.a_x_norm(&x) - (j * x).norm()).abs() < 1e-12);
+    let candidate = Vector::new([1.0, -2.0, 0.5]);
+    assert!((damped.a_x_norm(&candidate) - (jacobian * candidate).norm()).abs() < 1e-12);
 
     // is_non_singular: true for the full-rank problem, false once a column goes to zero.
-    assert!(dls.is_non_singular());
+    assert!(damped.is_non_singular());
     let deficient = Matrix::<4, 3>::new([
         [1.0, 0.0, 2.0],
         [3.0, 0.0, 4.0],
@@ -139,7 +151,7 @@ fn damped_accessors() {
     assert!(
         !PivotedQr::decompose(deficient)
             .unwrap()
-            .into_damped(b)
+            .into_damped(right_hand_side)
             .is_non_singular()
     );
 }
@@ -147,46 +159,47 @@ fn damped_accessors() {
 #[test]
 fn qr_fits_vandermonde_polynomial() {
     // Fit a degree-6 polynomial to 20 points on [-1, 1] by QR least squares.
-    let node = |i: usize| -1.0 + 2.0 * i as f64 / 19.0;
-    let vandermonde = Matrix::<20, 7>::from_fn(|i, j| {
-        let t = node(i);
-        (0..j).fold(1.0, |acc, _| acc * t)
+    let node = |index: usize| -1.0 + 2.0 * index as f64 / 19.0;
+    let vandermonde = Matrix::<20, 7>::from_fn(|row, column| {
+        let node_value = node(row);
+        (0..column).fold(1.0, |power, _| power * node_value)
     });
-    let coeffs = [0.5, -1.2, 2.0, 0.3, -0.8, 1.1, -0.4];
-    let b = vandermonde * Vector::new(coeffs);
+    let coefficients = [0.5, -1.2, 2.0, 0.3, -0.8, 1.1, -0.4];
+    let right_hand_side = vandermonde * Vector::new(coefficients);
 
-    let x = PivotedQr::decompose(vandermonde)
+    let solution = PivotedQr::decompose(vandermonde)
         .unwrap()
-        .solve_least_squares(b)
+        .solve_least_squares(right_hand_side)
         .unwrap();
 
     // Every coefficient is recovered and the fit reproduces the samples.
-    for (got, want) in x.into_array().iter().zip(coeffs.iter()) {
+    for (got, want) in solution.into_array().iter().zip(coefficients.iter()) {
         assert!((got - want).abs() < 1e-7, "got {got}, want {want}");
     }
-    assert!((vandermonde * x - b).norm() < 1e-10);
+    assert!((vandermonde * solution - right_hand_side).norm() < 1e-10);
 }
 
 #[test]
 fn qr_factorizes_hilbert_stably() {
     // The Hilbert matrix is famously ill-conditioned (cond(H_8) is about 1.5e10).
-    let hilbert = Matrix::<8, 8>::from_fn(|i, j| 1.0 / ((i + j + 1) as f64));
-    let f = PivotedQr::decompose(hilbert).unwrap();
-    let perm = f.permutation();
-    let q = f.q();
-    let r = f.r();
+    let hilbert = Matrix::<8, 8>::from_fn(|row, column| 1.0 / ((row + column + 1) as f64));
+    let factorization = PivotedQr::decompose(hilbert).unwrap();
+    let permutation = factorization.permutation();
+    let q = factorization.q();
+    let r = factorization.r();
 
     // The factorization stays backward-stable regardless of conditioning.
     assert_identity(q.transpose() * q, 1e-12);
-    let ap = Matrix::<8, 8>::from_fn(|i, c| hilbert[(i, perm[c])]);
-    assert_matrix_close(q * r, ap, 1e-12);
+    let column_permuted =
+        Matrix::<8, 8>::from_fn(|row, column| hilbert[(row, permutation[column])]);
+    assert_matrix_close(q * r, column_permuted, 1e-12);
 
     // Solving is backward-stable (tiny residual) though the solution itself degrades.
-    let x_true = [1.0; 8];
-    let b = hilbert * Vector::new(x_true);
-    let x = f.solve_least_squares(b).unwrap();
-    assert!((hilbert * x - b).norm() < 1e-12);
-    for value in x.into_array() {
+    let true_coefficients = [1.0; 8];
+    let right_hand_side = hilbert * Vector::new(true_coefficients);
+    let solution = factorization.solve_least_squares(right_hand_side).unwrap();
+    assert!((hilbert * solution - right_hand_side).norm() < 1e-12);
+    for value in solution.into_array() {
         assert!((value - 1.0).abs() < 1e-2);
     }
 }
@@ -195,28 +208,33 @@ fn qr_factorizes_hilbert_stably() {
 fn damped_solves_ridge_regression() {
     // Ridge (Tikhonov) regression on an ill-conditioned Vandermonde design:
     // (VᵀV + λ²I) x = Vᵀb, which is exactly the damped solve with a constant diagonal.
-    let node = |i: usize| -1.0 + 2.0 * i as f64 / 14.0;
-    let v = Matrix::<15, 8>::from_fn(|i, j| {
-        let t = node(i);
-        (0..j).fold(1.0, |acc, _| acc * t)
+    let node = |index: usize| -1.0 + 2.0 * index as f64 / 14.0;
+    let design = Matrix::<15, 8>::from_fn(|row, column| {
+        let node_value = node(row);
+        (0..column).fold(1.0, |power, _| power * node_value)
     });
-    let x_true = [0.4, 1.0, -0.6, 0.9, -1.3, 0.5, 0.7, -0.2];
-    let b = v * Vector::new(x_true);
-    let lambda = 0.1;
+    let true_coefficients = [0.4, 1.0, -0.6, 0.9, -1.3, 0.5, 0.7, -0.2];
+    let right_hand_side = design * Vector::new(true_coefficients);
+    let ridge_parameter = 0.1;
 
-    let (x, _) = PivotedQr::decompose(v)
+    let (solution, _) = PivotedQr::decompose(design)
         .unwrap()
-        .into_damped(b)
-        .solve_with_diagonal(&[lambda; 8]);
+        .into_damped(right_hand_side)
+        .solve_with_diagonal(&[ridge_parameter; 8]);
 
     // x satisfies the regularized normal equations.
-    let vtv = v.transpose() * v;
-    let vtb = v.transpose() * b;
-    let lhs =
-        Matrix::<8, 8>::from_fn(|r, c| vtv[(r, c)] + if r == c { lambda * lambda } else { 0.0 })
-            * x;
-    for i in 0..8 {
-        assert!((lhs[i] - vtb[i]).abs() < 1e-8);
+    let normal_matrix = design.transpose() * design;
+    let normal_right_hand_side = design.transpose() * right_hand_side;
+    let left_side = Matrix::<8, 8>::from_fn(|row, column| {
+        normal_matrix[(row, column)]
+            + if row == column {
+                ridge_parameter * ridge_parameter
+            } else {
+                0.0
+            }
+    }) * solution;
+    for index in 0..8 {
+        assert!((left_side[index] - normal_right_hand_side[index]).abs() < 1e-8);
     }
 }
 
@@ -234,31 +252,33 @@ fn damped_solves_ridge_regression() {
 fn check_qr_property<const M: usize, const N: usize>(
     entries: Vec<f64>,
 ) -> Result<(), TestCaseError> {
-    let a = Matrix::<M, N>::try_from_row_slice(&entries).expect("M*N entries");
-    let scale = max_abs(a).max(1.0);
+    let matrix = Matrix::<M, N>::try_from_row_slice(&entries).expect("M*N entries");
+    let scale = max_abs(matrix).max(1.0);
 
     // M >= N is guaranteed by the generators below, so this never hits `Underdetermined`.
-    let f = PivotedQr::decompose(a).unwrap();
-    let r = f.r();
-    let q = f.q();
-    let perm = f.permutation();
+    let factorization = PivotedQr::decompose(matrix).unwrap();
+    let r = factorization.r();
+    let q = factorization.q();
+    let permutation = factorization.permutation();
 
-    let min_diag = (0..N).fold(f64::MAX, |acc, j| acc.min(r[(j, j)].abs()));
-    prop_assume!(min_diag >= 1e-6 * scale);
+    let minimum_diagonal = (0..N).fold(f64::MAX, |smallest, index| {
+        smallest.min(r[(index, index)].abs())
+    });
+    prop_assume!(minimum_diagonal >= 1e-6 * scale);
 
-    let tol = M.max(N) as f64 * scale * f64::EPSILON * 1e3;
+    let tolerance = M.max(N) as f64 * scale * f64::EPSILON * 1e3;
 
     // R is upper-triangular by construction; check anyway as a structural guard.
     for row in 0..N {
-        for col in 0..row {
-            assert_eq!(r[(row, col)], 0.0);
+        for column in 0..row {
+            assert_eq!(r[(row, column)], 0.0);
         }
     }
 
-    assert_identity(q.transpose() * q, tol);
+    assert_identity(q.transpose() * q, tolerance);
 
-    let ap = Matrix::<M, N>::from_fn(|i, c| a[(i, perm[c])]);
-    assert_matrix_close(q * r, ap, tol);
+    let column_permuted = Matrix::<M, N>::from_fn(|row, column| matrix[(row, permutation[column])]);
+    assert_matrix_close(q * r, column_permuted, tolerance);
 
     Ok(())
 }

--- a/crates/multicalc/tests/suite/linear_algebra/svd.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/svd.rs
@@ -26,21 +26,21 @@ fn svd_reconstructs_various() {
     );
     // Larger, well-conditioned tall matrices.
     svd_reconstructs(
-        Matrix::<12, 6>::from_fn(|i, j| {
-            if i == j {
+        Matrix::<12, 6>::from_fn(|row, column| {
+            if row == column {
                 10.0
             } else {
-                1.0 / (1.0 + (i + j) as f64)
+                1.0 / (1.0 + (row + column) as f64)
             }
         }),
         1e-12,
     );
     svd_reconstructs(
-        Matrix::<20, 6>::from_fn(|i, j| {
-            if i == j {
+        Matrix::<20, 6>::from_fn(|row, column| {
+            if row == column {
                 8.0
             } else {
-                (i as f64 - j as f64) / (5.0 + (i + j) as f64)
+                (row as f64 - column as f64) / (5.0 + (row + column) as f64)
             }
         }),
         1e-12,
@@ -56,28 +56,31 @@ fn svd_reconstructs_various() {
 fn svd_singular_values() {
     // A symmetric matrix built from a known spectrum: A = R·diag(σ)·Rᵀ with R a proper rotation,
     // so the singular values are exactly [6, 3, 1].
-    let r = Matrix::<3, 3>::new([
+    let rotation = Matrix::<3, 3>::new([
         [2.0 / 3.0, -2.0 / 3.0, -1.0 / 3.0],
         [1.0 / 3.0, 2.0 / 3.0, -2.0 / 3.0],
         [2.0 / 3.0, 1.0 / 3.0, 2.0 / 3.0],
     ]);
-    let d = Matrix::<3, 3>::new([[6.0, 0.0, 0.0], [0.0, 3.0, 0.0], [0.0, 0.0, 1.0]]);
-    let s = (r * d * r.transpose()).svd().unwrap().singular_values();
-    for (k, want) in [6.0, 3.0, 1.0].into_iter().enumerate() {
-        assert!((s[k] - want).abs() < 1e-12);
+    let spectrum = Matrix::<3, 3>::new([[6.0, 0.0, 0.0], [0.0, 3.0, 0.0], [0.0, 0.0, 1.0]]);
+    let singular_values = (rotation * spectrum * rotation.transpose())
+        .svd()
+        .unwrap()
+        .singular_values();
+    for (index, expected) in [6.0, 3.0, 1.0].into_iter().enumerate() {
+        assert!((singular_values[index] - expected).abs() < 1e-12);
     }
 
     // Diagonal input: singular values are the sorted absolute diagonal.
-    let diag = Matrix::<4, 4>::from_fn(|i, j| {
-        if i == j {
-            [3.0, -5.0, 2.0, -1.0][i]
+    let diagonal_matrix = Matrix::<4, 4>::from_fn(|row, column| {
+        if row == column {
+            [3.0, -5.0, 2.0, -1.0][row]
         } else {
             0.0
         }
     });
-    let s = diag.svd().unwrap().singular_values();
-    for (k, want) in [5.0, 3.0, 2.0, 1.0].into_iter().enumerate() {
-        assert!((s[k] - want).abs() < 1e-12);
+    let singular_values = diagonal_matrix.svd().unwrap().singular_values();
+    for (index, expected) in [5.0, 3.0, 2.0, 1.0].into_iter().enumerate() {
+        assert!((singular_values[index] - expected).abs() < 1e-12);
     }
 }
 
@@ -96,11 +99,11 @@ fn svd_pseudo_inverse_conditions() {
         1e-10,
     );
     svd_moore_penrose(
-        Matrix::<12, 6>::from_fn(|i, j| {
-            if i == j {
+        Matrix::<12, 6>::from_fn(|row, column| {
+            if row == column {
                 10.0
             } else {
-                1.0 / (1.0 + (i + j) as f64)
+                1.0 / (1.0 + (row + column) as f64)
             }
         }),
         1e-10,
@@ -135,26 +138,26 @@ fn svd_f32_pseudo_inverse_conditions() {
 #[test]
 fn svd_rank_deficient() {
     // Column 2 is twice column 1: rank 1, one exactly-zero singular value.
-    let a = Matrix::<3, 2>::new([[1.0, 2.0], [2.0, 4.0], [3.0, 6.0]]);
-    let f = a.svd().unwrap();
-    assert_eq!(f.rank(1e-9), 1);
-    assert!(f.condition_number().is_infinite());
+    let rank_one = Matrix::<3, 2>::new([[1.0, 2.0], [2.0, 4.0], [3.0, 6.0]]);
+    let factorization = rank_one.svd().unwrap();
+    assert_eq!(factorization.rank(1e-9), 1);
+    assert!(factorization.condition_number().is_infinite());
 
     // Truncated pseudo-inverse stays finite.
-    let ap = f.pseudo_inverse();
-    for r in 0..2 {
-        for c in 0..3 {
-            assert!(ap[(r, c)].is_finite());
+    let pseudo_inverse = factorization.pseudo_inverse();
+    for row in 0..2 {
+        for column in 0..3 {
+            assert!(pseudo_inverse[(row, column)].is_finite());
         }
     }
 
     // Consistent system: the min-norm solution reproduces the range and equals A⁺·b.
-    let b = a * Vector::new([1.0, 0.5]);
-    let x = f.solve(b);
-    assert!((a * x - b).norm() < 1e-10);
-    let x_pinv = ap * b;
-    for i in 0..2 {
-        assert!((x[i] - x_pinv[i]).abs() < 1e-12);
+    let right_hand_side = rank_one * Vector::new([1.0, 0.5]);
+    let solution = factorization.solve(right_hand_side);
+    assert!((rank_one * solution - right_hand_side).norm() < 1e-10);
+    let pseudo_inverse_solution = pseudo_inverse * right_hand_side;
+    for index in 0..2 {
+        assert!((solution[index] - pseudo_inverse_solution[index]).abs() < 1e-12);
     }
 }
 
@@ -165,24 +168,24 @@ fn svd_error_paths() {
     assert_eq!(wide.svd().err(), Some(LinalgError::Underdetermined));
 
     // Non-finite entries are rejected.
-    let mut nan = Matrix::<3, 2>::new([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]);
-    nan[(2, 1)] = f64::NAN;
-    assert_eq!(nan.svd().err(), Some(LinalgError::NonFinite));
-    let mut inf = Matrix::<3, 2>::new([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]);
-    inf[(0, 0)] = f64::INFINITY;
-    assert_eq!(inf.svd().err(), Some(LinalgError::NonFinite));
+    let mut with_nan = Matrix::<3, 2>::new([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]);
+    with_nan[(2, 1)] = f64::NAN;
+    assert_eq!(with_nan.svd().err(), Some(LinalgError::NonFinite));
+    let mut with_infinity = Matrix::<3, 2>::new([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]);
+    with_infinity[(0, 0)] = f64::INFINITY;
+    assert_eq!(with_infinity.svd().err(), Some(LinalgError::NonFinite));
 }
 
 #[test]
 fn svd_kabsch_rotation_recovery() {
     // A proper rotation (orthonormal, determinant +1).
-    let rot = Matrix::<3, 3>::new([
+    let rotation = Matrix::<3, 3>::new([
         [2.0 / 3.0, -2.0 / 3.0, -1.0 / 3.0],
         [1.0 / 3.0, 2.0 / 3.0, -2.0 / 3.0],
         [2.0 / 3.0, 1.0 / 3.0, 2.0 / 3.0],
     ]);
     // Body points spanning 3D.
-    let pts = [
+    let body_points = [
         [1.0, 0.0, 0.0],
         [0.0, 1.0, 0.0],
         [0.0, 0.0, 1.0],
@@ -194,120 +197,127 @@ fn svd_kabsch_rotation_recovery() {
         [-1.0, 0.5, 2.0],
     ];
     // Cross-covariance H = Σ (R·p) pᵀ.
-    let mut h = Matrix::<3, 3>::zeros();
-    for p in pts {
-        let pv = Vector::new(p);
-        let q = rot * pv;
-        for i in 0..3 {
-            for j in 0..3 {
-                h[(i, j)] += q[i] * pv[j];
+    let mut cross_covariance = Matrix::<3, 3>::zeros();
+    for body_point in body_points {
+        let point = Vector::new(body_point);
+        let rotated_point = rotation * point;
+        for row in 0..3 {
+            for column in 0..3 {
+                cross_covariance[(row, column)] += rotated_point[row] * point[column];
             }
         }
     }
-    let f = h.svd().unwrap();
-    let (u, v) = (f.u(), f.v());
-    let mut rhat = u * v.transpose();
+    let factorization = cross_covariance.svd().unwrap();
+    let u = factorization.u();
+    let v = factorization.v();
+    let mut recovered_rotation = u * v.transpose();
     // Reflection fix: guarantee a proper rotation.
-    if rhat.determinant() < 0.0 {
-        let mut uf = u;
-        for i in 0..3 {
-            uf[(i, 2)] = -uf[(i, 2)];
+    if recovered_rotation.determinant() < 0.0 {
+        let mut flipped_u = u;
+        for row in 0..3 {
+            flipped_u[(row, 2)] = -flipped_u[(row, 2)];
         }
-        rhat = uf * v.transpose();
+        recovered_rotation = flipped_u * v.transpose();
     }
     // Recovered rotation matches, is orthonormal, and has determinant +1.
-    assert_matrix_close(rhat, rot, 1e-9);
-    assert_identity(rhat.transpose() * rhat, 1e-12);
-    assert!((rhat.determinant() - 1.0).abs() < 1e-9);
+    assert_matrix_close(recovered_rotation, rotation, 1e-9);
+    assert_identity(recovered_rotation.transpose() * recovered_rotation, 1e-12);
+    assert!((recovered_rotation.determinant() - 1.0).abs() < 1e-9);
 }
 
 #[test]
 fn svd_redundant_jacobian_pseudo_inverse() {
     // A 6x7 manipulator Jacobian (7 joints -> 6-D task twist), full row rank.
-    let j = Matrix::<6, 7>::from_fn(|r, c| {
-        if c < 6 {
-            if r == c {
+    let jacobian = Matrix::<6, 7>::from_fn(|row, column| {
+        if column < 6 {
+            if row == column {
                 2.0
             } else {
-                0.3 / (1.0 + (r + c) as f64)
+                0.3 / (1.0 + (row + column) as f64)
             }
         } else {
-            0.5 * (r as f64 + 1.0)
+            0.5 * (row as f64 + 1.0)
         }
     });
-    let jp = j.pseudo_inverse().unwrap();
+    let pseudo_inverse = jacobian.pseudo_inverse().unwrap();
 
     // Moore–Penrose: J·J⁺·J == J and J·J⁺ symmetric.
-    assert_matrix_close(j * jp * j, j, 1e-9);
-    let jjp = j * jp;
-    assert_matrix_close(jjp, jjp.transpose(), 1e-12);
+    assert_matrix_close(jacobian * pseudo_inverse * jacobian, jacobian, 1e-9);
+    let jacobian_times_pseudo_inverse = jacobian * pseudo_inverse;
+    assert_matrix_close(
+        jacobian_times_pseudo_inverse,
+        jacobian_times_pseudo_inverse.transpose(),
+        1e-12,
+    );
 
     // Minimum-norm resolution: J⁺·v beats any other solution of J·x = v.
-    let vtwist = Vector::<6>::from_fn(|i| i as f64 - 2.5);
-    let x_min = jp * vtwist;
-    let n = Vector::<7>::from_fn(|i| (i as f64 - 3.0) * 0.7);
-    let jpjn = (jp * j) * n;
-    let x_other = Vector::<7>::from_fn(|i| x_min[i] + n[i] - jpjn[i]);
-    assert!((j * x_min - vtwist).norm() < 1e-9);
-    assert!((j * x_other - vtwist).norm() < 1e-9);
-    assert!(x_min.norm() <= x_other.norm() + 1e-9);
+    let task_twist = Vector::<6>::from_fn(|index| index as f64 - 2.5);
+    let minimum_norm_solution = pseudo_inverse * task_twist;
+    let null_space_offset = Vector::<7>::from_fn(|index| (index as f64 - 3.0) * 0.7);
+    let projected_offset = (pseudo_inverse * jacobian) * null_space_offset;
+    let alternative_solution = Vector::<7>::from_fn(|index| {
+        minimum_norm_solution[index] + null_space_offset[index] - projected_offset[index]
+    });
+    assert!((jacobian * minimum_norm_solution - task_twist).norm() < 1e-9);
+    assert!((jacobian * alternative_solution - task_twist).norm() < 1e-9);
+    assert!(minimum_norm_solution.norm() <= alternative_solution.norm() + 1e-9);
 }
 
 #[test]
 fn svd_near_singular_jacobian() {
     // A 6x6 Jacobian at a near-singularity: column 5 nearly equals column 4.
-    let mut j = Matrix::<6, 6>::from_fn(|i, jj| {
-        if i == jj {
-            1.0 + 0.1 * jj as f64
+    let mut jacobian = Matrix::<6, 6>::from_fn(|row, column| {
+        if row == column {
+            1.0 + 0.1 * column as f64
         } else {
-            0.2 / (1.0 + (i + jj) as f64)
+            0.2 / (1.0 + (row + column) as f64)
         }
     });
-    for r in 0..6 {
-        let j4 = j[(r, 4)];
-        j[(r, 5)] = j4 + 1e-8 * (r as f64 + 1.0);
+    for row in 0..6 {
+        let column_four_entry = jacobian[(row, 4)];
+        jacobian[(row, 5)] = column_four_entry + 1e-8 * (row as f64 + 1.0);
     }
-    let f = j.svd().unwrap();
-    let s = f.singular_values();
-    let tol = 1e-4 * s[0];
+    let factorization = jacobian.svd().unwrap();
+    let singular_values = factorization.singular_values();
+    let tolerance = 1e-4 * singular_values[0];
 
-    assert!(f.condition_number() > 1e6);
-    assert_eq!(f.rank(tol), 5);
+    assert!(factorization.condition_number() > 1e6);
+    assert_eq!(factorization.rank(tolerance), 5);
 
     // Truncated pseudo-inverse and solve stay finite (no blow-up on the tiny σ).
-    let jp = f.pseudo_inverse_tol(tol);
-    for r in 0..6 {
-        for c in 0..6 {
-            assert!(jp[(r, c)].is_finite());
+    let pseudo_inverse = factorization.pseudo_inverse_tol(tolerance);
+    for row in 0..6 {
+        for column in 0..6 {
+            assert!(pseudo_inverse[(row, column)].is_finite());
         }
     }
-    let x = f.solve(Vector::from_fn(|i| i as f64 + 1.0));
-    for i in 0..6 {
-        assert!(x[i].is_finite());
+    let solution = factorization.solve(Vector::from_fn(|index| index as f64 + 1.0));
+    for index in 0..6 {
+        assert!(solution[index].is_finite());
     }
 }
 
 #[test]
 fn svd_overdetermined_least_squares() {
     // Fit a plane z = a·x + b·y + c to 30 sampled points; solve vs the normal equations.
-    let sample = |i: usize| ((i as f64 * 0.37).sin(), (i as f64 * 0.53).cos());
-    let design = Matrix::<30, 3>::from_fn(|i, c| {
-        let (x, y) = sample(i);
-        match c {
+    let sample_point = |index: usize| ((index as f64 * 0.37).sin(), (index as f64 * 0.53).cos());
+    let design = Matrix::<30, 3>::from_fn(|row, column| {
+        let (x, y) = sample_point(row);
+        match column {
             0 => x,
             1 => y,
             _ => 1.0,
         }
     });
-    let rhs = Vector::<30>::from_fn(|i| {
-        let (x, y) = sample(i);
-        0.5 * x - 1.2 * y + 2.0 + 1e-3 * (i as f64 * 1.7).sin()
+    let rhs = Vector::<30>::from_fn(|index| {
+        let (x, y) = sample_point(index);
+        0.5 * x - 1.2 * y + 2.0 + 1e-3 * (index as f64 * 1.7).sin()
     });
-    let x_svd = design.svd().unwrap().solve(rhs);
-    let x_ne = (design.transpose() * design)
+    let svd_solution = design.svd().unwrap().solve(rhs);
+    let normal_equations_solution = (design.transpose() * design)
         .solve(design.transpose() * rhs)
         .unwrap();
-    for i in 0..3 {
-        assert!((x_svd[i] - x_ne[i]).abs() < 1e-9);
+    for index in 0..3 {
+        assert!((svd_solution[index] - normal_equations_solution[index]).abs() < 1e-9);
     }
 }

--- a/crates/multicalc/tests/suite/linear_algebra/vector.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/vector.rs
@@ -4,39 +4,39 @@ use multicalc::linear_algebra::{Matrix, Vector};
 
 #[test]
 fn construct_and_access() {
-    let v = Vector::new([1.0, 2.0, 3.0]);
-    assert_eq!(v.get(0), Some(&1.0));
-    assert_eq!(v.into_array(), [1.0, 2.0, 3.0]);
+    let vector = Vector::new([1.0, 2.0, 3.0]);
+    assert_eq!(vector.get(0), Some(&1.0));
+    assert_eq!(vector.into_array(), [1.0, 2.0, 3.0]);
 
-    let mut w = Vector::from([4.0, 5.0]);
-    if let Some(x) = w.get_mut(1) {
-        *x = 9.0;
+    let mut mutable = Vector::from([4.0, 5.0]);
+    if let Some(entry) = mutable.get_mut(1) {
+        *entry = 9.0;
     }
-    assert_eq!(w, Vector::new([4.0, 9.0]));
+    assert_eq!(mutable, Vector::new([4.0, 9.0]));
 
-    let z: Vector<3> = Vector::zeros();
-    assert_eq!(z, Vector::new([0.0, 0.0, 0.0]));
+    let zeros: Vector<3> = Vector::zeros();
+    assert_eq!(zeros, Vector::new([0.0, 0.0, 0.0]));
 
     assert_eq!(
-        Vector::<4>::from_fn(|i| i as f64),
+        Vector::<4>::from_fn(|index| index as f64),
         Vector::new([0.0, 1.0, 2.0, 3.0])
     );
 
-    let mut m = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
-    assert_eq!(m.get(1, 0), Some(&3.0));
-    if let Some(x) = m.get_mut(0, 1) {
-        *x = 7.0;
+    let mut matrix = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
+    assert_eq!(matrix.get(1, 0), Some(&3.0));
+    if let Some(entry) = matrix.get_mut(0, 1) {
+        *entry = 7.0;
     }
-    assert_eq!(m.get(0, 1), Some(&7.0));
+    assert_eq!(matrix.get(0, 1), Some(&7.0));
 
-    let id: Matrix<3, 3> = Matrix::identity();
+    let identity: Matrix<3, 3> = Matrix::identity();
     assert_eq!(
-        id.into_array(),
+        identity.into_array(),
         [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
     );
 
     assert_eq!(
-        Matrix::<2, 2>::from_fn(|r, c| (r * 2 + c) as f64),
+        Matrix::<2, 2>::from_fn(|row, column| (row * 2 + column) as f64),
         Matrix::new([[0.0, 1.0], [2.0, 3.0]])
     );
 }
@@ -58,66 +58,66 @@ fn try_from_slice_length() {
 
 #[test]
 fn get_checked_access() {
-    let v = Vector::new([1.0, 2.0, 3.0]);
-    assert_eq!(v.get(0), Some(&1.0));
-    assert_eq!(v.get(3), None);
+    let vector = Vector::new([1.0, 2.0, 3.0]);
+    assert_eq!(vector.get(0), Some(&1.0));
+    assert_eq!(vector.get(3), None);
 
-    let mut w = Vector::new([4.0, 5.0]);
-    if let Some(x) = w.get_mut(1) {
-        *x = 9.0;
+    let mut mutable = Vector::new([4.0, 5.0]);
+    if let Some(entry) = mutable.get_mut(1) {
+        *entry = 9.0;
     }
-    assert_eq!(w.get(1), Some(&9.0));
+    assert_eq!(mutable.get(1), Some(&9.0));
 
-    let mut m = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
-    assert_eq!(m.get(1, 0), Some(&3.0));
-    assert_eq!(m.get(2, 0), None);
-    assert_eq!(m.get(0, 2), None);
-    if let Some(x) = m.get_mut(0, 1) {
-        *x = 7.0;
+    let mut matrix = Matrix::new([[1.0, 2.0], [3.0, 4.0]]);
+    assert_eq!(matrix.get(1, 0), Some(&3.0));
+    assert_eq!(matrix.get(2, 0), None);
+    assert_eq!(matrix.get(0, 2), None);
+    if let Some(entry) = matrix.get_mut(0, 1) {
+        *entry = 7.0;
     }
-    assert_eq!(m.get(0, 1), Some(&7.0));
+    assert_eq!(matrix.get(0, 1), Some(&7.0));
 
-    m.as_mut_slice_rows()[1][1] = 8.0;
-    assert_eq!(m.get(1, 1), Some(&8.0));
+    matrix.as_mut_slice_rows()[1][1] = 8.0;
+    assert_eq!(matrix.get(1, 1), Some(&8.0));
 }
 
 // ----- vector arithmetic -----
 
 #[test]
 fn vector_arithmetic() {
-    let a = Vector::new([1.0, 2.0, 3.0]);
-    let b = Vector::new([4.0, 5.0, 6.0]);
+    let left = Vector::new([1.0, 2.0, 3.0]);
+    let right = Vector::new([4.0, 5.0, 6.0]);
 
-    assert_eq!(a + b, Vector::new([5.0, 7.0, 9.0]));
-    assert_eq!(b - a, Vector::new([3.0, 3.0, 3.0]));
-    assert_eq!(-a, Vector::new([-1.0, -2.0, -3.0]));
-    assert_eq!(a * 2.0, a.scale(2.0));
-    assert_eq!(a.scale(2.0), Vector::new([2.0, 4.0, 6.0]));
+    assert_eq!(left + right, Vector::new([5.0, 7.0, 9.0]));
+    assert_eq!(right - left, Vector::new([3.0, 3.0, 3.0]));
+    assert_eq!(-left, Vector::new([-1.0, -2.0, -3.0]));
+    assert_eq!(left * 2.0, left.scale(2.0));
+    assert_eq!(left.scale(2.0), Vector::new([2.0, 4.0, 6.0]));
 
-    let mut c = a;
-    c += b;
-    assert_eq!(c, a + b);
-    c -= b;
-    assert_eq!(c, a);
+    let mut accumulated = left;
+    accumulated += right;
+    assert_eq!(accumulated, left + right);
+    accumulated -= right;
+    assert_eq!(accumulated, left);
 }
 
 #[test]
 fn vector_dot_and_norm() {
-    let a: Vector<3> = Vector::new([1.0, 2.0, 3.0]);
-    let b: Vector<3> = Vector::new([4.0, 5.0, 6.0]);
-    assert_eq!(a.dot(b), 32.0);
-    assert!((a.dot(b) - b.dot(a)).abs() < 1e-12); // symmetry
+    let left: Vector<3> = Vector::new([1.0, 2.0, 3.0]);
+    let right: Vector<3> = Vector::new([4.0, 5.0, 6.0]);
+    assert_eq!(left.dot(right), 32.0);
+    assert!((left.dot(right) - right.dot(left)).abs() < 1e-12); // symmetry
     assert_eq!(Vector::new([1.0, 0.0]).dot(Vector::new([0.0, 1.0])), 0.0); // orthogonal
 
     let empty: Vector<0> = Vector::zeros();
     assert_eq!(empty.dot(empty), 0.0);
 
-    let v: Vector<2> = Vector::new([3.0, 4.0]);
-    assert_eq!(v.norm(), 5.0);
-    assert!((v.norm_squared() - v.norm() * v.norm()).abs() < 1e-12);
+    let vector: Vector<2> = Vector::new([3.0, 4.0]);
+    assert_eq!(vector.norm(), 5.0);
+    assert!((vector.norm_squared() - vector.norm() * vector.norm()).abs() < 1e-12);
 
-    let z: Vector<3> = Vector::zeros();
-    assert_eq!(z.norm(), 0.0);
+    let zeros: Vector<3> = Vector::zeros();
+    assert_eq!(zeros.norm(), 0.0);
     assert!(Vector::new([f64::INFINITY, 0.0]).norm().is_infinite());
 }
 
@@ -134,38 +134,42 @@ fn vector_is_finite() {
 
 #[test]
 fn vector_cross_3d() {
-    let x = Vector::new([1.0, 0.0, 0.0]);
-    let y = Vector::new([0.0, 1.0, 0.0]);
-    let z = Vector::new([0.0, 0.0, 1.0]);
-    assert_eq!(x.cross(y), z);
-    assert_eq!(y.cross(z), x);
-    assert_eq!(z.cross(x), y);
-    assert_eq!(x.cross(y), -(y.cross(x))); // anti-commutativity
+    let unit_x = Vector::new([1.0, 0.0, 0.0]);
+    let unit_y = Vector::new([0.0, 1.0, 0.0]);
+    let unit_z = Vector::new([0.0, 0.0, 1.0]);
+    assert_eq!(unit_x.cross(unit_y), unit_z);
+    assert_eq!(unit_y.cross(unit_z), unit_x);
+    assert_eq!(unit_z.cross(unit_x), unit_y);
+    assert_eq!(unit_x.cross(unit_y), -(unit_y.cross(unit_x))); // anti-commutativity
 
-    let a = Vector::new([1.0, 2.0, 3.0]);
-    let b = Vector::new([4.0, 5.0, 6.0]);
-    let axb = a.cross(b);
-    assert_eq!(a.dot(axb), 0.0); // orthogonal to both inputs
-    assert_eq!(b.dot(axb), 0.0);
+    let left = Vector::new([1.0, 2.0, 3.0]);
+    let right = Vector::new([4.0, 5.0, 6.0]);
+    let cross_product = left.cross(right);
+    assert_eq!(left.dot(cross_product), 0.0); // orthogonal to both inputs
+    assert_eq!(right.dot(cross_product), 0.0);
 }
 
 #[test]
 fn vector_cross_2d_and_scalar_triple() {
     assert_eq!(Vector::new([1.0, 0.0]).cross(Vector::new([0.0, 1.0])), 1.0);
-    let a: Vector<2> = Vector::new([2.0, 3.0]);
-    let b: Vector<2> = Vector::new([5.0, 7.0]);
-    assert!((a.cross(b) + b.cross(a)).abs() < 1e-12); // anti-commutativity
-    assert_eq!(a.cross(a), 0.0); // parallel
+    let left: Vector<2> = Vector::new([2.0, 3.0]);
+    let right: Vector<2> = Vector::new([5.0, 7.0]);
+    assert!((left.cross(right) + right.cross(left)).abs() < 1e-12); // anti-commutativity
+    assert_eq!(left.cross(left), 0.0); // parallel
 
-    let x = Vector::new([1.0, 0.0, 0.0]);
-    let y = Vector::new([0.0, 1.0, 0.0]);
-    let z = Vector::new([0.0, 0.0, 1.0]);
-    assert_eq!(x.scalar_triple(y, z), 1.0);
+    let unit_x = Vector::new([1.0, 0.0, 0.0]);
+    let unit_y = Vector::new([0.0, 1.0, 0.0]);
+    let unit_z = Vector::new([0.0, 0.0, 1.0]);
+    assert_eq!(unit_x.scalar_triple(unit_y, unit_z), 1.0);
 
-    let p: Vector<3> = Vector::new([1.0, 2.0, 3.0]);
-    let q: Vector<3> = Vector::new([0.0, 1.0, 4.0]);
-    let r: Vector<3> = Vector::new([5.0, 6.0, 0.0]);
-    assert!((p.scalar_triple(q, r) - q.scalar_triple(r, p)).abs() < 1e-12); // cyclic
-    let m = Matrix::new([p.into_array(), q.into_array(), r.into_array()]);
-    assert!((p.scalar_triple(q, r) - m.determinant()).abs() < 1e-12); // == det([p; q; r])
+    let first: Vector<3> = Vector::new([1.0, 2.0, 3.0]);
+    let second: Vector<3> = Vector::new([0.0, 1.0, 4.0]);
+    let third: Vector<3> = Vector::new([5.0, 6.0, 0.0]);
+    // cyclic
+    assert!(
+        (first.scalar_triple(second, third) - second.scalar_triple(third, first)).abs() < 1e-12
+    );
+    let rows_as_matrix = Matrix::new([first.into_array(), second.into_array(), third.into_array()]);
+    // equals the determinant of the matrix whose rows are the three vectors
+    assert!((first.scalar_triple(second, third) - rows_as_matrix.determinant()).abs() < 1e-12);
 }

--- a/crates/multicalc/tests/suite/main.rs
+++ b/crates/multicalc/tests/suite/main.rs
@@ -15,5 +15,6 @@ mod random;
 mod root_finding;
 mod scalar;
 mod spatial;
+mod support;
 mod utils;
 mod vector_field;

--- a/crates/multicalc/tests/suite/motion/polyline_path.rs
+++ b/crates/multicalc/tests/suite/motion/polyline_path.rs
@@ -54,7 +54,12 @@ fn single_point_path_projects_to_that_point() {
     let projection = path.closest_point(Vector::new([5.0, 6.0])).unwrap();
     assert_eq!(projection.segment_index(), 0);
     assert!((projection.distance() - 5.0).abs() < 1e-12);
-    let [x, y] = path.lookahead_point(0.0, 10.0).unwrap().into_array();
+    let from_arc_length = 0.0;
+    let lookahead = 10.0;
+    let [x, y] = path
+        .lookahead_point(from_arc_length, lookahead)
+        .unwrap()
+        .into_array();
     assert!((x - 2.0).abs() < 1e-12 && (y - 2.0).abs() < 1e-12);
 }
 
@@ -69,12 +74,16 @@ fn lookahead_advances_monotonically() {
     ])
     .unwrap();
     let mut previous_x = -1.0;
-    let mut from = 0.0;
-    while from <= 8.0 {
-        let [x, _] = path.lookahead_point(from, 1.0).unwrap().into_array();
+    let mut from_arc_length = 0.0;
+    let lookahead = 1.0;
+    while from_arc_length <= 8.0 {
+        let [x, _] = path
+            .lookahead_point(from_arc_length, lookahead)
+            .unwrap()
+            .into_array();
         assert!(x >= previous_x - 1e-12);
         previous_x = x;
-        from += 0.5;
+        from_arc_length += 0.5;
     }
 }
 
@@ -83,7 +92,12 @@ fn lookahead_inside_first_segment_is_exact_distance() {
     let path: PolylinePath<2, 2, f64> =
         PolylinePath::try_from_points(&[Vector::new([0.0, 0.0]), Vector::new([10.0, 0.0])])
             .unwrap();
-    let [x, y] = path.lookahead_point(0.0, 3.5).unwrap().into_array();
+    let from_arc_length = 0.0;
+    let lookahead = 3.5;
+    let [x, y] = path
+        .lookahead_point(from_arc_length, lookahead)
+        .unwrap()
+        .into_array();
     assert!((x - 3.5).abs() < 1e-12 && y.abs() < 1e-12);
 }
 
@@ -91,7 +105,12 @@ fn lookahead_inside_first_segment_is_exact_distance() {
 fn stop_clamps_past_the_end() {
     let path: PolylinePath<2, 2, f64> =
         PolylinePath::try_from_points(&[Vector::new([0.0, 0.0]), Vector::new([4.0, 0.0])]).unwrap();
-    let [x, y] = path.lookahead_point(0.0, 100.0).unwrap().into_array();
+    let from_arc_length = 0.0;
+    let lookahead = 100.0;
+    let [x, y] = path
+        .lookahead_point(from_arc_length, lookahead)
+        .unwrap()
+        .into_array();
     assert!((x - 4.0).abs() < 1e-12 && y.abs() < 1e-12);
 }
 
@@ -102,7 +121,12 @@ fn loop_wraps_past_the_end() {
             .unwrap()
             .with_end_of_path(EndOfPath::Loop);
     // Total length 4; a target of 5 wraps to 1.
-    let [x, y] = path.lookahead_point(0.0, 5.0).unwrap().into_array();
+    let from_arc_length = 0.0;
+    let lookahead = 5.0;
+    let [x, y] = path
+        .lookahead_point(from_arc_length, lookahead)
+        .unwrap()
+        .into_array();
     assert!((x - 1.0).abs() < 1e-12 && y.abs() < 1e-12);
 }
 
@@ -123,7 +147,12 @@ fn duplicate_waypoints_do_not_divide_by_zero() {
     assert!(projection.distance().is_finite());
     assert!((projection.arc_length() - 1.0).abs() < 1e-12);
 
-    let [x, y] = path.lookahead_point(0.0, 1.0).unwrap().into_array();
+    let from_arc_length = 0.0;
+    let lookahead = 1.0;
+    let [x, y] = path
+        .lookahead_point(from_arc_length, lookahead)
+        .unwrap()
+        .into_array();
     assert!(x.is_finite() && y.is_finite());
 }
 

--- a/crates/multicalc/tests/suite/numerical_derivative.rs
+++ b/crates/multicalc/tests/suite/numerical_derivative.rs
@@ -14,79 +14,116 @@ use std::cell::Cell;
 #[test]
 fn ad_single_derivative() {
     // f(x) = x^3 -> f' = 3x^2, f'' = 6x, f''' = 6
-    let func = scalar_fn!(|x| x * x * x);
-    let d = AutoDiffSingle::default();
+    let function = scalar_fn!(|x| x * x * x);
+    let derivator = AutoDiffSingle::default();
 
-    assert!(f64::abs(d.differentiate(1, &func, 2.0).unwrap() - 12.0) < 1e-12);
-    assert!(f64::abs(d.differentiate(2, &func, 2.0).unwrap() - 12.0) < 1e-12);
-    assert!(f64::abs(d.differentiate(3, &func, 2.0).unwrap() - 6.0) < 1e-12);
+    assert!(f64::abs(derivator.differentiate(1, &function, 2.0).unwrap() - 12.0) < 1e-12);
+    assert!(f64::abs(derivator.differentiate(2, &function, 2.0).unwrap() - 12.0) < 1e-12);
+    assert!(f64::abs(derivator.differentiate(3, &function, 2.0).unwrap() - 6.0) < 1e-12);
 }
 
 #[test]
 fn ad_first_partials() {
     // f(x, y) = 3x^2 + 2xy -> df/dx = 6x + 2y, df/dy = 2x
-    let func = scalar_fn!(|v: &[f64; 2]| c(3.0) * v[0] * v[0] + c(2.0) * v[0] * v[1]);
-    let d = AutoDiffMulti::default();
+    let function = scalar_fn!(|v: &[f64; 2]| c(3.0) * v[0] * v[0] + c(2.0) * v[0] * v[1]);
+    let derivator = AutoDiffMulti::default();
     let point = [1.0, 3.0];
 
-    assert!(f64::abs(d.first_partial_derivative(&func, 0, &point).unwrap() - 12.0) < 1e-12);
-    assert!(f64::abs(d.first_partial_derivative(&func, 1, &point).unwrap() - 2.0) < 1e-12);
+    let x = 0;
+    let partial_x = derivator
+        .first_partial_derivative(&function, x, &point)
+        .unwrap();
+    assert!(f64::abs(partial_x - 12.0) < 1e-12);
+
+    let y = 1;
+    let partial_y = derivator
+        .first_partial_derivative(&function, y, &point)
+        .unwrap();
+    assert!(f64::abs(partial_y - 2.0) < 1e-12);
 }
 
 #[test]
 fn ad_first_partials_transcendental() {
     // f(x, y, z) = y*sin(x) + x*cos(y) + x*y*e^z
-    let func = G;
-    let d = AutoDiffMulti::default();
+    let function = G;
+    let derivator = AutoDiffMulti::default();
     let point = [1.0, 2.0, 3.0];
 
     // df/dx = y*cos(x) + cos(y) + y*e^z
-    let dx = 2.0 * f64::cos(1.0) + f64::cos(2.0) + 2.0 * f64::exp(3.0);
-    assert!(f64::abs(d.first_partial_derivative(&func, 0, &point).unwrap() - dx) < 1e-12);
+    let x = 0;
+    let expected_dx = 2.0 * f64::cos(1.0) + f64::cos(2.0) + 2.0 * f64::exp(3.0);
+    let partial_x = derivator
+        .first_partial_derivative(&function, x, &point)
+        .unwrap();
+    assert!(f64::abs(partial_x - expected_dx) < 1e-12);
 
     // df/dz = x*y*e^z
-    let dz = 1.0 * 2.0 * f64::exp(3.0);
-    assert!(f64::abs(d.first_partial_derivative(&func, 2, &point).unwrap() - dz) < 1e-12);
+    let z = 2;
+    let expected_dz = 1.0 * 2.0 * f64::exp(3.0);
+    let partial_z = derivator
+        .first_partial_derivative(&function, z, &point)
+        .unwrap();
+    assert!(f64::abs(partial_z - expected_dz) < 1e-12);
 }
 
 #[test]
 fn ad_second_partials() {
     // f(x, y, z) = y*sin(x) + x*cos(y) + x*y*e^z
-    let func = G;
-    let d = AutoDiffMulti::default();
+    let function = G;
+    let derivator = AutoDiffMulti::default();
     let point = [1.0, 2.0, 3.0];
 
+    let x = 0;
+    let y = 1;
+
     // d2f/dx2 = -y*sin(x)
-    let dxx = -2.0 * f64::sin(1.0);
-    assert!(f64::abs(d.second_partial_derivative(&func, &[0, 0], &point).unwrap() - dxx) < 1e-12);
+    let expected_dxx = -2.0 * f64::sin(1.0);
+    let partial_xx = derivator
+        .second_partial_derivative(&function, &[x, x], &point)
+        .unwrap();
+    assert!(f64::abs(partial_xx - expected_dxx) < 1e-12);
 
     // mixed d2f/dx dy = cos(x) - sin(y) + e^z
-    let dxy = f64::cos(1.0) - f64::sin(2.0) + f64::exp(3.0);
-    assert!(f64::abs(d.second_partial_derivative(&func, &[0, 1], &point).unwrap() - dxy) < 1e-12);
+    let expected_dxy = f64::cos(1.0) - f64::sin(2.0) + f64::exp(3.0);
+    let partial_xy = derivator
+        .second_partial_derivative(&function, &[x, y], &point)
+        .unwrap();
+    assert!(f64::abs(partial_xy - expected_dxy) < 1e-12);
 }
 
 #[test]
 fn ad_third_partials() {
     // f = x^3 y^3 z^3:  d3/dx dy dz = 27 x^2 y^2 z^2 = 972;  d3/dx2 dy = 18 x y^2 z^3 = 1944
-    let func = scalar_fn!(|v: &[f64; 3]| v[0].powi(3) * v[1].powi(3) * v[2].powi(3));
-    let d = AutoDiffMulti::default();
+    let function = scalar_fn!(|v: &[f64; 3]| v[0].powi(3) * v[1].powi(3) * v[2].powi(3));
+    let derivator = AutoDiffMulti::default();
     let point = [1.0, 2.0, 3.0];
 
-    assert!(f64::abs(d.differentiate(&func, &[0, 1, 2], &point).unwrap() - 972.0) < 1e-9);
-    assert!(f64::abs(d.differentiate(&func, &[0, 0, 1], &point).unwrap() - 1944.0) < 1e-9);
+    let x = 0;
+    let y = 1;
+    let z = 2;
+
+    let mixed_xyz = derivator
+        .differentiate(&function, &[x, y, z], &point)
+        .unwrap();
+    assert!(f64::abs(mixed_xyz - 972.0) < 1e-9);
+
+    let mixed_xxy = derivator
+        .differentiate(&function, &[x, x, y], &point)
+        .unwrap();
+    assert!(f64::abs(mixed_xxy - 1944.0) < 1e-9);
 }
 
 #[test]
 fn ad_jacobian() {
     // (x*y*z, x^2 + y^2)
-    let f = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
+    let function = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
     let jacobian: Jacobian = Jacobian::default();
-    let result = jacobian.evaluate(&f, &[1.0, 2.0, 3.0]).unwrap();
+    let result = jacobian.evaluate(&function, &[1.0, 2.0, 3.0]).unwrap();
 
     let expected = [[6.0, 3.0, 2.0], [2.0, 4.0, 0.0]];
-    for (i, row) in expected.iter().enumerate() {
-        for (j, &want) in row.iter().enumerate() {
-            assert!(f64::abs(result[(i, j)] - want) < 1e-12);
+    for (row, expected_row) in expected.iter().enumerate() {
+        for (column, &expected_entry) in expected_row.iter().enumerate() {
+            assert!(f64::abs(result[(row, column)] - expected_entry) < 1e-12);
         }
     }
 }
@@ -94,14 +131,16 @@ fn ad_jacobian() {
 #[test]
 #[cfg(feature = "alloc")]
 fn ad_jacobian_on_heap() {
-    let f = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
+    let function = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
     let jacobian: Jacobian = Jacobian::default();
-    let result = jacobian.evaluate_on_heap(&f, &[1.0, 2.0, 3.0]).unwrap();
+    let result = jacobian
+        .evaluate_on_heap(&function, &[1.0, 2.0, 3.0])
+        .unwrap();
 
     let expected = [[6.0, 3.0, 2.0], [2.0, 4.0, 0.0]];
-    for (i, row) in expected.iter().enumerate() {
-        for (j, &want) in row.iter().enumerate() {
-            assert!(f64::abs(result[i][j] - want) < 1e-12);
+    for (row, expected_row) in expected.iter().enumerate() {
+        for (column, &expected_entry) in expected_row.iter().enumerate() {
+            assert!(f64::abs(result[row][column] - expected_entry) < 1e-12);
         }
     }
 }
@@ -109,17 +148,17 @@ fn ad_jacobian_on_heap() {
 #[test]
 fn ad_hessian() {
     // f(x, y) = y*sin(x) + 2*x*e^y
-    let func = scalar_fn!(|v: &[f64; 2]| v[1] * v[0].sin() + c(2.0) * v[0] * v[1].exp());
+    let function = scalar_fn!(|v: &[f64; 2]| v[1] * v[0].sin() + c(2.0) * v[0] * v[1].exp());
     let hessian: Hessian = Hessian::default();
-    let result = hessian.evaluate(&func, &[1.0, 2.0]).unwrap();
+    let result = hessian.evaluate(&function, &[1.0, 2.0]).unwrap();
 
     let expected = [
         [-2.0 * f64::sin(1.0), f64::cos(1.0) + 2.0 * f64::exp(2.0)],
         [f64::cos(1.0) + 2.0 * f64::exp(2.0), 2.0 * f64::exp(2.0)],
     ];
-    for (i, row) in expected.iter().enumerate() {
-        for (j, &want) in row.iter().enumerate() {
-            assert!(f64::abs(result[(i, j)] - want) < 1e-12);
+    for (row, expected_row) in expected.iter().enumerate() {
+        for (column, &expected_entry) in expected_row.iter().enumerate() {
+            assert!(f64::abs(result[(row, column)] - expected_entry) < 1e-12);
         }
     }
 }
@@ -127,28 +166,30 @@ fn ad_hessian() {
 #[test]
 fn ad_f32() {
     // x*x at 0.5; first derivative 2x = 1.0, exact under autodiff
-    let func = scalar_fn!(|x| x * x);
-    let d = AutoDiffSingle::<f32>::default();
-    assert!(f32::abs(d.differentiate(1, &func, 0.5_f32).unwrap() - 1.0) < 1e-6);
+    let function = scalar_fn!(|x| x * x);
+    let derivator = AutoDiffSingle::<f32>::default();
+    assert!(f32::abs(derivator.differentiate(1, &function, 0.5_f32).unwrap() - 1.0) < 1e-6);
 }
 
 // ----- autodiff error handling -----
 
 #[test]
 fn ad_error_index_out_of_range() {
-    let func = scalar_fn!(|v: &[f64; 3]| v[0] + v[1] + v[2]);
-    let d = AutoDiffMulti::default();
-    let result = d.first_partial_derivative(&func, 5, &[1.0, 2.0, 3.0]);
+    let function = scalar_fn!(|v: &[f64; 3]| v[0] + v[1] + v[2]);
+    let derivator = AutoDiffMulti::default();
+    let result = derivator.first_partial_derivative(&function, 5, &[1.0, 2.0, 3.0]);
     assert_eq!(result.unwrap_err(), DiffError::IndexOutOfRange);
 }
 
 #[test]
 fn ad_error_order_zero() {
-    let func = scalar_fn!(|v: &[f64; 3]| v[0] + v[1] + v[2]);
-    let d = AutoDiffMulti::default();
-    let idx: [usize; 0] = [];
+    let function = scalar_fn!(|v: &[f64; 3]| v[0] + v[1] + v[2]);
+    let derivator = AutoDiffMulti::default();
+    let variable_indices: [usize; 0] = [];
     assert_eq!(
-        d.differentiate(&func, &idx, &[1.0, 2.0, 3.0]).unwrap_err(),
+        derivator
+            .differentiate(&function, &variable_indices, &[1.0, 2.0, 3.0])
+            .unwrap_err(),
         DiffError::OrderZero
     );
 }
@@ -156,10 +197,11 @@ fn ad_error_order_zero() {
 #[test]
 fn ad_error_order_unsupported() {
     // autodiff multi caps at third order; a fourth-order partial is rejected
-    let func = scalar_fn!(|v: &[f64; 3]| v[0] + v[1] + v[2]);
-    let d = AutoDiffMulti::default();
+    let function = scalar_fn!(|v: &[f64; 3]| v[0] + v[1] + v[2]);
+    let derivator = AutoDiffMulti::default();
     assert_eq!(
-        d.differentiate(&func, &[0, 1, 2, 0], &[1.0, 2.0, 3.0])
+        derivator
+            .differentiate(&function, &[0, 1, 2, 0], &[1.0, 2.0, 3.0])
             .unwrap_err(),
         DiffError::OrderUnsupported
     );
@@ -189,48 +231,53 @@ struct CountingVectorFn {
 }
 
 impl VectorFn<3, 2> for CountingVectorFn {
-    fn eval<S: Numeric>(&self, p: &[S; 3]) -> [S; 2] {
+    fn eval<S: Numeric>(&self, point: &[S; 3]) -> [S; 2] {
         self.calls.set(self.calls.get() + 1);
         // (x*y*z, x^2 + y^2)
-        [p[0] * p[1] * p[2], p[0] * p[0] + p[1] * p[1]]
+        [
+            point[0] * point[1] * point[2],
+            point[0] * point[0] + point[1] * point[1],
+        ]
     }
 }
 
 #[test]
 fn ad_jacobian_is_column_seeded() {
-    let f = CountingVectorFn {
+    let counter = CountingVectorFn {
         calls: Cell::new(0),
     };
     let jacobian: Jacobian = Jacobian::default();
-    let result = jacobian.evaluate(&f, &[1.0, 2.0, 3.0]).unwrap();
+    let result = jacobian.evaluate(&counter, &[1.0, 2.0, 3.0]).unwrap();
 
     // values are unchanged from the old harness
     let expected = [[6.0, 3.0, 2.0], [2.0, 4.0, 0.0]];
-    for (i, row) in expected.iter().enumerate() {
-        for (j, &want) in row.iter().enumerate() {
-            assert!(f64::abs(result[(i, j)] - want) < 1e-12);
+    for (row, expected_row) in expected.iter().enumerate() {
+        for (column, &expected_entry) in expected_row.iter().enumerate() {
+            assert!(f64::abs(result[(row, column)] - expected_entry) < 1e-12);
         }
     }
 
     // one evaluation per input column (3), not per cell (2*3 = 6)
-    assert_eq!(f.calls.get(), 3);
+    assert_eq!(counter.calls.get(), 3);
 }
 
 #[test]
 fn ad_jacobian_column_reads_all_outputs() {
     // one seeded pass on input 0 gives d/dx of both outputs: [y*z, 2x] = [6, 2]
-    let f = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
-    let d = AutoDiffMulti::default();
-    let column = d.jacobian_column(&f, 0, &[1.0, 2.0, 3.0]).unwrap();
+    let function = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
+    let derivator = AutoDiffMulti::default();
+    let column = derivator
+        .jacobian_column(&function, 0, &[1.0, 2.0, 3.0])
+        .unwrap();
     assert!(f64::abs(column[0] - 6.0) < 1e-12);
     assert!(f64::abs(column[1] - 2.0) < 1e-12);
 }
 
 #[test]
 fn ad_jacobian_column_index_out_of_range() {
-    let f = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
-    let d = AutoDiffMulti::default();
-    let result = d.jacobian_column(&f, 5, &[1.0, 2.0, 3.0]);
+    let function = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
+    let derivator = AutoDiffMulti::default();
+    let result = derivator.jacobian_column(&function, 5, &[1.0, 2.0, 3.0]);
     assert_eq!(result.unwrap_err(), DiffError::IndexOutOfRange);
 }
 
@@ -238,14 +285,14 @@ fn ad_jacobian_column_index_out_of_range() {
 fn fd_jacobian_column_matches() {
     // the finite-difference implementation produces the right matrix, matching the analytic
     // values to finite-difference tolerance (unchanged from the per-Component path it replaces)
-    let f = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
+    let function = scalar_fn_vec!(|v: &[f64; 3]| [v[0] * v[1] * v[2], v[0] * v[0] + v[1] * v[1]]);
     let jacobian = Jacobian::from_derivator(FiniteDifferenceMulti::default());
-    let result = jacobian.evaluate(&f, &[1.0, 2.0, 3.0]).unwrap();
+    let result = jacobian.evaluate(&function, &[1.0, 2.0, 3.0]).unwrap();
 
     let expected = [[6.0, 3.0, 2.0], [2.0, 4.0, 0.0]];
-    for (i, row) in expected.iter().enumerate() {
-        for (j, &want) in row.iter().enumerate() {
-            assert!(f64::abs(result[(i, j)] - want) < 1e-5);
+    for (row, expected_row) in expected.iter().enumerate() {
+        for (column, &expected_entry) in expected_row.iter().enumerate() {
+            assert!(f64::abs(result[(row, column)] - expected_entry) < 1e-5);
         }
     }
 }
@@ -254,12 +301,12 @@ fn fd_jacobian_column_matches() {
 fn fd_jacobian_is_column_seeded() {
     // central difference evaluates the full function twice per input column (2*3 = 6), not twice
     // per matrix cell (2*M*N = 12)
-    let f = CountingVectorFn {
+    let counter = CountingVectorFn {
         calls: Cell::new(0),
     };
     let jacobian = Jacobian::from_derivator(FiniteDifferenceMulti::default());
-    let _ = jacobian.evaluate(&f, &[1.0, 2.0, 3.0]).unwrap();
-    assert_eq!(f.calls.get(), 6);
+    let _ = jacobian.evaluate(&counter, &[1.0, 2.0, 3.0]).unwrap();
+    assert_eq!(counter.calls.get(), 6);
 }
 
 // ----- finite differences: kept as a sparse fallback for the engine and the cases autodiff
@@ -268,24 +315,26 @@ fn fd_jacobian_is_column_seeded() {
 #[test]
 fn fd_single_derivative_modes() {
     // x^2/2, derivative x; check all three finite-difference modes still work
-    let func = scalar_fn!(|x| c(0.5) * x * x);
+    let function = scalar_fn!(|x| c(0.5) * x * x);
     for mode in [
         FiniteDifferenceMode::Forward,
         FiniteDifferenceMode::Backward,
         FiniteDifferenceMode::Central,
     ] {
-        let mut d = FiniteDifferenceSingle::default();
-        d.config.method = mode;
-        assert!(f64::abs(d.differentiate(1, &func, 2.0).unwrap() - 2.0) < 0.001);
+        let mut derivator = FiniteDifferenceSingle::default();
+        derivator.config.method = mode;
+        assert!(f64::abs(derivator.differentiate(1, &function, 2.0).unwrap() - 2.0) < 0.001);
     }
 }
 
 #[test]
 fn fd_step_size_zero_error() {
-    let func = scalar_fn!(|v: &[f64; 3]| v[1] * v[0].sin());
-    let d = FiniteDifferenceMulti::from_parameters(0.0, FiniteDifferenceMode::Central, 1.0);
+    let function = scalar_fn!(|v: &[f64; 3]| v[1] * v[0].sin());
+    let derivator = FiniteDifferenceMulti::from_parameters(0.0, FiniteDifferenceMode::Central, 1.0);
     assert_eq!(
-        d.differentiate(&func, &[0], &[1.0, 2.0, 3.0]).unwrap_err(),
+        derivator
+            .differentiate(&function, &[0], &[1.0, 2.0, 3.0])
+            .unwrap_err(),
         DiffError::StepSizeZero
     );
 }
@@ -316,10 +365,16 @@ struct BivariatePoly {
 }
 
 impl ScalarFnN<2> for BivariatePoly {
-    fn eval<S: Numeric>(&self, p: &[S; 2]) -> S {
-        let (x, y) = (p[0], p[1]);
-        let c = |i| S::from_f64(self.coeffs[i]);
-        c(0) + c(1) * x + c(2) * y + c(3) * x * x + c(4) * x * y + c(5) * y * y
+    fn eval<S: Numeric>(&self, point: &[S; 2]) -> S {
+        let x = point[0];
+        let y = point[1];
+        let coefficient = |index| S::from_f64(self.coeffs[index]);
+        coefficient(0)
+            + coefficient(1) * x
+            + coefficient(2) * y
+            + coefficient(3) * x * x
+            + coefficient(4) * x * y
+            + coefficient(5) * y * y
     }
 }
 
@@ -342,15 +397,16 @@ proptest! {
         x in -2.0f64..2.0,
     ) {
         let scale = 1.0 + coeff_l1(&inner) + coeff_l1(&outer);
-        let f = PolyComp { inner, outer };
-        let h = DEFAULT_STEP_SIZE;
-        let ad = AutoDiffSingle::default().differentiate(1, &f, x).unwrap();
-        let fd = FiniteDifferenceSingle::default();
-        let fd_val = fd.differentiate(1, &f, x).unwrap();
-        let tol = ad_fd_tol(ad, h, 2, 1e3, scale);
+        let composed_polynomial = PolyComp { inner, outer };
+        let step = DEFAULT_STEP_SIZE;
+        let autodiff = AutoDiffSingle::default().differentiate(1, &composed_polynomial, x).unwrap();
+        let finite_difference_derivator = FiniteDifferenceSingle::default();
+        let finite_difference =
+            finite_difference_derivator.differentiate(1, &composed_polynomial, x).unwrap();
+        let tolerance = ad_fd_tol(autodiff, step, 2, 1e3, scale);
         prop_assert!(
-            (fd_val - ad).abs() < tol,
-            "fd={fd_val} ad={ad} tol={tol} x={x}"
+            (finite_difference - autodiff).abs() < tolerance,
+            "fd={finite_difference} ad={autodiff} tol={tolerance} x={x}"
         );
     }
 
@@ -361,18 +417,20 @@ proptest! {
         y in -2.0f64..2.0,
     ) {
         let scale = 1.0 + coeff_l1(&coeffs);
-        let f = BivariatePoly { coeffs };
+        let bivariate = BivariatePoly { coeffs };
         let point = [x, y];
-        let h = DEFAULT_STEP_SIZE;
-        let ad_d = AutoDiffMulti::default();
-        let fd_d = FiniteDifferenceMulti::default();
-        for idx in [0usize, 1] {
-            let ad = ad_d.first_partial_derivative(&f, idx, &point).unwrap();
-            let fd_val = fd_d.first_partial_derivative(&f, idx, &point).unwrap();
-            let tol = ad_fd_tol(ad, h, 2, 1e3, scale);
+        let step = DEFAULT_STEP_SIZE;
+        let autodiff_derivator = AutoDiffMulti::default();
+        let finite_difference_derivator = FiniteDifferenceMulti::default();
+        for variable_index in [0usize, 1] {
+            let autodiff =
+                autodiff_derivator.first_partial_derivative(&bivariate, variable_index, &point).unwrap();
+            let finite_difference =
+                finite_difference_derivator.first_partial_derivative(&bivariate, variable_index, &point).unwrap();
+            let tolerance = ad_fd_tol(autodiff, step, 2, 1e3, scale);
             prop_assert!(
-                (fd_val -ad).abs() < tol,
-                "idx={idx} fd={fd_val} ad={ad} tol={tol}"
+                (finite_difference - autodiff).abs() < tolerance,
+                "idx={variable_index} fd={finite_difference} ad={autodiff} tol={tolerance}"
             );
         }
     }

--- a/crates/multicalc/tests/suite/numerical_integration.rs
+++ b/crates/multicalc/tests/suite/numerical_integration.rs
@@ -6,321 +6,303 @@ use multicalc::numerical_integration::*;
 use proptest::prelude::*;
 
 #[test]
-fn test_booles_integration_1() {
-    //equation is 2.0*x
-    let func = |args: f64| -> f64 { 2.0 * args };
+fn booles_rule_integrates_a_line_to_its_closed_form() {
+    // closed form of 2x is x*x
+    let line = |x: f64| -> f64 { 2.0 * x };
+    let limits = [0.0, 2.0];
+    let interval_count = 100;
+    let integrator = IterativeSingle::from_parameters(interval_count, IterativeMethod::Booles);
 
-    let integration_limit = [0.0, 2.0];
-
-    let integrator = IterativeSingle::from_parameters(100, IterativeMethod::Booles);
-
-    //simple integration for x, known to be x*x, expect a value of ~4.00
-    let val = integrator
-        .single_integral(&func, &integration_limit)
-        .unwrap();
-    assert!(f64::abs(val - 4.0) < 1e-14);
+    let expected = 4.0;
+    let area = integrator.single_integral(&line, &limits).unwrap();
+    assert!(f64::abs(area - expected) < 1e-14);
 }
 
 #[test]
-fn test_booles_integration_2() {
-    //equation is 2.0*x + y*z
-    let func = |args: &[f64; 3]| -> f64 { 2.0 * args[0] + args[1] * args[2] };
-
-    let integration_limit = [0.0, 1.0];
+fn booles_rule_takes_partial_integrals_in_each_variable() {
+    let function = |point: &[f64; 3]| -> f64 { 2.0 * point[0] + point[1] * point[2] };
     let point = [1.0, 2.0, 3.0];
+    let interval_count = 100;
+    let integrator = IterativeMulti::from_parameters(interval_count, IterativeMethod::Booles);
 
-    let integrator = IterativeMulti::from_parameters(100, IterativeMethod::Booles);
-
-    //partial integration for x, known to be x*x + x*y*z, expect a value of ~7.00
-    let val = integrator
-        .single_partial_integral(&func, 0, &integration_limit, &point)
+    // closed form in x is x*x + x*y*z
+    let x = 0;
+    let limits = [0.0, 1.0];
+    let expected = 7.0;
+    let partial = integrator
+        .single_partial_integral(&function, x, &limits, &point)
         .unwrap();
-    assert!(f64::abs(val - 7.0) < 1e-25);
+    assert!(f64::abs(partial - expected) < 1e-25);
 
-    let integration_limit = [0.0, 2.0];
-
-    //partial integration for y, known to be 2.0*x*y + y*y*z/2.0, expect a value of ~10.00
-    let val = integrator
-        .single_partial_integral(&func, 1, &integration_limit, &point)
+    // closed form in y is 2.0*x*y + y*y*z/2.0
+    let y = 1;
+    let limits = [0.0, 2.0];
+    let expected = 10.0;
+    let partial = integrator
+        .single_partial_integral(&function, y, &limits, &point)
         .unwrap();
-    assert!(f64::abs(val - 10.0) < 0.00001);
+    assert!(f64::abs(partial - expected) < 0.00001);
 
-    let integration_limit = [0.0, 3.0];
-
-    //partial integration for z, known to be 2.0*x*z + y*z*z/2.0, expect a value of ~15.0
-    let val = integrator
-        .single_partial_integral(&func, 2, &integration_limit, &point)
+    // closed form in z is 2.0*x*z + y*z*z/2.0
+    let z = 2;
+    let limits = [0.0, 3.0];
+    let expected = 15.0;
+    let partial = integrator
+        .single_partial_integral(&function, z, &limits, &point)
         .unwrap();
-    assert!(f64::abs(val - 15.0) < 0.00001);
+    assert!(f64::abs(partial - expected) < 0.00001);
 }
 
 #[test]
-fn test_booles_integration_3() {
-    //equation is 6.0*x
-    let func = |args: f64| -> f64 { 6.0 * args };
+fn booles_rule_double_integrates_a_line() {
+    let line = |x: f64| -> f64 { 6.0 * x };
+    let limits = [[0.0, 2.0], [0.0, 2.0]];
+    let interval_count = 20;
+    let integrator = IterativeSingle::from_parameters(interval_count, IterativeMethod::Booles);
 
-    let integration_limits = [[0.0, 2.0], [0.0, 2.0]];
-
-    let integrator = IterativeSingle::from_parameters(20, IterativeMethod::Booles);
-
-    //simple double integration for 6*x, expect a value of ~24.00
-    let val = integrator
-        .double_integral(&func, &integration_limits)
-        .unwrap();
-    assert!(f64::abs(val - 24.0) < 0.00001);
+    let expected = 24.0;
+    let volume = integrator.double_integral(&line, &limits).unwrap();
+    assert!(f64::abs(volume - expected) < 0.00001);
 }
 
 #[test]
-fn test_gauss_legendre_quadrature_integration_1() {
-    //equation is 4.0*x*x*x - 3.0*x*x
-    let func = |args: f64| -> f64 { 4.0 * args * args * args - 3.0 * args * args };
+fn gauss_legendre_integrates_a_cubic_exactly() {
+    // closed form of 4x³ - 3x² is x^4 - x^3
+    let cubic = |x: f64| -> f64 { 4.0 * x * x * x - 3.0 * x * x };
+    let limits = [0.0, 2.0];
+    let order = 4;
+    let integrator =
+        GaussianSingle::from_parameters(order, GaussianQuadratureMethod::GaussLegendre);
 
-    let integration_limit = [0.0, 2.0];
-
-    let integrator = GaussianSingle::from_parameters(4, GaussianQuadratureMethod::GaussLegendre);
-
-    //simple integration for x, known to be x^4 - x^3, expect a value of ~8.00
-    let val = integrator
-        .single_integral(&func, &integration_limit)
-        .unwrap();
-    assert!(f64::abs(val - 8.0) < 1e-14);
+    let expected = 8.0;
+    let area = integrator.single_integral(&cubic, &limits).unwrap();
+    assert!(f64::abs(area - expected) < 1e-14);
 }
 
 #[test]
-fn test_gauss_legendre_quadrature_integration_2() {
-    //equation is 2.0*x + y*z
-    let func = |args: &[f64; 3]| -> f64 { 2.0 * args[0] + args[1] * args[2] };
-
-    let integration_limit = [0.0, 1.0];
+fn gauss_legendre_takes_partial_integrals_in_each_variable() {
+    let function = |point: &[f64; 3]| -> f64 { 2.0 * point[0] + point[1] * point[2] };
     let point = [1.0, 2.0, 3.0];
+    let order = 2;
+    let integrator = GaussianMulti::from_parameters(order, GaussianQuadratureMethod::GaussLegendre);
 
-    let integrator = GaussianMulti::from_parameters(2, GaussianQuadratureMethod::GaussLegendre);
-
-    //partial integration for x, known to be x*x + x*y*z, expect a value of ~7.00
-    let val = integrator
-        .single_partial_integral(&func, 0, &integration_limit, &point)
+    // closed form in x is x*x + x*y*z
+    let x = 0;
+    let limits = [0.0, 1.0];
+    let expected = 7.0;
+    let partial = integrator
+        .single_partial_integral(&function, x, &limits, &point)
         .unwrap();
-    assert!(f64::abs(val - 7.0) < 1e-14);
+    assert!(f64::abs(partial - expected) < 1e-14);
 
-    let integration_limit = [0.0, 2.0];
-
-    //partial integration for y, known to be 2.0*x*y + y*y*z/2.0, expect a value of ~10.00
-    let val = integrator
-        .single_partial_integral(&func, 1, &integration_limit, &point)
+    // closed form in y is 2.0*x*y + y*y*z/2.0
+    let y = 1;
+    let limits = [0.0, 2.0];
+    let expected = 10.0;
+    let partial = integrator
+        .single_partial_integral(&function, y, &limits, &point)
         .unwrap();
-    assert!(f64::abs(val - 10.0) < 1e-14);
+    assert!(f64::abs(partial - expected) < 1e-14);
 
-    let integration_limit = [0.0, 3.0];
-
-    //partial integration for z, known to be 2.0*x*z + y*z*z/2.0, expect a value of ~15.0
-    let val = integrator
-        .single_partial_integral(&func, 2, &integration_limit, &point)
+    // closed form in z is 2.0*x*z + y*z*z/2.0
+    let z = 2;
+    let limits = [0.0, 3.0];
+    let expected = 15.0;
+    let partial = integrator
+        .single_partial_integral(&function, z, &limits, &point)
         .unwrap();
-    assert!(f64::abs(val - 15.0) < 1e-14);
+    assert!(f64::abs(partial - expected) < 1e-14);
 }
 
 #[test]
-fn test_gauss_legendre_quadrature_integration_3() {
-    //equation is 6.0*x
-    let func = |args: f64| -> f64 { 6.0 * args };
+fn gauss_legendre_double_integrates_a_line() {
+    let line = |x: f64| -> f64 { 6.0 * x };
+    let limits = [[0.0, 2.0], [0.0, 2.0]];
+    let order = 2;
+    let integrator =
+        GaussianSingle::from_parameters(order, GaussianQuadratureMethod::GaussLegendre);
 
-    let integration_limits = [[0.0, 2.0], [0.0, 2.0]];
-    let integrator = GaussianSingle::from_parameters(2, GaussianQuadratureMethod::GaussLegendre);
-
-    //simple double integration for 6*x, expect a value of ~24.00
-    let val = integrator
-        .double_integral(&func, &integration_limits)
-        .unwrap();
-    assert!(f64::abs(val - 24.0) < 1e-14);
+    let expected = 24.0;
+    let volume = integrator.double_integral(&line, &limits).unwrap();
+    assert!(f64::abs(volume - expected) < 1e-14);
 }
 
 #[test]
-fn test_simpsons_integration_1() {
-    //equation is 2.0*x
-    let func = |args: f64| -> f64 { 2.0 * args };
+fn simpsons_rule_integrates_a_line_to_its_closed_form() {
+    // closed form of 2x is x*x
+    let line = |x: f64| -> f64 { 2.0 * x };
+    let limits = [0.0, 2.0];
+    let interval_count = 200;
+    let integrator = IterativeSingle::from_parameters(interval_count, IterativeMethod::Simpsons);
 
-    let integration_limit = [0.0, 2.0];
-
-    let integrator = IterativeSingle::from_parameters(200, IterativeMethod::Simpsons);
-
-    //simple integration for x, known to be x*x, expect a value of ~4.00
-    let val = integrator
-        .single_integral(&func, &integration_limit)
-        .unwrap();
-    assert!(f64::abs(val - 4.0) < 0.05);
+    let expected = 4.0;
+    let area = integrator.single_integral(&line, &limits).unwrap();
+    assert!(f64::abs(area - expected) < 0.05);
 }
 
 #[test]
-fn test_simpsons_integration_2() {
-    //equation is 2.0*x + y*z
-    let func = |args: &[f64; 3]| -> f64 { 2.0 * args[0] + args[1] * args[2] };
-
-    let integration_limit = [0.0, 1.0];
+fn simpsons_rule_takes_partial_integrals_in_each_variable() {
+    let function = |point: &[f64; 3]| -> f64 { 2.0 * point[0] + point[1] * point[2] };
     let point = [1.0, 2.0, 3.0];
+    let interval_count = 200;
+    let integrator = IterativeMulti::from_parameters(interval_count, IterativeMethod::Simpsons);
 
-    let integrator = IterativeMulti::from_parameters(200, IterativeMethod::Simpsons);
-
-    //partial integration for x, known to be x*x + x*y*z, expect a value of ~7.00
-    let val = integrator
-        .single_partial_integral(&func, 0, &integration_limit, &point)
+    // closed form in x is x*x + x*y*z
+    let x = 0;
+    let limits = [0.0, 1.0];
+    let expected = 7.0;
+    let partial = integrator
+        .single_partial_integral(&function, x, &limits, &point)
         .unwrap();
-    assert!(f64::abs(val - 7.0) < 0.05);
+    assert!(f64::abs(partial - expected) < 0.05);
 
-    let integration_limit = [0.0, 2.0];
-
-    //partial integration for y, known to be 2.0*x*y + y*y*z/2.0, expect a value of ~10.00
-    let val = integrator
-        .single_partial_integral(&func, 1, &integration_limit, &point)
+    // closed form in y is 2.0*x*y + y*y*z/2.0
+    let y = 1;
+    let limits = [0.0, 2.0];
+    let expected = 10.0;
+    let partial = integrator
+        .single_partial_integral(&function, y, &limits, &point)
         .unwrap();
-    assert!(f64::abs(val - 10.0) < 0.05);
+    assert!(f64::abs(partial - expected) < 0.05);
 
-    let integration_limit = [0.0, 3.0];
-
-    //partial integration for z, known to be 2.0*x*z + y*z*z/2.0, expect a value of ~15.0
-    let val = integrator
-        .single_partial_integral(&func, 2, &integration_limit, &point)
+    // closed form in z is 2.0*x*z + y*z*z/2.0
+    let z = 2;
+    let limits = [0.0, 3.0];
+    let expected = 15.0;
+    let partial = integrator
+        .single_partial_integral(&function, z, &limits, &point)
         .unwrap();
-    assert!(f64::abs(val - 15.0) < 0.05);
+    assert!(f64::abs(partial - expected) < 0.05);
 }
 
 #[test]
-fn test_simpsons_integration_3() {
-    //equation is 6.0*x
-    let func = |args: f64| -> f64 { 6.0 * args };
+fn simpsons_rule_double_integrates_a_line() {
+    let line = |x: f64| -> f64 { 6.0 * x };
+    let limits = [[0.0, 2.0], [0.0, 2.0]];
+    let interval_count = 200;
+    let integrator = IterativeSingle::from_parameters(interval_count, IterativeMethod::Simpsons);
 
-    let integration_limits = [[0.0, 2.0], [0.0, 2.0]];
-
-    let integrator = IterativeSingle::from_parameters(200, IterativeMethod::Simpsons);
-
-    //simple double integration for 6*x, expect a value of ~24.00
-    let val = integrator
-        .double_integral(&func, &integration_limits)
-        .unwrap();
-    assert!(f64::abs(val - 24.0) < 0.05);
+    let expected = 24.0;
+    let volume = integrator.double_integral(&line, &limits).unwrap();
+    assert!(f64::abs(volume - expected) < 0.05);
 }
 
 #[test]
-fn test_simpsons_integration_4() {
-    //equation is 2.0*x + y*z
-    let func = |args: &[f64; 3]| -> f64 { 2.0 * args[0] + args[1] * args[2] };
-
-    let integration_limits = [[0.0, 1.0], [0.0, 1.0]];
+fn simpsons_rule_takes_a_double_partial_integral() {
+    let function = |point: &[f64; 3]| -> f64 { 2.0 * point[0] + point[1] * point[2] };
     let point = [1.0, 1.0, 1.0];
+    let interval_count = 200;
+    let integrator = IterativeMulti::from_parameters(interval_count, IterativeMethod::Simpsons);
 
-    let integrator = IterativeMulti::from_parameters(200, IterativeMethod::Simpsons);
-
-    //double partial integration for first x then y, expect a value of ~1.50
-    let val = integrator
-        .double_partial_integral(&func, [0, 1], &integration_limits, &point)
+    // first in x, then in y
+    let x = 0;
+    let y = 1;
+    let limits = [[0.0, 1.0], [0.0, 1.0]];
+    let expected = 1.50;
+    let partial = integrator
+        .double_partial_integral(&function, [x, y], &limits, &point)
         .unwrap();
-    assert!(f64::abs(val - 1.50) < 0.05);
+    assert!(f64::abs(partial - expected) < 0.05);
 }
 
 #[test]
-fn test_trapezoidal_integration_1() {
-    //equation is 2.0*x
-    let func = |args: f64| -> f64 { 2.0 * args };
+fn trapezoidal_rule_integrates_a_line_to_its_closed_form() {
+    // closed form of 2x is x*x
+    let line = |x: f64| -> f64 { 2.0 * x };
+    let limits = [0.0, 2.0];
+    let interval_count = 100;
+    let integrator = IterativeSingle::from_parameters(interval_count, IterativeMethod::Trapezoidal);
 
-    let integration_limit = [0.0, 2.0];
-
-    let iterator = IterativeSingle::from_parameters(100, IterativeMethod::Trapezoidal);
-    let val = iterator.single_integral(&func, &integration_limit).unwrap();
-
-    assert!(f64::abs(val - 4.0) < 0.00001);
+    let expected = 4.0;
+    let area = integrator.single_integral(&line, &limits).unwrap();
+    assert!(f64::abs(area - expected) < 0.00001);
 }
 
 #[test]
-fn test_trapezoidal_integration_2() {
-    //equation is 2.0*x + y*z
-    let func = |args: &[f64; 3]| -> f64 { 2.0 * args[0] + args[1] * args[2] };
-
-    let integration_limit = [0.0, 1.0];
+fn trapezoidal_rule_takes_partial_integrals_in_each_variable() {
+    let function = |point: &[f64; 3]| -> f64 { 2.0 * point[0] + point[1] * point[2] };
     let point = [1.0, 2.0, 3.0];
+    let interval_count = 100;
+    let integrator = IterativeMulti::from_parameters(interval_count, IterativeMethod::Trapezoidal);
 
-    let iterator = IterativeMulti::from_parameters(100, IterativeMethod::Trapezoidal);
-
-    //partial integration for x, known to be x*x + x*y*z, expect a value of ~7.00
-    let val = iterator
-        .single_partial_integral(&func, 0, &integration_limit, &point)
+    // closed form in x is x*x + x*y*z
+    let x = 0;
+    let limits = [0.0, 1.0];
+    let expected = 7.0;
+    let partial = integrator
+        .single_partial_integral(&function, x, &limits, &point)
         .unwrap();
-    assert!(f64::abs(val - 7.0) < 0.00001);
+    assert!(f64::abs(partial - expected) < 0.00001);
 
-    let integration_limit = [0.0, 2.0];
-
-    //partial integration for y, known to be 2.0*x*y + y*y*z/2.0, expect a value of ~10.00
-    let val = iterator
-        .single_partial_integral(&func, 1, &integration_limit, &point)
+    // closed form in y is 2.0*x*y + y*y*z/2.0
+    let y = 1;
+    let limits = [0.0, 2.0];
+    let expected = 10.0;
+    let partial = integrator
+        .single_partial_integral(&function, y, &limits, &point)
         .unwrap();
-    assert!(f64::abs(val - 10.0) < 0.00001);
+    assert!(f64::abs(partial - expected) < 0.00001);
 
-    let integration_limit = [0.0, 3.0];
-
-    //partial integration for z, known to be 2.0*x*z + y*z*z/2.0, expect a value of ~15.0
-    let val = iterator
-        .single_partial_integral(&func, 2, &integration_limit, &point)
+    // closed form in z is 2.0*x*z + y*z*z/2.0
+    let z = 2;
+    let limits = [0.0, 3.0];
+    let expected = 15.0;
+    let partial = integrator
+        .single_partial_integral(&function, z, &limits, &point)
         .unwrap();
-    assert!(f64::abs(val - 15.0) < 0.00001);
+    assert!(f64::abs(partial - expected) < 0.00001);
 }
 
 #[test]
-fn test_trapezoidal_integration_3() {
-    //equation is 6.0*x
-    let func = |args: f64| -> f64 { 6.0 * args };
+fn trapezoidal_rule_double_integrates_a_line() {
+    let line = |x: f64| -> f64 { 6.0 * x };
+    let limits = [[0.0, 2.0], [0.0, 2.0]];
+    let interval_count = 10;
+    let integrator = IterativeSingle::from_parameters(interval_count, IterativeMethod::Trapezoidal);
 
-    let integration_limits = [[0.0, 2.0], [0.0, 2.0]];
-
-    let integrator = IterativeSingle::from_parameters(10, IterativeMethod::Trapezoidal);
-
-    //simple double integration for 6*x, expect a value of ~24.00
-    let val = integrator
-        .double_integral(&func, &integration_limits)
-        .unwrap();
-    assert!(f64::abs(val - 24.0) < 0.00001);
+    let expected = 24.0;
+    let volume = integrator.double_integral(&line, &limits).unwrap();
+    assert!(f64::abs(volume - expected) < 0.00001);
 }
 
 #[test]
-fn test_trapezoidal_integration_4() {
-    //equation is 2.0*x + y*z
-    let func = |args: &[f64; 3]| -> f64 { 2.0 * args[0] + args[1] * args[2] };
-
-    let integration_limits = [[0.0, 1.0], [0.0, 2.0]];
+fn trapezoidal_rule_takes_a_double_partial_integral() {
+    let function = |point: &[f64; 3]| -> f64 { 2.0 * point[0] + point[1] * point[2] };
     let point = [1.0, 2.0, 3.0];
+    let interval_count = 10;
+    let integrator = IterativeMulti::from_parameters(interval_count, IterativeMethod::Trapezoidal);
 
-    let integrator = IterativeMulti::from_parameters(10, IterativeMethod::Trapezoidal);
-
-    //double partial integration for first x then y, expect a value of ~2.50
-    let val = integrator
-        .double_partial_integral(&func, [0, 1], &integration_limits, &point)
+    // first in x, then in y
+    let x = 0;
+    let y = 1;
+    let limits = [[0.0, 1.0], [0.0, 2.0]];
+    let expected = 8.0;
+    let partial = integrator
+        .double_partial_integral(&function, [x, y], &limits, &point)
         .unwrap();
-    assert!(f64::abs(val - 8.0) < 0.00001);
+    assert!(f64::abs(partial - expected) < 0.00001);
 }
 
 #[test]
-fn test_error_checking_1() {
-    //equation is 2.0*x
-    let func = |args: f64| -> f64 { 2.0 * args };
+fn reversed_limits_are_rejected() {
+    let line = |x: f64| -> f64 { 2.0 * x };
 
-    let integration_limit = [10.0, 1.0];
+    //lower limit is higher than the upper limit
+    let limits = [10.0, 1.0];
 
     let integrator = IterativeSingle::default();
-
-    //expect failure because integration interval is ill-defined (lower limit is higher than the upper limit)
-    let result = integrator.single_integral(&func, &integration_limit);
+    let result = integrator.single_integral(&line, &limits);
     assert!(result.is_err());
     assert!(result.unwrap_err() == IntegrateError::LimitsIllDefined);
 }
 
 #[test]
-fn test_error_checking_2() {
-    //equation is 2.0*x
-    let func = |args: f64| -> f64 { 2.0 * args };
-
-    let integration_limit = [0.0, 1.0];
+fn zero_interval_count_is_rejected() {
+    let line = |x: f64| -> f64 { 2.0 * x };
+    let limits = [0.0, 1.0];
 
     let integrator = IterativeSingle::from_parameters(0, IterativeMethod::Booles);
-
-    //expect failure because number of steps is 0
-    let result = integrator.single_integral(&func, &integration_limit);
+    let result = integrator.single_integral(&line, &limits);
     assert!(result.is_err());
     assert!(result.unwrap_err() == IntegrateError::IterationsZero);
 }
@@ -328,219 +310,216 @@ fn test_error_checking_2() {
 //TODO: add more tests
 
 #[test]
-fn test_error_checking_3() {
-    //equation is 4.0*x*x*x - 3.0*x*x
-    let func = |args: f64| -> f64 { 4.0 * args * args * args - 3.0 * args * args };
+fn gauss_legendre_rejects_an_order_below_one() {
+    let cubic = |x: f64| -> f64 { 4.0 * x * x * x - 3.0 * x * x };
+    let limits = [0.0, 2.0];
 
-    let integration_limit = [0.0, 2.0];
-
-    //Gauss Legendre not valid for n < 1
     let integrator = GaussianSingle::from_parameters(0, GaussianQuadratureMethod::GaussLegendre);
-    let result = integrator.single_integral(&func, &integration_limit);
+    let result = integrator.single_integral(&cubic, &limits);
     assert!(result.is_err());
     assert!(result.unwrap_err() == IntegrateError::QuadratureOrderOutOfRange);
 }
 
 #[test]
-fn test_error_checking_4() {
-    //equation is 4.0*x*x*x - 3.0*x*x
-    let func = |args: f64| -> f64 { 4.0 * args * args * args - 3.0 * args * args };
+fn gauss_legendre_rejects_an_order_above_thirty() {
+    let cubic = |x: f64| -> f64 { 4.0 * x * x * x - 3.0 * x * x };
+    let limits = [0.0, 2.0];
 
-    let integration_limit = [0.0, 2.0];
-
-    //Gauss Legendre not valid for n > 30
     let integrator = GaussianSingle::from_parameters(31, GaussianQuadratureMethod::GaussLegendre);
-    let result = integrator.single_integral(&func, &integration_limit);
+    let result = integrator.single_integral(&cubic, &limits);
     assert!(result.is_err());
     assert!(result.unwrap_err() == IntegrateError::QuadratureOrderOutOfRange);
 }
 
 #[test]
-fn test_error_checking_5() {
-    //integrand returns NaN, which the iterative rule must surface instead of a garbage number
-    let func = |_args: f64| -> f64 { f64::NAN };
-
-    let integration_limit = [0.0, 1.0];
+fn iterative_rule_surfaces_a_nan_integrand() {
+    //the rule must surface the NaN instead of a garbage number
+    let nan_integrand = |_x: f64| -> f64 { f64::NAN };
+    let limits = [0.0, 1.0];
 
     let integrator = IterativeSingle::default();
-    let result = integrator.single_integral(&func, &integration_limit);
+    let result = integrator.single_integral(&nan_integrand, &limits);
     assert!(result.is_err());
     assert!(result.unwrap_err() == IntegrateError::NonFinite);
 }
 
 #[test]
-fn test_error_checking_6() {
-    //integrand blows up to infinity, which Gauss-Legendre must surface as an error
-    let func = |_args: f64| -> f64 { f64::INFINITY };
-
-    let integration_limit = [0.0, 2.0];
+fn gaussian_rule_surfaces_an_infinite_integrand() {
+    let infinite_integrand = |_x: f64| -> f64 { f64::INFINITY };
+    let limits = [0.0, 2.0];
 
     let integrator = GaussianSingle::default();
-    let result = integrator.single_integral(&func, &integration_limit);
+    let result = integrator.single_integral(&infinite_integrand, &limits);
     assert!(result.is_err());
     assert!(result.unwrap_err() == IntegrateError::NonFinite);
 }
 
 #[test]
-fn test_gauss_hermite_single() {
+fn gauss_hermite_integrates_over_the_real_line() {
     //integrand is x*x; weights carry the e^{-x*x} kernel
     //∫_{-∞}^∞ x² e^{-x²} dx = √π / 2
-    let func = |x: f64| -> f64 { x * x };
+    let square = |x: f64| -> f64 { x * x };
+    let order = 5;
+    let integrator = GaussianSingle::from_parameters(order, GaussianQuadratureMethod::GaussHermite);
 
-    let integrator = GaussianSingle::from_parameters(5, GaussianQuadratureMethod::GaussHermite);
-
-    let integration_limit = [f64::NEG_INFINITY, f64::INFINITY];
-    let val = integrator
-        .single_integral(&func, &integration_limit)
-        .unwrap();
+    let real_line = [f64::NEG_INFINITY, f64::INFINITY];
+    let area = integrator.single_integral(&square, &real_line).unwrap();
 
     let expected = core::f64::consts::PI.sqrt() / 2.0;
-    assert!(f64::abs(val - expected) < 1e-10);
+    assert!(f64::abs(area - expected) < 1e-10);
 }
 
 #[test]
-fn test_gauss_laguerre_single() {
+fn gauss_laguerre_integrates_over_the_half_line() {
     //integrand is x*x; weights carry the e^{-x} kernel
     //∫_0^∞ x² e^{-x} dx = 2
-    let func = |x: f64| -> f64 { x * x };
+    let square = |x: f64| -> f64 { x * x };
+    let order = 5;
+    let integrator =
+        GaussianSingle::from_parameters(order, GaussianQuadratureMethod::GaussLaguerre);
 
-    let integrator = GaussianSingle::from_parameters(5, GaussianQuadratureMethod::GaussLaguerre);
+    let half_line = [0.0, f64::INFINITY];
+    let area = integrator.single_integral(&square, &half_line).unwrap();
 
-    let integration_limit = [0.0, f64::INFINITY];
-    let val = integrator
-        .single_integral(&func, &integration_limit)
-        .unwrap();
-
-    assert!(f64::abs(val - 2.0) < 1e-9);
+    let expected = 2.0;
+    assert!(f64::abs(area - expected) < 1e-9);
 }
 
 #[test]
-fn test_gauss_hermite_multivariable() {
+fn gauss_hermite_integrates_a_product_over_the_plane() {
     //∫∫ x² y² e^{-x²} e^{-y²} dx dy = (√π/2)²
-    let func = |args: &[f64; 2]| -> f64 { args[0] * args[0] * args[1] * args[1] };
+    let product_of_squares =
+        |point: &[f64; 2]| -> f64 { point[0] * point[0] * point[1] * point[1] };
+    let order = 5;
+    let integrator = GaussianMulti::from_parameters(order, GaussianQuadratureMethod::GaussHermite);
 
-    let integrator = GaussianMulti::from_parameters(5, GaussianQuadratureMethod::GaussHermite);
-
-    let integration_limits = [
+    let limits = [
         [f64::NEG_INFINITY, f64::INFINITY],
         [f64::NEG_INFINITY, f64::INFINITY],
     ];
     let point = [0.0, 0.0];
-    let val = integrator
-        .integrate([0, 1], &func, &integration_limits, &point)
+    let x = 0;
+    let y = 1;
+    let volume = integrator
+        .integrate([x, y], &product_of_squares, &limits, &point)
         .unwrap();
 
     let sqrt_pi_half = core::f64::consts::PI.sqrt() / 2.0;
-    assert!(f64::abs(val - sqrt_pi_half * sqrt_pi_half) < 1e-10);
+    let expected = sqrt_pi_half * sqrt_pi_half;
+    assert!(f64::abs(volume - expected) < 1e-10);
 }
 
 #[test]
-fn test_gauss_laguerre_multivariable() {
+fn gauss_laguerre_integrates_a_product_over_the_quadrant() {
     //∫∫ x² y² e^{-x} e^{-y} dx dy = 2 * 2 = 4
-    let func = |args: &[f64; 2]| -> f64 { args[0] * args[0] * args[1] * args[1] };
+    let product_of_squares =
+        |point: &[f64; 2]| -> f64 { point[0] * point[0] * point[1] * point[1] };
+    let order = 5;
+    let integrator = GaussianMulti::from_parameters(order, GaussianQuadratureMethod::GaussLaguerre);
 
-    let integrator = GaussianMulti::from_parameters(5, GaussianQuadratureMethod::GaussLaguerre);
-
-    let integration_limits = [[0.0, f64::INFINITY], [0.0, f64::INFINITY]];
+    let limits = [[0.0, f64::INFINITY], [0.0, f64::INFINITY]];
     let point = [0.0, 0.0];
-    let val = integrator
-        .integrate([0, 1], &func, &integration_limits, &point)
+    let x = 0;
+    let y = 1;
+    let volume = integrator
+        .integrate([x, y], &product_of_squares, &limits, &point)
         .unwrap();
 
-    assert!(f64::abs(val - 4.0) < 1e-8);
+    let expected = 4.0;
+    assert!(f64::abs(volume - expected) < 1e-8);
 }
 
 #[test]
-fn test_iterative_infinite_gaussian() {
+fn iterative_rule_integrates_a_bell_curve_over_the_real_line() {
     //∫_{-∞}^∞ e^{-x²} dx = √π
-    let func = |x: f64| -> f64 { f64::exp(-x * x) };
-
+    let bell_curve = |x: f64| -> f64 { f64::exp(-x * x) };
     let integrator = IterativeSingle::default();
 
-    let integration_limit = [f64::NEG_INFINITY, f64::INFINITY];
-    let val = integrator
-        .single_integral(&func, &integration_limit)
-        .unwrap();
+    let real_line = [f64::NEG_INFINITY, f64::INFINITY];
+    let area = integrator.single_integral(&bell_curve, &real_line).unwrap();
 
-    assert!(f64::abs(val - core::f64::consts::PI.sqrt()) < 1e-3);
+    let expected = core::f64::consts::PI.sqrt();
+    assert!(f64::abs(area - expected) < 1e-3);
 }
 
 #[test]
-fn test_iterative_semi_infinite_exp() {
+fn iterative_rule_integrates_a_decaying_exponential_over_the_half_line() {
     //∫_0^∞ e^{-x} dx = 1
-    let func = |x: f64| -> f64 { f64::exp(-x) };
-
+    let decay = |x: f64| -> f64 { f64::exp(-x) };
     let integrator = IterativeSingle::default();
 
-    let integration_limit = [0.0, f64::INFINITY];
-    let val = integrator
-        .single_integral(&func, &integration_limit)
-        .unwrap();
+    let half_line = [0.0, f64::INFINITY];
+    let area = integrator.single_integral(&decay, &half_line).unwrap();
 
-    assert!(f64::abs(val - 1.0) < 1e-3);
+    let expected = 1.0;
+    assert!(f64::abs(area - expected) < 1e-3);
 }
 
 #[test]
-fn test_iterative_semi_infinite_inverse_square() {
+fn iterative_rule_integrates_an_inverse_square_over_the_half_line() {
     //∫_1^∞ x^{-2} dx = 1
-    let func = |x: f64| -> f64 { 1.0 / (x * x) };
-
+    let inverse_square = |x: f64| -> f64 { 1.0 / (x * x) };
     let integrator = IterativeSingle::default();
 
-    let integration_limit = [1.0, f64::INFINITY];
-    let val = integrator
-        .single_integral(&func, &integration_limit)
+    let half_line = [1.0, f64::INFINITY];
+    let area = integrator
+        .single_integral(&inverse_square, &half_line)
         .unwrap();
 
-    assert!(f64::abs(val - 1.0) < 1e-3);
+    let expected = 1.0;
+    assert!(f64::abs(area - expected) < 1e-3);
 }
 
 #[test]
-fn test_iterative_negative_limits() {
+fn iterative_rule_accepts_a_negative_lower_limit() {
     //∫_{-2}^{1} 2x dx = x² evaluated from -2 to 1 = 1 - 4 = -3
-    let func = |x: f64| -> f64 { 2.0 * x };
-
+    let line = |x: f64| -> f64 { 2.0 * x };
     let integrator = IterativeSingle::default();
 
-    let integration_limit = [-2.0, 1.0];
-    let val = integrator
-        .single_integral(&func, &integration_limit)
-        .unwrap();
+    let limits = [-2.0, 1.0];
+    let area = integrator.single_integral(&line, &limits).unwrap();
 
-    assert!(f64::abs(val - (-3.0)) < 1e-9);
+    let expected = -3.0;
+    assert!(f64::abs(area - expected) < 1e-9);
 }
 
 #[test]
-fn test_composite_rule_degree_3_polynomial() {
+fn composite_rules_are_exact_on_a_cubic() {
     //a degree-3 integrand exposes composite-rule divisibility (a linear one would be exact
     //under every rule and hide it). ∫_0^2 x³ dx = 4
-    let func = |x: f64| -> f64 { x * x * x };
-
-    let integration_limit = [0.0, 2.0];
+    let cubic = |x: f64| -> f64 { x * x * x };
+    let limits = [0.0, 2.0];
+    let interval_count = 120;
+    let expected = 4.0;
 
     //120 is a multiple of 3, so Simpson's 3/8 is exact for cubics here
-    let simpson = IterativeSingle::from_parameters(120, IterativeMethod::Simpsons);
-    let val = simpson.single_integral(&func, &integration_limit).unwrap();
-    assert!(f64::abs(val - 4.0) < 1e-9);
+    let simpson = IterativeSingle::from_parameters(interval_count, IterativeMethod::Simpsons);
+    let area = simpson.single_integral(&cubic, &limits).unwrap();
+    assert!(f64::abs(area - expected) < 1e-9);
 
     //120 is a multiple of 4, so Boole's rule is exact too
-    let boole = IterativeSingle::from_parameters(120, IterativeMethod::Booles);
-    let val = boole.single_integral(&func, &integration_limit).unwrap();
-    assert!(f64::abs(val - 4.0) < 1e-9);
+    let boole = IterativeSingle::from_parameters(interval_count, IterativeMethod::Booles);
+    let area = boole.single_integral(&cubic, &limits).unwrap();
+    assert!(f64::abs(area - expected) < 1e-9);
 }
 
 //naive left-to-right trapezoidal accumulation, matching the library's point stepping and
 //weights so the only difference from the pairwise version is the summation order
-fn naive_trapezoidal<F: Fn(f64) -> f64>(iterations: u64, lo: f64, hi: f64, f: F) -> f64 {
-    let delta = (hi - lo) / iterations as f64;
-    let mut point = lo;
-    let mut ans = f(point);
-    for _ in 0..iterations - 1 {
-        point += delta;
-        ans += 2.0 * f(point);
+fn naive_trapezoidal<F: Fn(f64) -> f64>(
+    interval_count: u64,
+    lower_limit: f64,
+    upper_limit: f64,
+    function: F,
+) -> f64 {
+    let width = (upper_limit - lower_limit) / interval_count as f64;
+    let mut point = lower_limit;
+    let mut sum = function(point);
+    for _ in 0..interval_count - 1 {
+        point += width;
+        sum += 2.0 * function(point);
     }
-    ans += f(hi);
-    0.5 * delta * ans
+    sum += function(upper_limit);
+    0.5 * width * sum
 }
 
 #[test]
@@ -548,60 +527,63 @@ fn pairwise_integration_is_accurate_on_long_sum() {
     //1/(1+x^2) over [0, 1] is exactly pi/4. With 2^23 intervals the trapezoidal truncation
     //error sits at machine epsilon, so naive accumulation (error ~ n*eps) becomes the limiting
     //factor; pairwise keeps the result truncation-limited and lands far closer to the exact value
-    let func = |x: f64| -> f64 { 1.0 / (1.0 + x * x) };
+    let function = |x: f64| -> f64 { 1.0 / (1.0 + x * x) };
     let exact = core::f64::consts::PI / 4.0;
-    let iterations: u64 = 1 << 23;
+    let interval_count: u64 = 1 << 23;
 
-    let integrator = IterativeSingle::from_parameters(iterations, IterativeMethod::Trapezoidal);
-    let pairwise = integrator.single_integral(&func, &[0.0, 1.0]).unwrap();
-    let naive = naive_trapezoidal(iterations, 0.0, 1.0, func);
+    let integrator = IterativeSingle::from_parameters(interval_count, IterativeMethod::Trapezoidal);
+    let pairwise = integrator.single_integral(&function, &[0.0, 1.0]).unwrap();
+    let naive = naive_trapezoidal(interval_count, 0.0, 1.0, function);
 
-    let pairwise_err = f64::abs(pairwise - exact);
-    let naive_err = f64::abs(naive - exact);
+    let pairwise_error = f64::abs(pairwise - exact);
+    let naive_error = f64::abs(naive - exact);
 
     //tighter than the ~n*eps a naive sum could reach at this term count
     assert!(
-        pairwise_err < 1e-12,
-        "pairwise error {pairwise_err:e} too large"
+        pairwise_error < 1e-12,
+        "pairwise error {pairwise_error:e} too large"
     );
     //and strictly closer to the exact value than the naive accumulation
     assert!(
-        pairwise_err < naive_err,
-        "pairwise ({pairwise_err:e}) should be closer than naive ({naive_err:e})"
+        pairwise_error < naive_error,
+        "pairwise ({pairwise_error:e}) should be closer than naive ({naive_error:e})"
     );
 }
 
 #[test]
-fn test_booles_integration_f32() {
+fn booles_rule_integrates_a_line_at_f32() {
     //2x integrated over [0, 2] is 4
-    let func = |x: f32| -> f32 { 2.0 * x };
+    let line = |x: f32| -> f32 { 2.0 * x };
+    let interval_count = 100;
+    let integrator =
+        IterativeSingle::<f32>::from_parameters(interval_count, IterativeMethod::Booles);
 
-    let integrator = IterativeSingle::<f32>::from_parameters(100, IterativeMethod::Booles);
-
-    let val = integrator.single_integral(&func, &[0.0, 2.0]).unwrap();
-    assert!(f32::abs(val - 4.0) < 1e-3, "got {val}");
+    let expected = 4.0;
+    let area = integrator.single_integral(&line, &[0.0, 2.0]).unwrap();
+    assert!(f32::abs(area - expected) < 1e-3, "got {area}");
 }
 
 #[test]
-fn test_gauss_legendre_integration_f32() {
+fn gauss_legendre_integrates_a_cubic_at_f32() {
     //4x^3 - 3x^2 integrated over [0, 2] is 8
-    let func = |x: f32| -> f32 { 4.0 * x * x * x - 3.0 * x * x };
-
+    let cubic = |x: f32| -> f32 { 4.0 * x * x * x - 3.0 * x * x };
+    let order = 4;
     let integrator =
-        GaussianSingle::<f32>::from_parameters(4, GaussianQuadratureMethod::GaussLegendre);
+        GaussianSingle::<f32>::from_parameters(order, GaussianQuadratureMethod::GaussLegendre);
 
-    let val = integrator.single_integral(&func, &[0.0, 2.0]).unwrap();
-    assert!(f32::abs(val - 8.0) < 1e-2, "got {val}");
+    let expected = 8.0;
+    let area = integrator.single_integral(&cubic, &[0.0, 2.0]).unwrap();
+    assert!(f32::abs(area - expected) < 1e-2, "got {area}");
 }
 
-fn polynomial_coeffs(deg: usize) -> impl Strategy<Value = Vec<f64>> {
-    prop::collection::vec(-10.0..10.0, deg + 1)
+fn polynomial_coeffs(degree: usize) -> impl Strategy<Value = Vec<f64>> {
+    prop::collection::vec(-10.0..10.0, degree + 1)
 }
 
 fn integration_limit() -> impl Strategy<Value = [f64; 2]> {
-    (-10.0..10.0f64, 0.1..5.0f64).prop_map(|(a, length)| {
-        let b = a + length;
-        [a, b]
+    (-10.0..10.0f64, 0.1..5.0f64).prop_map(|(lower_limit, length)| {
+        let upper_limit = lower_limit + length;
+        [lower_limit, upper_limit]
     })
 }
 
@@ -610,31 +592,36 @@ fn func_from_coeffs(coefficients: &[f64]) -> impl Fn(f64) -> f64 {
         coefficients
             .iter()
             .enumerate()
-            .map(|(deg, c)| c * x.powf(deg as f64))
+            .map(|(degree, coefficient)| coefficient * x.powf(degree as f64))
             .sum()
     }
 }
 
 fn closed_form_from_coeffs(coefficients: &[f64], interval: [f64; 2]) -> f64 {
-    let [a, b] = interval;
+    let [lower_limit, upper_limit] = interval;
     coefficients
         .iter()
         .enumerate()
-        .map(|(deg, c)| {
-            let exp = (deg + 1) as f64;
-            (b.powf(exp) - a.powf(exp)) * c / exp
+        .map(|(degree, coefficient)| {
+            let exponent = (degree + 1) as f64;
+            (upper_limit.powf(exponent) - lower_limit.powf(exponent)) * coefficient / exponent
         })
         .sum()
 }
 
 fn tolerance_from_coeffs(coefficients: &[f64], interval: [f64; 2]) -> f64 {
-    let [a, b] = interval;
+    let [lower_limit, upper_limit] = interval;
     let bound: f64 = coefficients
         .iter()
         .enumerate()
-        .map(|(deg, c)| {
-            let exp = (deg + 1) as f64;
-            a.powf(exp).abs().max(b.powf(exp).abs()) * c.abs() / exp
+        .map(|(degree, coefficient)| {
+            let exponent = (degree + 1) as f64;
+            lower_limit
+                .powf(exponent)
+                .abs()
+                .max(upper_limit.powf(exponent).abs())
+                * coefficient.abs()
+                / exponent
         })
         .sum();
 
@@ -649,79 +636,84 @@ fn iterative_integration_proptest(
         limit in integration_limit(),
         coeffs in polynomial_coeffs(degree)
         )| {
-        let func = func_from_coeffs(&coeffs);
+        let function = func_from_coeffs(&coeffs);
         let closed_form = closed_form_from_coeffs(&coeffs, limit);
-        let scaled_tol = tolerance_from_coeffs(&coeffs, limit);
+        let tolerance = tolerance_from_coeffs(&coeffs, limit);
 
-        let val = integrator.single_integral(&func, &limit).unwrap();
-        prop_assert!(f64::abs(val - closed_form) < scaled_tol);
+        let area = integrator.single_integral(&function, &limit).unwrap();
+        prop_assert!(f64::abs(area - closed_form) < tolerance);
     });
 }
 
 #[test]
 fn proptest_trapezoid_integration_f64() {
-    let iterator = IterativeSingle::from_parameters(100, IterativeMethod::Trapezoidal);
-    iterative_integration_proptest(1, iterator);
+    let integrator = IterativeSingle::from_parameters(100, IterativeMethod::Trapezoidal);
+    iterative_integration_proptest(1, integrator);
 }
 
 #[test]
 fn proptest_simpsons_integration_f64() {
-    let iterator = IterativeSingle::from_parameters(120, IterativeMethod::Simpsons);
-    iterative_integration_proptest(3, iterator);
+    let integrator = IterativeSingle::from_parameters(120, IterativeMethod::Simpsons);
+    iterative_integration_proptest(3, integrator);
 }
 
 #[test]
 fn proptest_booles_integration_f64() {
-    let iterator = IterativeSingle::from_parameters(100, IterativeMethod::Booles);
-    iterative_integration_proptest(5, iterator);
+    let integrator = IterativeSingle::from_parameters(100, IterativeMethod::Booles);
+    iterative_integration_proptest(5, integrator);
 }
 
 fn gauss_coeffs() -> impl Strategy<Value = (usize, Vec<f64>)> {
-    (1..10usize).prop_flat_map(|n| (Just(n), polynomial_coeffs(2 * n - 1)))
+    (1..10usize).prop_flat_map(|order| (Just(order), polynomial_coeffs(2 * order - 1)))
 }
 
-fn double_factorial(n: u64) -> f64 {
-    let mut result = 1.0;
-    let mut k = n;
-    while k > 1 {
-        result *= k as f64;
-        k -= 2;
+fn double_factorial(value: u64) -> f64 {
+    let mut product = 1.0;
+    let mut term = value;
+    while term > 1 {
+        product *= term as f64;
+        term -= 2;
     }
-    result
+    product
 }
 
-fn legendre_moment(k: usize, [a, b]: [f64; 2]) -> f64 {
-    (b.powi(k as i32 + 1) - a.powi(k as i32 + 1)) / (k as f64 + 1.0)
+fn legendre_moment(degree: usize, [lower_limit, upper_limit]: [f64; 2]) -> f64 {
+    (upper_limit.powi(degree as i32 + 1) - lower_limit.powi(degree as i32 + 1))
+        / (degree as f64 + 1.0)
 }
 
-fn hermite_moment(deg: usize) -> f64 {
-    if deg % 2 == 1 {
+fn hermite_moment(degree: usize) -> f64 {
+    if degree % 2 == 1 {
         0.0
     } else {
-        let m = deg / 2;
-        let df = if m == 0 {
+        let half_degree = degree / 2;
+        let double_factorial_term = if half_degree == 0 {
             1.0
         } else {
-            double_factorial(2 * m as u64 - 1)
+            double_factorial(2 * half_degree as u64 - 1)
         };
-        df * std::f64::consts::PI.sqrt() / 2f64.powi(m as i32)
+        double_factorial_term * std::f64::consts::PI.sqrt() / 2f64.powi(half_degree as i32)
     }
 }
 
-fn laguerre_moment(k: usize) -> f64 {
-    (1..=k as u64).map(|i| i as f64).product::<f64>().max(1.0)
+fn laguerre_moment(degree: usize) -> f64 {
+    (1..=degree as u64)
+        .map(|factor| factor as f64)
+        .product::<f64>()
+        .max(1.0)
 }
 
 fn gauss_closed_form(quadrature: GaussianQuadratureMethod, coeffs: &[f64], limit: [f64; 2]) -> f64 {
     coeffs
         .iter()
         .enumerate()
-        .map(|(deg, c)| {
-            c * match quadrature {
-                GaussianQuadratureMethod::GaussLegendre => legendre_moment(deg, limit),
-                GaussianQuadratureMethod::GaussHermite => hermite_moment(deg),
-                GaussianQuadratureMethod::GaussLaguerre => laguerre_moment(deg),
-            }
+        .map(|(degree, coefficient)| {
+            coefficient
+                * match quadrature {
+                    GaussianQuadratureMethod::GaussLegendre => legendre_moment(degree, limit),
+                    GaussianQuadratureMethod::GaussHermite => hermite_moment(degree),
+                    GaussianQuadratureMethod::GaussLaguerre => laguerre_moment(degree),
+                }
         })
         .sum()
 }
@@ -736,7 +728,7 @@ fn gauss_tolerance(quadrature: GaussianQuadratureMethod, coeffs: &[f64], limit: 
     let term_sum_abs: f64 = coeffs
         .iter()
         .enumerate()
-        .map(|(k, &c)| (c * moment_fn(k)).abs())
+        .map(|(degree, &coefficient)| (coefficient * moment_fn(degree)).abs())
         .sum();
 
     (term_sum_abs).max(1.0) * 1e-9
@@ -751,17 +743,17 @@ fn gauss_integration_proptest(
         (n, coeffs) in gauss_coeffs(),
         )| {
 
-        let func = func_from_coeffs(&coeffs);
+        let function = func_from_coeffs(&coeffs);
         let closed_form = gauss_closed_form(quadrature, &coeffs, limit);
-        let scaled_tol = gauss_tolerance(quadrature, &coeffs, limit);
+        let tolerance = gauss_tolerance(quadrature, &coeffs, limit);
 
         let integrator = GaussianSingle::<f64>::from_parameters(
         n,
         quadrature,
         );
 
-        let val = integrator.single_integral(&func, &limit).unwrap();
-        prop_assert!(f64::abs(val - closed_form) < scaled_tol);
+        let area = integrator.single_integral(&function, &limit).unwrap();
+        prop_assert!(f64::abs(area - closed_form) < tolerance);
     });
 }
 
@@ -788,43 +780,43 @@ fn proptest_gauss_laguerre_integration_f64() {
 
 #[test]
 fn kahan_integration_beats_naive_on_long_sum() {
-    let func = |x: f64| -> f64 { 1.0 / (1.0 + x * x) };
+    let function = |x: f64| -> f64 { 1.0 / (1.0 + x * x) };
     let exact = core::f64::consts::PI / 4.0;
-    let iterations: u64 = 1 << 23;
+    let interval_count: u64 = 1 << 23;
 
-    let integrator = IterativeSingle::from_parameters(iterations, IterativeMethod::Trapezoidal)
+    let integrator = IterativeSingle::from_parameters(interval_count, IterativeMethod::Trapezoidal)
         .with_kahan_summation();
 
-    let kahan = integrator.single_integral(&func, &[0.0, 1.0]).unwrap();
-    let naive = naive_trapezoidal(iterations, 0.0, 1.0, func);
+    let kahan = integrator.single_integral(&function, &[0.0, 1.0]).unwrap();
+    let naive = naive_trapezoidal(interval_count, 0.0, 1.0, function);
 
-    let kahan_err = f64::abs(kahan - exact);
-    let naive_err = f64::abs(naive - exact);
-    assert!(kahan_err < 1e-12, "kahan error {kahan_err:e} too large");
+    let kahan_error = f64::abs(kahan - exact);
+    let naive_error = f64::abs(naive - exact);
+    assert!(kahan_error < 1e-12, "kahan error {kahan_error:e} too large");
     assert!(
-        kahan_err < naive_err,
-        "kahan ({kahan_err:e}) should be closer than naive ({naive_err:e})"
+        kahan_error < naive_error,
+        "kahan ({kahan_error:e}) should be closer than naive ({naive_error:e})"
     );
 }
 
 #[test]
 fn iterative_multi_rejects_out_of_range_index() {
-    let func = |args: &[f64; 2]| args[0] + args[1];
+    let function = |point: &[f64; 2]| point[0] + point[1];
     let point = [1.0, 2.0];
     let integrator = IterativeMulti::default();
-    let err = integrator
-        .integrate([2; 1], &func, &[[0.0, 1.0]; 1], &point)
+    let error = integrator
+        .integrate([2; 1], &function, &[[0.0, 1.0]; 1], &point)
         .unwrap_err();
-    assert_eq!(err, IntegrateError::IndexOutOfRange);
+    assert_eq!(error, IntegrateError::IndexOutOfRange);
 }
 
 #[test]
 fn gaussian_multi_rejects_out_of_range_index() {
-    let func = |args: &[f64; 2]| args[0] + args[1];
+    let function = |point: &[f64; 2]| point[0] + point[1];
     let point = [1.0, 2.0];
     let integrator = GaussianMulti::default();
-    let err = integrator
-        .integrate([2; 1], &func, &[[0.0, 1.0]; 1], &point)
+    let error = integrator
+        .integrate([2; 1], &function, &[[0.0, 1.0]; 1], &point)
         .unwrap_err();
-    assert_eq!(err, IntegrateError::IndexOutOfRange);
+    assert_eq!(error, IntegrateError::IndexOutOfRange);
 }

--- a/crates/multicalc/tests/suite/ode/rk4.rs
+++ b/crates/multicalc/tests/suite/ode/rk4.rs
@@ -3,59 +3,58 @@ use multicalc::linear_algebra::Vector;
 use multicalc::ode::Rk4;
 
 // y' = -y, generic over the scalar so the same RHS runs at f64 and through Dual.
-fn decay<T: multicalc::Numeric>(_t: T, y: &Vector<1, T>) -> Vector<1, T> {
-    -*y
+fn decay<T: multicalc::Numeric>(_time: T, state: &Vector<1, T>) -> Vector<1, T> {
+    -*state
 }
 
 #[test]
 fn exp_decay_matches_closed_form() {
     // y(1) = e^{-1} from 1000 fixed steps.
     let steps = 1000;
-    let yf = Rk4::integrate(
+    let initial_state = Vector::new([1.0]);
+    let timestep = 1.0 / steps as f64;
+    let final_state = Rk4::integrate(
         &decay::<f64>,
         0.0,
-        &Vector::new([1.0]),
-        1.0 / steps as f64,
+        &initial_state,
+        timestep,
         steps,
         |_, _| {},
     );
-    assert!((yf[0] - (-1.0_f64).exp()).abs() < 1e-9);
+    assert!((final_state[0] - (-1.0_f64).exp()).abs() < 1e-9);
 }
 
 #[test]
 fn harmonic_matches_closed_form() {
     // y'' = -y as [y2, -y1]; over one period the state returns to [cos, -sin].
-    let f = |_t: f64, y: &Vector<2, f64>| Vector::new([y[1], -y[0]]);
-    let tf = core::f64::consts::TAU;
+    let harmonic = |_time: f64, state: &Vector<2, f64>| Vector::new([state[1], -state[0]]);
+    let final_time = core::f64::consts::TAU;
     let steps = 2000;
-    let yf = Rk4::integrate(
-        &f,
-        0.0,
-        &Vector::new([1.0, 0.0]),
-        tf / steps as f64,
-        steps,
-        |_, _| {},
-    );
-    assert!((yf[0] - tf.cos()).abs() < 1e-7);
-    assert!((yf[1] - (-tf.sin())).abs() < 1e-7);
+    let initial_state = Vector::new([1.0, 0.0]);
+    let timestep = final_time / steps as f64;
+    let final_state = Rk4::integrate(&harmonic, 0.0, &initial_state, timestep, steps, |_, _| {});
+    assert!((final_state[0] - final_time.cos()).abs() < 1e-7);
+    assert!((final_state[1] - (-final_time.sin())).abs() < 1e-7);
 }
 
 #[test]
 fn fourth_order_convergence() {
     // Halving the step should cut the global endpoint error by ~2^4 = 16.
     let exact = (-1.0_f64).exp();
-    let err = |steps: usize| {
-        let yf = Rk4::integrate(
+    let endpoint_error = |steps: usize| {
+        let initial_state = Vector::new([1.0]);
+        let timestep = 1.0 / steps as f64;
+        let final_state = Rk4::integrate(
             &decay::<f64>,
             0.0,
-            &Vector::new([1.0]),
-            1.0 / steps as f64,
+            &initial_state,
+            timestep,
             steps,
             |_, _| {},
         );
-        (yf[0] - exact).abs()
+        (final_state[0] - exact).abs()
     };
-    let ratio = err(50) / err(100);
+    let ratio = endpoint_error(50) / endpoint_error(100);
     assert!((12.0..=20.0).contains(&ratio), "convergence ratio {ratio}");
 }
 
@@ -63,52 +62,58 @@ fn fourth_order_convergence() {
 fn ad_through_rk4_matches_fd() {
     // Differentiate the final state w.r.t. the initial condition. For y' = -y the
     // exact sensitivity is d y_f / d a = e^{-t_f}; check it against a central FD.
-    let a = 1.3_f64;
-    let tf = 0.7;
+    let initial_value = 1.3_f64;
+    let final_time = 0.7;
     let steps = 100;
 
-    let y0 = Vector::new([Dual::variable(a)]);
-    let dt = Dual::constant(tf / steps as f64);
-    let yf = Rk4::integrate(
+    let initial_state = Vector::new([Dual::variable(initial_value)]);
+    let timestep = Dual::constant(final_time / steps as f64);
+    let final_state = Rk4::integrate(
         &decay::<Dual<f64>>,
         Dual::constant(0.0),
-        &y0,
-        dt,
+        &initial_state,
+        timestep,
         steps,
         |_, _| {},
     );
-    let ad = yf[0].deriv;
-    assert!((ad - (-tf).exp()).abs() < 1e-6);
+    let autodiff = final_state[0].deriv;
+    assert!((autodiff - (-final_time).exp()).abs() < 1e-6);
 
-    let run = |a0: f64| {
+    let final_state_from = |initial_value: f64| {
+        let initial_state = Vector::new([initial_value]);
+        let timestep = final_time / steps as f64;
         Rk4::integrate(
             &decay::<f64>,
             0.0,
-            &Vector::new([a0]),
-            tf / steps as f64,
+            &initial_state,
+            timestep,
             steps,
             |_, _| {},
         )[0]
     };
-    let h = 1e-6;
-    let fd = (run(a + h) - run(a - h)) / (2.0 * h);
-    assert!((ad - fd).abs() < 1e-6);
+    let step = 1e-6;
+    let finite_difference = (final_state_from(initial_value + step)
+        - final_state_from(initial_value - step))
+        / (2.0 * step);
+    assert!((autodiff - finite_difference).abs() < 1e-6);
 }
 
 #[test]
 fn f32_energy_round_trip() {
     // Harmonic oscillator at f32 over one period conserves y0^2 + y1^2 = 1.
-    let f = |_t: f32, y: &Vector<2, f32>| Vector::new([y[1], -y[0]]);
-    let tf = core::f32::consts::TAU;
+    let harmonic = |_time: f32, state: &Vector<2, f32>| Vector::new([state[1], -state[0]]);
+    let final_time = core::f32::consts::TAU;
     let steps = 2000;
-    let yf = Rk4::integrate(
-        &f,
+    let initial_state = Vector::new([1.0, 0.0]);
+    let timestep = final_time / steps as f32;
+    let final_state = Rk4::integrate(
+        &harmonic,
         0.0_f32,
-        &Vector::new([1.0, 0.0]),
-        tf / steps as f32,
+        &initial_state,
+        timestep,
         steps,
         |_, _| {},
     );
-    let energy = yf[0] * yf[0] + yf[1] * yf[1];
+    let energy = final_state[0] * final_state[0] + final_state[1] * final_state[1];
     assert!((energy - 1.0).abs() < 1e-3);
 }

--- a/crates/multicalc/tests/suite/ode/rk45.rs
+++ b/crates/multicalc/tests/suite/ode/rk45.rs
@@ -10,37 +10,42 @@ use proptest::prelude::*;
 #[test]
 fn solve_matches_closed_form() {
     // y' = -y over [0, 2]: y(2) = e^{-2}.
-    let decay = |_t: f64, y: &Vector<1, f64>| -*y;
-    let yf = Rk45::default()
+    let decay = |_time: f64, state: &Vector<1, f64>| -*state;
+    let final_state = Rk45::default()
         .with_rtol(1e-10)
         .with_atol(1e-12)
         .solve(&decay, 0.0, &Vector::new([1.0]), 2.0)
         .unwrap();
-    assert!((yf[0] - (-2.0_f64).exp()).abs() < 1e-7);
+    assert!((final_state[0] - (-2.0_f64).exp()).abs() < 1e-7);
 
     // Harmonic oscillator over one period returns to [1, 0].
-    let harmonic = |_t: f64, y: &Vector<2, f64>| Vector::new([y[1], -y[0]]);
-    let tf = core::f64::consts::TAU;
-    let yf = Rk45::default()
+    let harmonic = |_time: f64, state: &Vector<2, f64>| Vector::new([state[1], -state[0]]);
+    let final_time = core::f64::consts::TAU;
+    let final_state = Rk45::default()
         .with_rtol(1e-10)
         .with_atol(1e-12)
-        .solve(&harmonic, 0.0, &Vector::new([1.0, 0.0]), tf)
+        .solve(&harmonic, 0.0, &Vector::new([1.0, 0.0]), final_time)
         .unwrap();
-    assert!((yf[0] - 1.0).abs() < 1e-7 && yf[1].abs() < 1e-7);
+    assert!((final_state[0] - 1.0).abs() < 1e-7 && final_state[1].abs() < 1e-7);
 
     // Two-body unit circular orbit returns to its start after one period.
-    let two_body = |_t: f64, y: &Vector<4, f64>| {
-        let r = (y[0] * y[0] + y[1] * y[1]).sqrt();
-        let r3 = r * r * r;
-        Vector::new([y[2], y[3], -y[0] / r3, -y[1] / r3])
+    let two_body = |_time: f64, state: &Vector<4, f64>| {
+        let radius = (state[0] * state[0] + state[1] * state[1]).sqrt();
+        let radius_cubed = radius * radius * radius;
+        Vector::new([
+            state[2],
+            state[3],
+            -state[0] / radius_cubed,
+            -state[1] / radius_cubed,
+        ])
     };
-    let y0 = Vector::new([1.0, 0.0, 0.0, 1.0]);
-    let yf = Rk45::default()
+    let initial_state = Vector::new([1.0, 0.0, 0.0, 1.0]);
+    let final_state = Rk45::default()
         .with_rtol(1e-10)
         .with_atol(1e-12)
-        .solve(&two_body, 0.0, &y0, tf)
+        .solve(&two_body, 0.0, &initial_state, final_time)
         .unwrap();
-    for (got, want) in yf.as_array().iter().zip(y0.as_array()) {
+    for (got, want) in final_state.as_array().iter().zip(initial_state.as_array()) {
         assert!((got - want).abs() < 1e-7);
     }
 }
@@ -48,13 +53,13 @@ fn solve_matches_closed_form() {
 #[test]
 fn dense_output_endpoints_exact() {
     // Capture the first accepted step and check its cubic-Hermite interpolation.
-    let decay = |_t: f64, y: &Vector<1, f64>| -*y;
-    let y0 = Vector::new([1.0]);
+    let decay = |_time: f64, state: &Vector<1, f64>| -*state;
+    let initial_state = Vector::new([1.0]);
     let mut first: Option<Step<1, f64>> = None;
     let _ = Rk45::default()
         .with_rtol(1e-8)
         .with_atol(1e-10)
-        .for_each_step(&decay, 0.0, &y0, 1.0, |step| {
+        .for_each_step(&decay, 0.0, &initial_state, 1.0, |step| {
             if first.is_none() {
                 first = Some(*step);
             }
@@ -67,50 +72,50 @@ fn dense_output_endpoints_exact() {
     assert_eq!(step.interpolate(step.t1).as_array(), step.y1.as_array());
 
     // An interior sample matches a separate solve to that time.
-    let tm = 0.5 * (step.t0 + step.t1);
-    let ym = step.interpolate(tm);
+    let midpoint_time = 0.5 * (step.t0 + step.t1);
+    let interpolated = step.interpolate(midpoint_time);
     let solved = Rk45::default()
         .with_rtol(1e-10)
         .with_atol(1e-12)
-        .solve(&decay, 0.0, &y0, tm)
+        .solve(&decay, 0.0, &initial_state, midpoint_time)
         .unwrap();
-    assert!((ym[0] - solved[0]).abs() < 1e-8);
+    assert!((interpolated[0] - solved[0]).abs() < 1e-8);
 }
 
 #[test]
 fn min_step_floor_errors() {
     // A floor larger than any feasible step forces StepSizeTooSmall.
-    let decay = |_t: f64, y: &Vector<1, f64>| -*y;
-    let res = Rk45::default()
+    let decay = |_time: f64, state: &Vector<1, f64>| -*state;
+    let result = Rk45::default()
         .with_min_step(1e9)
         .solve(&decay, 0.0, &Vector::new([1.0]), 1.0);
-    assert_eq!(res.unwrap_err(), IntegrateError::StepSizeTooSmall);
+    assert_eq!(result.unwrap_err(), IntegrateError::StepSizeTooSmall);
 }
 
 #[test]
 fn max_steps_budget_errors() {
     // One step cannot cross a long span, so the budget is exhausted.
-    let decay = |_t: f64, y: &Vector<1, f64>| -*y;
-    let res = Rk45::default()
+    let decay = |_time: f64, state: &Vector<1, f64>| -*state;
+    let result = Rk45::default()
         .with_max_steps(1)
         .solve(&decay, 0.0, &Vector::new([1.0]), 100.0);
     assert!(matches!(
-        res.unwrap_err(),
+        result.unwrap_err(),
         IntegrateError::DidNotConverge { .. }
     ));
 }
 
 #[test]
 fn zero_span_errors() {
-    let decay = |_t: f64, y: &Vector<1, f64>| -*y;
-    let res = Rk45::default().solve(&decay, 1.0, &Vector::new([1.0]), 1.0);
-    assert_eq!(res.unwrap_err(), IntegrateError::LimitsIllDefined);
+    let decay = |_time: f64, state: &Vector<1, f64>| -*state;
+    let result = Rk45::default().solve(&decay, 1.0, &Vector::new([1.0]), 1.0);
+    assert_eq!(result.unwrap_err(), IntegrateError::LimitsIllDefined);
 }
 
 #[test]
 fn zero_dimensional_state_remains_empty() {
     let empty = Vector::<0, f64>::zeros();
-    let zero = |_t: f64, _y: &Vector<0, f64>| Vector::zeros();
+    let zero = |_time: f64, _state: &Vector<0, f64>| Vector::zeros();
 
     let result = Rk45::default().solve(&zero, 0.0, &empty, 1.0);
 
@@ -119,18 +124,19 @@ fn zero_dimensional_state_remains_empty() {
 
 #[test]
 fn non_finite_rhs_errors() {
-    let f = |_t: f64, _y: &Vector<1, f64>| Vector::new([f64::NAN]);
-    let res = Rk45::default().solve(&f, 0.0, &Vector::new([1.0]), 1.0);
-    assert_eq!(res.unwrap_err(), IntegrateError::NonFinite);
+    let non_finite = |_time: f64, _state: &Vector<1, f64>| Vector::new([f64::NAN]);
+    let result = Rk45::default().solve(&non_finite, 0.0, &Vector::new([1.0]), 1.0);
+    assert_eq!(result.unwrap_err(), IntegrateError::NonFinite);
 }
 
 #[test]
 fn grid_length_mismatch_errors() {
-    let decay = |_t: f64, y: &Vector<1, f64>| -*y;
+    let decay = |_time: f64, state: &Vector<1, f64>| -*state;
     let times = [0.5, 1.0];
-    let mut out = [Vector::<1, f64>::zeros(); 1];
-    let res = Rk45::default().solve_on_grid(&decay, 0.0, &Vector::new([1.0]), &times, &mut out);
-    assert_eq!(res.unwrap_err(), IntegrateError::LimitsIllDefined);
+    let mut outputs = [Vector::<1, f64>::zeros(); 1];
+    let result =
+        Rk45::default().solve_on_grid(&decay, 0.0, &Vector::new([1.0]), &times, &mut outputs);
+    assert_eq!(result.unwrap_err(), IntegrateError::LimitsIllDefined);
 }
 
 proptest! {
@@ -143,13 +149,13 @@ proptest! {
         tf in 0.5f64..3.0,
     ) {
         // y' = lambda*y, y(0) = a  ->  y(tf) = a * e^{lambda*tf}.
-        let f = |_t: f64, y: &Vector<1, f64>| y.scale(lambda);
-        let yf = Rk45::default()
+        let decay = |_time: f64, state: &Vector<1, f64>| state.scale(lambda);
+        let final_state = Rk45::default()
             .with_rtol(1e-9)
             .with_atol(1e-12)
-            .solve(&f, 0.0, &Vector::new([a]), tf)
+            .solve(&decay, 0.0, &Vector::new([a]), tf)
             .unwrap();
         let exact = a * (lambda * tf).exp();
-        prop_assert!((yf[0] - exact).abs() < 1e-6 * (1.0 + exact.abs()));
+        prop_assert!((final_state[0] - exact).abs() < 1e-6 * (1.0 + exact.abs()));
     }
 }

--- a/crates/multicalc/tests/suite/optimization.rs
+++ b/crates/multicalc/tests/suite/optimization.rs
@@ -15,9 +15,9 @@ use multicalc_testkit::problems::Rosenbrock;
 
 #[test]
 fn lm_solves_rosenbrock() {
-    let f = Rosenbrock;
+    let rosenbrock = Rosenbrock;
     let report: MinimizationReport<2> = LevenbergMarquardt::<AutoDiffMulti>::default()
-        .minimize(&f, &[-1.2, 1.0])
+        .minimize(&rosenbrock, &[-1.2, 1.0])
         .unwrap();
     assert!((report.solution[0] - 1.0).abs() < 1e-8);
     assert!((report.solution[1] - 1.0).abs() < 1e-8);
@@ -27,13 +27,13 @@ fn lm_solves_rosenbrock() {
 #[test]
 fn lm_recovers_linear_least_squares() {
     // Fit a*t + b to points lying exactly on y = 2t + 1.
-    let f = scalar_fn_vec!(|v: &[f64; 2]| [
+    let linear_residual = scalar_fn_vec!(|v: &[f64; 2]| [
         c(-1.0) + v[1],
         c(-3.0) + v[0] + v[1],
         c(-5.0) + c(2.0) * v[0] + v[1],
     ]);
     let report = LevenbergMarquardt::<AutoDiffMulti>::default()
-        .minimize(&f, &[0.0, 0.0])
+        .minimize(&linear_residual, &[0.0, 0.0])
         .unwrap();
     assert!((report.solution[0] - 2.0).abs() < 1e-12);
     assert!((report.solution[1] - 1.0).abs() < 1e-12);
@@ -43,13 +43,13 @@ fn lm_recovers_linear_least_squares() {
 #[test]
 fn lm_fits_exponential_decay() {
     // a*e^(b*t) through (0,100), (1,50), (2,25): a = 100, b = -ln 2.
-    let f = scalar_fn_vec!(|v: &[f64; 2]| [
+    let exponential_decay = scalar_fn_vec!(|v: &[f64; 2]| [
         c(-100.0) + v[0],
         c(-50.0) + v[0] * v[1].exp(),
         c(-25.0) + v[0] * (c(2.0) * v[1]).exp(),
     ]);
     let report = LevenbergMarquardt::<AutoDiffMulti>::default()
-        .minimize(&f, &[80.0, -0.3])
+        .minimize(&exponential_decay, &[80.0, -0.3])
         .unwrap();
     assert!((report.solution[0] - 100.0).abs() < 1e-7);
     assert!((report.solution[1] + 2.0_f64.ln()).abs() < 1e-8);
@@ -63,9 +63,9 @@ fn lm_fits_exponential_decay() {
 #[test]
 fn lm_solves_rosenbrock_f32() {
     // One residual definition drives both precisions; eval is generic over the scalar.
-    let f = Rosenbrock;
+    let rosenbrock = Rosenbrock;
     let report = LevenbergMarquardt::<AutoDiffMulti<f32>>::default()
-        .minimize(&f, &[-1.2_f32, 1.0])
+        .minimize(&rosenbrock, &[-1.2_f32, 1.0])
         .unwrap();
     assert!((report.solution[0] - 1.0).abs() < 1e-3);
     assert!((report.solution[1] - 1.0).abs() < 1e-3);
@@ -74,8 +74,9 @@ fn lm_solves_rosenbrock_f32() {
 #[test]
 fn lm_rejects_underdetermined() {
     // Two residuals, three parameters.
-    let f = scalar_fn_vec!(|v: &[f64; 3]| [c(-1.0) + v[0] + v[1], c(-2.0) + v[2]]);
-    let result = LevenbergMarquardt::<AutoDiffMulti>::default().minimize(&f, &[0.0, 0.0, 0.0]);
+    let underdetermined = scalar_fn_vec!(|v: &[f64; 3]| [c(-1.0) + v[0] + v[1], c(-2.0) + v[2]]);
+    let result =
+        LevenbergMarquardt::<AutoDiffMulti>::default().minimize(&underdetermined, &[0.0, 0.0, 0.0]);
     assert!(matches!(
         result,
         Err(SolveError::Linalg(LinalgError::Underdetermined))
@@ -85,41 +86,42 @@ fn lm_rejects_underdetermined() {
 #[test]
 fn lm_reports_non_finite() {
     // The residual is infinite at the starting point.
-    let f = scalar_fn_vec!(|v: &[f64; 1]| [c(1.0) / v[0], v[0]]);
-    let result = LevenbergMarquardt::<AutoDiffMulti>::default().minimize(&f, &[0.0]);
+    let residual = scalar_fn_vec!(|v: &[f64; 1]| [c(1.0) / v[0], v[0]]);
+    let result = LevenbergMarquardt::<AutoDiffMulti>::default().minimize(&residual, &[0.0]);
     assert!(matches!(result, Err(SolveError::NonFinite)));
 }
 
 #[test]
 fn lm_reports_did_not_converge() {
     // A one-iteration budget is too small for Rosenbrock, so the solver runs out.
-    let f = Rosenbrock;
+    let rosenbrock = Rosenbrock;
     let result = LevenbergMarquardt::<AutoDiffMulti>::default()
         .with_patience(1)
-        .minimize(&f, &[-1.2, 1.0]);
+        .minimize(&rosenbrock, &[-1.2, 1.0]);
     assert!(matches!(result, Err(SolveError::DidNotConverge { .. })));
 }
 
 // Sum of three damped sinusoids sampled at 60 points, with parameters [A, lambda, omega, phi]
 // per component. Holds the sample times and targets so the residual is model - target.
 struct DampedSinusoids {
-    t: [f64; 60],
-    y: [f64; 60],
+    sample_times: [f64; 60],
+    targets: [f64; 60],
 }
 
 impl VectorFn<12, 60> for DampedSinusoids {
-    fn eval<S: Numeric>(&self, p: &[S; 12]) -> [S; 60] {
-        core::array::from_fn(|i| {
-            let t = S::from_f64(self.t[i]);
+    fn eval<S: Numeric>(&self, parameters: &[S; 12]) -> [S; 60] {
+        core::array::from_fn(|sample_index| {
+            let time = S::from_f64(self.sample_times[sample_index]);
             let mut model = S::ZERO;
-            for k in 0..3 {
-                let a = p[4 * k];
-                let lambda = p[4 * k + 1];
-                let omega = p[4 * k + 2];
-                let phi = p[4 * k + 3];
-                model += a * (-(lambda * t)).exp() * (omega * t + phi).sin();
+            for component in 0..3 {
+                let amplitude = parameters[4 * component];
+                let decay_rate = parameters[4 * component + 1];
+                let frequency = parameters[4 * component + 2];
+                let phase = parameters[4 * component + 3];
+                model +=
+                    amplitude * (-(decay_rate * time)).exp() * (frequency * time + phase).sin();
             }
-            model - S::from_f64(self.y[i])
+            model - S::from_f64(self.targets[sample_index])
         })
     }
 }
@@ -132,10 +134,13 @@ fn lm_fits_damped_sinusoids() {
         0.7, 0.2, 5.0, 1.1, //
         1.3, 0.8, 8.5, -0.5, //
     ];
-    let t: [f64; 60] = core::array::from_fn(|i| i as f64 * 6.0 / 59.0);
-    let mut problem = DampedSinusoids { t, y: [0.0; 60] };
+    let sample_times: [f64; 60] = core::array::from_fn(|index| index as f64 * 6.0 / 59.0);
+    let mut problem = DampedSinusoids {
+        sample_times,
+        targets: [0.0; 60],
+    };
     // Generate noiseless targets: with y = 0 the residual is exactly the model.
-    problem.y = problem.eval(&truth);
+    problem.targets = problem.eval(&truth);
 
     // Start a modest step away (frequencies kept close, the rest looser).
     let start = [
@@ -159,14 +164,15 @@ fn lm_fits_damped_sinusoids() {
 struct Trigonometric<const N: usize>;
 
 impl<const N: usize> VectorFn<N, N> for Trigonometric<N> {
-    fn eval<S: Numeric>(&self, x: &[S; N]) -> [S; N] {
-        let n = S::from_f64(N as f64);
+    fn eval<S: Numeric>(&self, point: &[S; N]) -> [S; N] {
+        let dimension = S::from_f64(N as f64);
         let mut cos_sum = S::ZERO;
-        for &xj in x {
-            cos_sum += xj.cos();
+        for &component in point {
+            cos_sum += component.cos();
         }
-        core::array::from_fn(|i| {
-            n - cos_sum + S::from_f64((i + 1) as f64) * (S::ONE - x[i].cos()) - x[i].sin()
+        core::array::from_fn(|index| {
+            dimension - cos_sum + S::from_f64((index + 1) as f64) * (S::ONE - point[index].cos())
+                - point[index].sin()
         })
     }
 }
@@ -190,13 +196,13 @@ fn lm_solves_trigonometric() {
 #[test]
 fn gn_recovers_linear_least_squares() {
     // A linear residual: Gauss-Newton reaches the exact least-squares solution.
-    let f = scalar_fn_vec!(|v: &[f64; 2]| [
+    let linear_residual = scalar_fn_vec!(|v: &[f64; 2]| [
         c(-1.0) + v[1],
         c(-3.0) + v[0] + v[1],
         c(-5.0) + c(2.0) * v[0] + v[1],
     ]);
     let report = GaussNewton::<AutoDiffMulti>::default()
-        .minimize(&f, &[0.0, 0.0])
+        .minimize(&linear_residual, &[0.0, 0.0])
         .unwrap();
     assert!((report.solution[0] - 2.0).abs() < 1e-12);
     assert!((report.solution[1] - 1.0).abs() < 1e-12);
@@ -206,9 +212,9 @@ fn gn_recovers_linear_least_squares() {
 #[test]
 fn gn_solves_rosenbrock() {
     // From a near guess, Gauss-Newton converges quadratically on this zero-residual problem.
-    let f = Rosenbrock;
+    let rosenbrock = Rosenbrock;
     let report = GaussNewton::<AutoDiffMulti>::default()
-        .minimize(&f, &[0.9, 0.9])
+        .minimize(&rosenbrock, &[0.9, 0.9])
         .unwrap();
     assert!((report.solution[0] - 1.0).abs() < 1e-9);
     assert!((report.solution[1] - 1.0).abs() < 1e-9);
@@ -218,11 +224,11 @@ fn gn_solves_rosenbrock() {
 #[test]
 fn gn_reports_singular() {
     // The two residuals are proportional, so the Jacobian is rank-deficient.
-    let f = scalar_fn_vec!(|v: &[f64; 2]| [
+    let singular_residual = scalar_fn_vec!(|v: &[f64; 2]| [
         c(-1.0) + v[0] - v[1],
         c(-2.0) + c(2.0) * v[0] - c(2.0) * v[1],
     ]);
-    let result = GaussNewton::<AutoDiffMulti>::default().minimize(&f, &[0.0, 0.0]);
+    let result = GaussNewton::<AutoDiffMulti>::default().minimize(&singular_residual, &[0.0, 0.0]);
     assert!(matches!(
         result,
         Err(SolveError::Linalg(LinalgError::Singular))
@@ -231,8 +237,9 @@ fn gn_reports_singular() {
 
 #[test]
 fn gn_rejects_underdetermined() {
-    let f = scalar_fn_vec!(|v: &[f64; 3]| [c(-1.0) + v[0] + v[1], c(-2.0) + v[2]]);
-    let result = GaussNewton::<AutoDiffMulti>::default().minimize(&f, &[0.0, 0.0, 0.0]);
+    let underdetermined = scalar_fn_vec!(|v: &[f64; 3]| [c(-1.0) + v[0] + v[1], c(-2.0) + v[2]]);
+    let result =
+        GaussNewton::<AutoDiffMulti>::default().minimize(&underdetermined, &[0.0, 0.0, 0.0]);
     assert!(matches!(
         result,
         Err(SolveError::Linalg(LinalgError::Underdetermined))
@@ -241,27 +248,27 @@ fn gn_rejects_underdetermined() {
 
 #[test]
 fn gn_reports_non_finite() {
-    let f = scalar_fn_vec!(|v: &[f64; 1]| [c(1.0) / v[0], v[0]]);
-    let result = GaussNewton::<AutoDiffMulti>::default().minimize(&f, &[0.0]);
+    let residual = scalar_fn_vec!(|v: &[f64; 1]| [c(1.0) / v[0], v[0]]);
+    let result = GaussNewton::<AutoDiffMulti>::default().minimize(&residual, &[0.0]);
     assert!(matches!(result, Err(SolveError::NonFinite)));
 }
 
 // Fit a circle (center cx, cy, radius r) to points, minimizing the geometric distance residual
 // sqrt((x-cx)^2 + (y-cy)^2) - r. Holds the measured points.
 struct CircleFit {
-    px: [f64; 40],
-    py: [f64; 40],
+    measured_x: [f64; 40],
+    measured_y: [f64; 40],
 }
 
 impl VectorFn<3, 40> for CircleFit {
-    fn eval<S: Numeric>(&self, p: &[S; 3]) -> [S; 40] {
-        let cx = p[0];
-        let cy = p[1];
-        let r = p[2];
-        core::array::from_fn(|i| {
-            let dx = S::from_f64(self.px[i]) - cx;
-            let dy = S::from_f64(self.py[i]) - cy;
-            (dx * dx + dy * dy).sqrt() - r
+    fn eval<S: Numeric>(&self, parameters: &[S; 3]) -> [S; 40] {
+        let centre_x = parameters[0];
+        let centre_y = parameters[1];
+        let radius = parameters[2];
+        core::array::from_fn(|index| {
+            let offset_x = S::from_f64(self.measured_x[index]) - centre_x;
+            let offset_y = S::from_f64(self.measured_y[index]) - centre_y;
+            (offset_x * offset_x + offset_y * offset_y).sqrt() - radius
         })
     }
 }
@@ -269,10 +276,13 @@ impl VectorFn<3, 40> for CircleFit {
 #[test]
 fn gn_fits_circle() {
     // Points sampled exactly on a circle of center (2, -1), radius 3.
-    let angle = |i: usize| core::f64::consts::TAU * i as f64 / 40.0;
-    let px = core::array::from_fn(|i| 2.0 + 3.0 * angle(i).cos());
-    let py = core::array::from_fn(|i| -1.0 + 3.0 * angle(i).sin());
-    let problem = CircleFit { px, py };
+    let angle = |index: usize| core::f64::consts::TAU * index as f64 / 40.0;
+    let measured_x = core::array::from_fn(|index| 2.0 + 3.0 * angle(index).cos());
+    let measured_y = core::array::from_fn(|index| -1.0 + 3.0 * angle(index).sin());
+    let problem = CircleFit {
+        measured_x,
+        measured_y,
+    };
 
     // A near guess for the geometry.
     let report = GaussNewton::<AutoDiffMulti>::default()
@@ -286,23 +296,23 @@ fn gn_fits_circle() {
 
 // Fit two Gaussian peaks [a, mu, sigma] each to a sampled spectrum.
 struct GaussianPeaks {
-    t: [f64; 50],
-    y: [f64; 50],
+    sample_times: [f64; 50],
+    targets: [f64; 50],
 }
 
 impl VectorFn<6, 50> for GaussianPeaks {
-    fn eval<S: Numeric>(&self, p: &[S; 6]) -> [S; 50] {
-        core::array::from_fn(|i| {
-            let t = S::from_f64(self.t[i]);
+    fn eval<S: Numeric>(&self, parameters: &[S; 6]) -> [S; 50] {
+        core::array::from_fn(|sample_index| {
+            let time = S::from_f64(self.sample_times[sample_index]);
             let mut model = S::ZERO;
-            for k in 0..2 {
-                let a = p[3 * k];
-                let mu = p[3 * k + 1];
-                let sigma = p[3 * k + 2];
-                let z = (t - mu) / sigma;
-                model += a * (-(z * z)).exp();
+            for peak in 0..2 {
+                let amplitude = parameters[3 * peak];
+                let centre = parameters[3 * peak + 1];
+                let width = parameters[3 * peak + 2];
+                let standardized = (time - centre) / width;
+                model += amplitude * (-(standardized * standardized)).exp();
             }
-            model - S::from_f64(self.y[i])
+            model - S::from_f64(self.targets[sample_index])
         })
     }
 }
@@ -311,9 +321,12 @@ impl VectorFn<6, 50> for GaussianPeaks {
 fn gn_fits_gaussian_peaks() {
     // Two well-separated peaks: a=2 at mu=3 (sigma 0.8), a=1.5 at mu=7 (sigma 1.2).
     let truth = [2.0, 3.0, 0.8, 1.5, 7.0, 1.2];
-    let t: [f64; 50] = core::array::from_fn(|i| i as f64 * 10.0 / 49.0);
-    let mut problem = GaussianPeaks { t, y: [0.0; 50] };
-    problem.y = problem.eval(&truth);
+    let sample_times: [f64; 50] = core::array::from_fn(|index| index as f64 * 10.0 / 49.0);
+    let mut problem = GaussianPeaks {
+        sample_times,
+        targets: [0.0; 50],
+    };
+    problem.targets = problem.eval(&truth);
 
     // A near start recovers all six parameters.
     let start = [2.2, 3.2, 0.7, 1.3, 6.8, 1.3];
@@ -338,7 +351,7 @@ fn gn_backtracking_rescues_far_start() {
     // Plain Gauss-Newton overshoots: it either overflows or stalls on the tail far from x = 0.
     let plain = GaussNewton::<AutoDiffMulti>::default().minimize(&residual(), &far);
     let plain_missed = match &plain {
-        Ok(r) => r.objective_function > 0.4,
+        Ok(report) => report.objective_function > 0.4,
         Err(_) => true,
     };
     assert!(
@@ -358,22 +371,29 @@ fn gn_backtracking_rescues_far_start() {
 // ----- Embedded artifact regression -----
 
 struct SensorFit<const M: usize> {
-    t: [f64; M],
-    y: [f64; M],
+    sample_times: [f64; M],
+    targets: [f64; M],
 }
 
 impl<const M: usize> VectorFn<2, M> for SensorFit<M> {
-    fn eval<S: Numeric>(&self, p: &[S; 2]) -> [S; M] {
-        let (a, b) = (p[0], p[1]);
-        core::array::from_fn(|i| a * (b * S::from_f64(self.t[i])).exp() - S::from_f64(self.y[i]))
+    fn eval<S: Numeric>(&self, parameters: &[S; 2]) -> [S; M] {
+        let amplitude = parameters[0];
+        let decay_rate = parameters[1];
+        core::array::from_fn(|sample_index| {
+            amplitude * (decay_rate * S::from_f64(self.sample_times[sample_index])).exp()
+                - S::from_f64(self.targets[sample_index])
+        })
     }
 }
 
 #[test]
 fn embedded_artifact_fit_recovers_parameters() {
-    let t: [f64; 8] = core::array::from_fn(|i| i as f64);
-    let y: [f64; 8] = core::array::from_fn(|i| 100.0 * (-0.5 * i as f64).exp());
-    let problem = SensorFit { t, y };
+    let sample_times: [f64; 8] = core::array::from_fn(|index| index as f64);
+    let targets: [f64; 8] = core::array::from_fn(|index| 100.0 * (-0.5 * index as f64).exp());
+    let problem = SensorFit {
+        sample_times,
+        targets,
+    };
 
     let report = LevenbergMarquardt::<AutoDiffMulti>::default()
         .with_patience(50)
@@ -388,17 +408,22 @@ fn embedded_artifact_fit_recovers_parameters() {
 // ----- Residual / Jacobian API -----
 
 // Largest entrywise gap between the exact autodiff Jacobian and a central finite-difference
-// Jacobian of `f` at `x`. A small value confirms the autodiff derivatives the solvers rely on
-// match an independent finite-difference estimate.
-fn check_jacobian<F: VectorFn<N, M>, const N: usize, const M: usize>(f: &F, x: &[f64; N]) -> f64 {
-    let autodiff = Jacobian::<AutoDiffMulti>::default().evaluate(f, x).unwrap();
-    let finite = Jacobian::from_derivator(FiniteDifferenceMulti::<f64>::default())
-        .evaluate(f, x)
+// Jacobian of `function` at `point`. A small value confirms the autodiff derivatives the solvers
+// rely on match an independent finite-difference estimate.
+fn check_jacobian<F: VectorFn<N, M>, const N: usize, const M: usize>(
+    function: &F,
+    point: &[f64; N],
+) -> f64 {
+    let autodiff = Jacobian::<AutoDiffMulti>::default()
+        .evaluate(function, point)
+        .unwrap();
+    let finite_difference = Jacobian::from_derivator(FiniteDifferenceMulti::<f64>::default())
+        .evaluate(function, point)
         .unwrap();
     let mut worst = 0.0_f64;
-    for m in 0..M {
-        for n in 0..N {
-            worst = worst.max((autodiff[(m, n)] - finite[(m, n)]).abs());
+    for row in 0..M {
+        for column in 0..N {
+            worst = worst.max((autodiff[(row, column)] - finite_difference[(row, column)]).abs());
         }
     }
     worst
@@ -419,17 +444,30 @@ fn autodiff_jacobian_matches_finite_differences() {
 fn solvers_accept_a_finite_difference_backend() {
     // Swap the autodiff default for a finite-difference Jacobian; both solvers still converge on
     // the zero-residual Rosenbrock problem.
-    let f = Rosenbrock;
+    let rosenbrock = Rosenbrock;
 
-    let lm = LevenbergMarquardt::from_derivator(FiniteDifferenceMulti::<f64>::default())
-        .minimize(&f, &[-1.2, 1.0])
-        .unwrap();
-    assert!((lm.solution[0] - 1.0).abs() < 1e-5, "{lm:?}");
-    assert!((lm.solution[1] - 1.0).abs() < 1e-5, "{lm:?}");
+    let levenberg_marquardt =
+        LevenbergMarquardt::from_derivator(FiniteDifferenceMulti::<f64>::default())
+            .minimize(&rosenbrock, &[-1.2, 1.0])
+            .unwrap();
+    assert!(
+        (levenberg_marquardt.solution[0] - 1.0).abs() < 1e-5,
+        "{levenberg_marquardt:?}"
+    );
+    assert!(
+        (levenberg_marquardt.solution[1] - 1.0).abs() < 1e-5,
+        "{levenberg_marquardt:?}"
+    );
 
-    let gn = GaussNewton::from_derivator(FiniteDifferenceMulti::<f64>::default())
-        .minimize(&f, &[0.9, 0.9])
+    let gauss_newton = GaussNewton::from_derivator(FiniteDifferenceMulti::<f64>::default())
+        .minimize(&rosenbrock, &[0.9, 0.9])
         .unwrap();
-    assert!((gn.solution[0] - 1.0).abs() < 1e-5, "{gn:?}");
-    assert!((gn.solution[1] - 1.0).abs() < 1e-5, "{gn:?}");
+    assert!(
+        (gauss_newton.solution[0] - 1.0).abs() < 1e-5,
+        "{gauss_newton:?}"
+    );
+    assert!(
+        (gauss_newton.solution[1] - 1.0).abs() < 1e-5,
+        "{gauss_newton:?}"
+    );
 }

--- a/crates/multicalc/tests/suite/root_finding.rs
+++ b/crates/multicalc/tests/suite/root_finding.rs
@@ -10,46 +10,56 @@ use multicalc::scalar::{Numeric, ScalarFn, VectorFn, c};
 use multicalc::scalar_fn;
 use multicalc::scalar_fn_vec;
 
-fn bisect<F: ScalarFn>(f: &F, a: f64, b: f64) -> Result<RootReport<f64>, SolveError> {
-    Bisection::default().solve(f, a, b)
+fn bisect<F: ScalarFn>(
+    function: &F,
+    lower_bound: f64,
+    upper_bound: f64,
+) -> Result<RootReport<f64>, SolveError> {
+    Bisection::default().solve(function, lower_bound, upper_bound)
 }
 
-fn newton<F: ScalarFn>(f: &F, x0: f64) -> Result<RootReport<f64>, SolveError> {
-    let s: Newton = Newton::default();
-    s.solve(f, x0)
+fn newton<F: ScalarFn>(function: &F, initial_guess: f64) -> Result<RootReport<f64>, SolveError> {
+    let solver: Newton = Newton::default();
+    solver.solve(function, initial_guess)
 }
 
-fn nsystem<F: VectorFn<2, 2>>(f: &F, x0: &[f64; 2]) -> Result<RootReportN<2>, SolveError> {
-    let s: NewtonSystem = NewtonSystem::default();
-    s.solve(f, x0)
+fn newton_system<F: VectorFn<2, 2>>(
+    function: &F,
+    initial_guess: &[f64; 2],
+) -> Result<RootReportN<2>, SolveError> {
+    let solver: NewtonSystem = NewtonSystem::default();
+    solver.solve(function, initial_guess)
 }
 
 // x² + y² = 4, xy = 1; roots near (±1.932, ±0.518).
 struct CircleHyperbola;
 
 impl VectorFn<2, 2> for CircleHyperbola {
-    fn eval<S: Numeric>(&self, v: &[S; 2]) -> [S; 2] {
-        [c(-4.0) + v[0] * v[0] + v[1] * v[1], c(-1.0) + v[0] * v[1]]
+    fn eval<S: Numeric>(&self, point: &[S; 2]) -> [S; 2] {
+        [
+            c(-4.0) + point[0] * point[0] + point[1] * point[1],
+            c(-1.0) + point[0] * point[1],
+        ]
     }
 }
 
 // Two-link planar arm forward kinematics. Holds the link lengths and target tip position.
 struct TwoLinkArm {
-    l1: f64,
-    l2: f64,
-    px: f64,
-    py: f64,
+    first_link: f64,
+    second_link: f64,
+    target_x: f64,
+    target_y: f64,
 }
 
 impl VectorFn<2, 2> for TwoLinkArm {
-    fn eval<S: Numeric>(&self, v: &[S; 2]) -> [S; 2] {
-        let l1 = S::from_f64(self.l1);
-        let l2 = S::from_f64(self.l2);
-        let px = S::from_f64(self.px);
-        let py = S::from_f64(self.py);
+    fn eval<S: Numeric>(&self, angles: &[S; 2]) -> [S; 2] {
+        let first_link = S::from_f64(self.first_link);
+        let second_link = S::from_f64(self.second_link);
+        let target_x = S::from_f64(self.target_x);
+        let target_y = S::from_f64(self.target_y);
         [
-            l1 * v[0].cos() + l2 * (v[0] + v[1]).cos() - px,
-            l1 * v[0].sin() + l2 * (v[0] + v[1]).sin() - py,
+            first_link * angles[0].cos() + second_link * (angles[0] + angles[1]).cos() - target_x,
+            first_link * angles[0].sin() + second_link * (angles[0] + angles[1]).sin() - target_y,
         ]
     }
 }
@@ -58,8 +68,8 @@ impl VectorFn<2, 2> for TwoLinkArm {
 
 #[test]
 fn bisection_sqrt2() {
-    let f = scalar_fn!(|x| c(-2.0) + x * x);
-    let report = bisect(&f, 0.0_f64, 2.0).unwrap();
+    let sqrt_two = scalar_fn!(|x| c(-2.0) + x * x);
+    let report = bisect(&sqrt_two, 0.0_f64, 2.0).unwrap();
     assert!((report.root - 2.0_f64.sqrt()).abs() < 1e-9);
     assert!(matches!(
         report.termination,
@@ -70,25 +80,25 @@ fn bisection_sqrt2() {
 #[test]
 fn bisection_dottie_number() {
     // cos(x) = x, the fixed point of cosine ≈ 0.7390851332151607.
-    let f = scalar_fn!(|x| x.cos() - x);
-    let report = bisect(&f, 0.0_f64, 1.0).unwrap();
+    let dottie = scalar_fn!(|x| x.cos() - x);
+    let report = bisect(&dottie, 0.0_f64, 1.0).unwrap();
     assert!((report.root - 0.7390851332151607).abs() < 1e-9);
 }
 
 #[test]
 fn bisection_wien_displacement() {
     // Wien's displacement law: x - 5 + 5*e^(-x) = 0, constant ≈ 4.965114231744276.
-    let f = scalar_fn!(|x| c(-5.0) + x + c(5.0) * (-x).exp());
-    let report = bisect(&f, 1.0_f64, 10.0).unwrap();
+    let wien = scalar_fn!(|x| c(-5.0) + x + c(5.0) * (-x).exp());
+    let report = bisect(&wien, 1.0_f64, 10.0).unwrap();
     assert!((report.root - 4.965114231744276).abs() < 1e-9);
 }
 
 #[test]
 fn bisection_invalid_bracket() {
     // x² - 2 on [2, 3]: both values positive, no sign change.
-    let f = scalar_fn!(|x| c(-2.0) + x * x);
+    let sqrt_two = scalar_fn!(|x| c(-2.0) + x * x);
     assert!(matches!(
-        bisect(&f, 2.0_f64, 3.0),
+        bisect(&sqrt_two, 2.0_f64, 3.0),
         Err(SolveError::InvalidBracket)
     ));
 }
@@ -96,27 +106,27 @@ fn bisection_invalid_bracket() {
 #[test]
 fn bisection_non_finite() {
     // 1/x on [-1, 1]: f(-1) and f(1) have opposite signs, but f(0) = +∞.
-    let f = scalar_fn!(|x| c(1.0) / x);
+    let reciprocal = scalar_fn!(|x| c(1.0) / x);
     assert!(matches!(
-        bisect(&f, -1.0_f64, 1.0),
+        bisect(&reciprocal, -1.0_f64, 1.0),
         Err(SolveError::NonFinite)
     ));
 }
 
 #[test]
 fn bisection_budget_exhausted() {
-    let f = scalar_fn!(|x| c(-2.0) + x * x);
+    let sqrt_two = scalar_fn!(|x| c(-2.0) + x * x);
     let result = Bisection::default()
         .with_max_iterations(2)
-        .solve(&f, 0.0_f64, 2.0);
+        .solve(&sqrt_two, 0.0_f64, 2.0);
     assert!(matches!(result, Err(SolveError::DidNotConverge { .. })));
 }
 
 #[test]
 fn bisection_exact_endpoint_root() {
     // f(0) = 0 exactly; the solver returns before the first iteration.
-    let f = scalar_fn!(|x| x);
-    let report = bisect(&f, 0.0_f64, 1.0).unwrap();
+    let line = scalar_fn!(|x| x);
+    let report = bisect(&line, 0.0_f64, 1.0).unwrap();
     assert_eq!(report.root, 0.0_f64);
     assert!(matches!(
         report.termination,
@@ -128,8 +138,8 @@ fn bisection_exact_endpoint_root() {
 
 #[test]
 fn newton_sqrt2() {
-    let f = scalar_fn!(|x| c(-2.0) + x * x);
-    let report = newton(&f, 2.0_f64).unwrap();
+    let sqrt_two = scalar_fn!(|x| c(-2.0) + x * x);
+    let report = newton(&sqrt_two, 2.0_f64).unwrap();
     assert!((report.root - 2.0_f64.sqrt()).abs() < 1e-12);
     assert!(matches!(
         report.termination,
@@ -140,58 +150,58 @@ fn newton_sqrt2() {
 #[test]
 fn newton_cbrt2() {
     // x³ - 2 = 0, root at 2^(1/3) ≈ 1.2599210498948732.
-    let f = scalar_fn!(|x| c(-2.0) + x.powi(3));
-    let report = newton(&f, 1.0_f64).unwrap();
+    let cbrt_two = scalar_fn!(|x| c(-2.0) + x.powi(3));
+    let report = newton(&cbrt_two, 1.0_f64).unwrap();
     assert!((report.root - 2.0_f64.powf(1.0 / 3.0)).abs() < 1e-12);
 }
 
 #[test]
 fn newton_wien_displacement() {
-    let f = scalar_fn!(|x| c(-5.0) + x + c(5.0) * (-x).exp());
-    let report = newton(&f, 5.0_f64).unwrap();
+    let wien = scalar_fn!(|x| c(-5.0) + x + c(5.0) * (-x).exp());
+    let report = newton(&wien, 5.0_f64).unwrap();
     assert!((report.root - 4.965114231744276).abs() < 1e-12);
 }
 
 #[test]
 fn newton_finite_difference_backend() {
     // Any DerivatorSingleVariable works in place of the autodiff default.
-    let f = scalar_fn!(|x| c(-2.0) + x * x);
+    let sqrt_two = scalar_fn!(|x| c(-2.0) + x * x);
     let solver = Newton::from_derivator(FiniteDifferenceSingle::<f64>::default());
-    let report = solver.solve(&f, 2.0_f64).unwrap();
+    let report = solver.solve(&sqrt_two, 2.0_f64).unwrap();
     assert!((report.root - 2.0_f64.sqrt()).abs() < 1e-6);
 }
 
 #[test]
 fn newton_vanishing_derivative() {
     // f'(0) = 0 for x² - 2, so the first step is undefined.
-    let f = scalar_fn!(|x| c(-2.0) + x * x);
+    let sqrt_two = scalar_fn!(|x| c(-2.0) + x * x);
     assert!(matches!(
-        newton(&f, 0.0_f64),
+        newton(&sqrt_two, 0.0_f64),
         Err(SolveError::Linalg(LinalgError::Singular))
     ));
 }
 
 #[test]
 fn newton_budget_exhausted() {
-    let f = scalar_fn!(|x| c(-2.0) + x * x);
-    let s: Newton = Newton::default().with_max_iterations(1);
-    // One step from x0=2 is not enough to satisfy either tolerance.
+    let sqrt_two = scalar_fn!(|x| c(-2.0) + x * x);
+    let solver: Newton = Newton::default().with_max_iterations(1);
+    // One step from an initial guess of 2 is not enough to satisfy either tolerance.
     assert!(matches!(
-        s.solve(&f, 2.0_f64),
+        solver.solve(&sqrt_two, 2.0_f64),
         Err(SolveError::DidNotConverge { .. })
     ));
 }
 
 #[test]
 fn newton_damped_rescues_far_start() {
-    // f(x) = x / sqrt(1 + x²), root at 0. The Newton map is x → −x³, so from x0 = 2.0
-    // plain Newton diverges immediately. Backtracking halves the step until |f| decreases,
-    // which is enough to land back in the basin of the root.
-    let f = scalar_fn!(|x| x / (c(1.0) + x * x).sqrt());
+    // f(x) = x / sqrt(1 + x²), root at 0. The Newton map is x → −x³, so from an initial guess
+    // of 2.0 plain Newton diverges immediately. Backtracking halves the step until |f|
+    // decreases, which is enough to land back in the basin of the root.
+    let bounded_sigmoid = scalar_fn!(|x| x / (c(1.0) + x * x).sqrt());
 
-    let plain_result = newton(&f, 2.0_f64);
+    let plain_result = newton(&bounded_sigmoid, 2.0_f64);
     let plain_missed = match &plain_result {
-        Ok(r) => r.root.abs() > 0.1,
+        Ok(report) => report.root.abs() > 0.1,
         Err(_) => true,
     };
     assert!(
@@ -200,7 +210,7 @@ fn newton_damped_rescues_far_start() {
     );
 
     let damped: Newton = Newton::default().with_backtracking(true);
-    let report = damped.solve(&f, 2.0_f64).unwrap();
+    let report = damped.solve(&bounded_sigmoid, 2.0_f64).unwrap();
     assert!(report.root.abs() < 1e-6, "{report:?}");
 }
 
@@ -209,7 +219,7 @@ fn newton_damped_rescues_far_start() {
 #[test]
 fn newton_system_circle_hyperbola() {
     // x² + y² = 4 and xy = 1; root near (1.932, 0.518).
-    let report = nsystem(&CircleHyperbola, &[1.5_f64, 0.8]).unwrap();
+    let report = newton_system(&CircleHyperbola, &[1.5_f64, 0.8]).unwrap();
     assert!(report.residual_norm < 1e-12);
     let [x, y] = report.root;
     assert!((x * x + y * y - 4.0).abs() < 1e-12);
@@ -222,34 +232,47 @@ fn newton_system_circle_hyperbola() {
 
 #[test]
 fn newton_system_two_link_ik() {
-    // Two-link arm (l1 = l2 = 1) with true joint angles (0.5 rad, 0.8 rad).
+    // Two-link arm (both links 1 m) with true joint angles (0.5 rad, 0.8 rad).
     // Tip position is computed from the truth; the solver recovers the angles from a near start.
-    let (l1, l2) = (1.0_f64, 1.0_f64);
-    let (t1_true, t2_true) = (0.5_f64, 0.8_f64);
-    let px = l1 * t1_true.cos() + l2 * (t1_true + t2_true).cos();
-    let py = l1 * t1_true.sin() + l2 * (t1_true + t2_true).sin();
-    let report = nsystem(&TwoLinkArm { l1, l2, px, py }, &[0.4_f64, 0.9]).unwrap();
+    let first_link = 1.0_f64;
+    let second_link = 1.0_f64;
+    let true_first_angle = 0.5_f64;
+    let true_second_angle = 0.8_f64;
+    let target_x = first_link * true_first_angle.cos()
+        + second_link * (true_first_angle + true_second_angle).cos();
+    let target_y = first_link * true_first_angle.sin()
+        + second_link * (true_first_angle + true_second_angle).sin();
+    let report = newton_system(
+        &TwoLinkArm {
+            first_link,
+            second_link,
+            target_x,
+            target_y,
+        },
+        &[0.4_f64, 0.9],
+    )
+    .unwrap();
     assert!(report.residual_norm < 1e-12, "{report:?}");
-    let [t1, t2] = report.root;
+    let [first_angle, second_angle] = report.root;
     assert!(
-        (t1 - t1_true).abs() < 1e-10,
-        "theta1: got {t1}, want {t1_true}"
+        (first_angle - true_first_angle).abs() < 1e-10,
+        "theta1: got {first_angle}, want {true_first_angle}"
     );
     assert!(
-        (t2 - t2_true).abs() < 1e-10,
-        "theta2: got {t2}, want {t2_true}"
+        (second_angle - true_second_angle).abs() < 1e-10,
+        "theta2: got {second_angle}, want {true_second_angle}"
     );
 }
 
 #[test]
 fn newton_system_singular_jacobian() {
     // The two equations are proportional, so the Jacobian is rank-deficient.
-    let f = scalar_fn_vec!(|v: &[f64; 2]| [
+    let proportional_equations = scalar_fn_vec!(|v: &[f64; 2]| [
         c(-1.0) + v[0] + c(-1.0) * v[1],
         c(-2.0) + c(2.0) * v[0] + c(-2.0) * v[1],
     ]);
     assert!(matches!(
-        nsystem(&f, &[0.0_f64, 0.0]),
+        newton_system(&proportional_equations, &[0.0_f64, 0.0]),
         Err(SolveError::Linalg(LinalgError::Singular))
     ));
 }
@@ -257,18 +280,18 @@ fn newton_system_singular_jacobian() {
 #[test]
 fn newton_system_non_finite() {
     // First component is 1/v[0], which is infinite at the starting point.
-    let f = scalar_fn_vec!(|v: &[f64; 2]| [c(1.0) / v[0], v[1]]);
+    let pole_at_origin = scalar_fn_vec!(|v: &[f64; 2]| [c(1.0) / v[0], v[1]]);
     assert!(matches!(
-        nsystem(&f, &[0.0_f64, 0.0]),
+        newton_system(&pole_at_origin, &[0.0_f64, 0.0]),
         Err(SolveError::NonFinite)
     ));
 }
 
 #[test]
 fn newton_system_budget_exhausted() {
-    let s: NewtonSystem = NewtonSystem::default().with_max_iterations(1);
+    let solver: NewtonSystem = NewtonSystem::default().with_max_iterations(1);
     assert!(matches!(
-        s.solve(&CircleHyperbola, &[1.5_f64, 0.8]),
+        solver.solve(&CircleHyperbola, &[1.5_f64, 0.8]),
         Err(SolveError::DidNotConverge { .. })
     ));
 }
@@ -278,15 +301,15 @@ fn newton_system_damped_rescues_far_start() {
     // F(v) = [v[0]/sqrt(1+v[0]²), v[1]/sqrt(1+v[1]²)], root at (0, 0).
     // Each component has the Newton map x → −x³, so from (3, 3) the plain solver
     // diverges. Backtracking halves the step length until ‖F‖ decreases.
-    let f = scalar_fn_vec!(|v: &[f64; 2]| [
+    let bounded_sigmoids = scalar_fn_vec!(|v: &[f64; 2]| [
         v[0] / (c(1.0) + v[0] * v[0]).sqrt(),
         v[1] / (c(1.0) + v[1] * v[1]).sqrt(),
     ]);
     let far = [3.0_f64, 3.0];
 
-    let plain_result = nsystem(&f, &far);
+    let plain_result = newton_system(&bounded_sigmoids, &far);
     let plain_missed = match &plain_result {
-        Ok(r) => r.residual_norm > 0.1,
+        Ok(report) => report.residual_norm > 0.1,
         Err(_) => true,
     };
     assert!(
@@ -295,7 +318,7 @@ fn newton_system_damped_rescues_far_start() {
     );
 
     let damped: NewtonSystem = NewtonSystem::default().with_backtracking(true);
-    let report = damped.solve(&f, &far).unwrap();
+    let report = damped.solve(&bounded_sigmoids, &far).unwrap();
     assert!(report.residual_norm < 1e-10, "{report:?}");
 }
 
@@ -303,9 +326,9 @@ fn newton_system_damped_rescues_far_start() {
 
 #[test]
 fn newton_sqrt2_f32() {
-    let f = scalar_fn!(|x| c(-2.0) + x * x);
+    let sqrt_two = scalar_fn!(|x| c(-2.0) + x * x);
     let solver = Newton::<AutoDiffSingle<f32>>::default();
-    let report = solver.solve(&f, 2.0_f32).unwrap();
+    let report = solver.solve(&sqrt_two, 2.0_f32).unwrap();
     assert!((report.root - 2.0_f32.sqrt()).abs() < 1e-3);
 }
 
@@ -328,27 +351,39 @@ fn newton_system_circle_hyperbola_f32() {
 // Kepler's equation E - e*sin(E) = M, relating the mean anomaly M to the
 // eccentric anomaly E of an orbit with eccentricity e.
 struct Kepler {
-    e: f64,
-    m: f64,
+    eccentricity: f64,
+    mean_anomaly: f64,
 }
 
 impl ScalarFn for Kepler {
-    fn eval<S: Numeric>(&self, big_e: S) -> S {
-        big_e - S::from_f64(self.e) * big_e.sin() - S::from_f64(self.m)
+    fn eval<S: Numeric>(&self, eccentric_anomaly: S) -> S {
+        eccentric_anomaly
+            - S::from_f64(self.eccentricity) * eccentric_anomaly.sin()
+            - S::from_f64(self.mean_anomaly)
     }
 }
 
 #[test]
 fn kepler_equation_moderate_eccentricity() {
     // Orbit with e = 0.8. Pick a true eccentric anomaly, form the mean
-    // anomaly from it, then recover E by Newton starting at x0 = M.
-    let e = 0.8_f64;
-    let e_true = 1.0_f64;
-    let m = e_true - e * e_true.sin();
-    let report = newton(&Kepler { e, m }, m).unwrap();
-    assert!((report.root - e_true).abs() < 1e-12, "{report:?}");
+    // anomaly from it, then recover E by Newton starting at the mean anomaly.
+    let eccentricity = 0.8_f64;
+    let true_eccentric_anomaly = 1.0_f64;
+    let mean_anomaly = true_eccentric_anomaly - eccentricity * true_eccentric_anomaly.sin();
+    let report = newton(
+        &Kepler {
+            eccentricity,
+            mean_anomaly,
+        },
+        mean_anomaly,
+    )
+    .unwrap();
+    assert!(
+        (report.root - true_eccentric_anomaly).abs() < 1e-12,
+        "{report:?}"
+    );
     // The solved equation holds: E - e*sin(E) == M.
-    assert!((report.root - e * report.root.sin() - m).abs() < 1e-12);
+    assert!((report.root - eccentricity * report.root.sin() - mean_anomaly).abs() < 1e-12);
 }
 
 #[test]
@@ -356,45 +391,55 @@ fn kepler_equation_high_eccentricity() {
     // e = 0.99 with M near zero makes 1 - e*cos(E) ~ 0.01 near the root, so
     // the Newton derivative is small and the plain step is fragile. Bisection
     // on [0, π] is guaranteed; damped Newton also recovers the root.
-    let e = 0.99_f64;
-    let e_true = 0.5_f64;
-    let m = e_true - e * e_true.sin();
-    let f = Kepler { e, m };
+    let eccentricity = 0.99_f64;
+    let true_eccentric_anomaly = 0.5_f64;
+    let mean_anomaly = true_eccentric_anomaly - eccentricity * true_eccentric_anomaly.sin();
+    let kepler = Kepler {
+        eccentricity,
+        mean_anomaly,
+    };
 
-    let bracketed = bisect(&f, 0.0_f64, core::f64::consts::PI).unwrap();
-    assert!((bracketed.root - e_true).abs() < 1e-9, "{bracketed:?}");
+    let bracketed = bisect(&kepler, 0.0_f64, core::f64::consts::PI).unwrap();
+    assert!(
+        (bracketed.root - true_eccentric_anomaly).abs() < 1e-9,
+        "{bracketed:?}"
+    );
 
     let damped: Newton = Newton::default().with_backtracking(true);
-    let stepped = damped.solve(&f, m).unwrap();
-    assert!((stepped.root - e_true).abs() < 1e-9, "{stepped:?}");
+    let stepped = damped.solve(&kepler, mean_anomaly).unwrap();
+    assert!(
+        (stepped.root - true_eccentric_anomaly).abs() < 1e-9,
+        "{stepped:?}"
+    );
 }
 
-// Colebrook–White equation for the Darcy friction factor f of turbulent
-// pipe flow: 1/√f + 2*log10(rel_roughness/3.7 + 2.51/(Re*√f)) = 0.
+// Colebrook–White equation for the Darcy friction factor f of turbulent pipe flow:
+// 1/√f + 2*log10(relative_roughness/3.7 + 2.51/(Re*√f)) = 0.
 struct Colebrook {
-    reynolds: f64,
-    rel_roughness: f64,
+    reynolds_number: f64,
+    relative_roughness: f64,
 }
 
 impl ScalarFn for Colebrook {
-    fn eval<S: Numeric>(&self, f: S) -> S {
-        let re = S::from_f64(self.reynolds);
-        let eps = S::from_f64(self.rel_roughness);
-        let root_f = f.sqrt();
-        let inner = eps / S::from_f64(3.7) + S::from_f64(2.51) / (re * root_f);
-        let log10 = inner.ln() / S::from_f64(10.0).ln();
-        S::ONE / root_f + S::TWO * log10
+    fn eval<S: Numeric>(&self, friction_factor: S) -> S {
+        let reynolds_number = S::from_f64(self.reynolds_number);
+        let relative_roughness = S::from_f64(self.relative_roughness);
+        let root_friction_factor = friction_factor.sqrt();
+        let inner = relative_roughness / S::from_f64(3.7)
+            + S::from_f64(2.51) / (reynolds_number * root_friction_factor);
+        let base_ten_log = inner.ln() / S::from_f64(10.0).ln();
+        S::ONE / root_friction_factor + S::TWO * base_ten_log
     }
 }
 
 #[test]
 fn colebrook_white_friction_factor() {
     // Water in a commercial-steel pipe: Re = 1e5, relative roughness 1e-4.
-    let f = Colebrook {
-        reynolds: 1.0e5,
-        rel_roughness: 1.0e-4,
+    let colebrook = Colebrook {
+        reynolds_number: 1.0e5,
+        relative_roughness: 1.0e-4,
     };
-    let report = newton(&f, 0.02_f64).unwrap();
+    let report = newton(&colebrook, 0.02_f64).unwrap();
     assert!(report.residual.abs() < 1e-10, "{report:?}");
     // Physical friction factors sit in this range.
     assert!(report.root > 0.01 && report.root < 0.05, "{report:?}");
@@ -409,12 +454,12 @@ struct BondYield {
 }
 
 impl ScalarFn for BondYield {
-    fn eval<S: Numeric>(&self, r: S) -> S {
-        let mut pv = S::ZERO;
-        for (cash, t) in self.cashflows.iter().zip(self.times.iter()) {
-            pv += S::from_f64(*cash) / (S::ONE + r).powi(*t);
+    fn eval<S: Numeric>(&self, yield_rate: S) -> S {
+        let mut present_value = S::ZERO;
+        for (cash, time) in self.cashflows.iter().zip(self.times.iter()) {
+            present_value += S::from_f64(*cash) / (S::ONE + yield_rate).powi(*time);
         }
-        pv - S::from_f64(self.price)
+        present_value - S::from_f64(self.price)
     }
 }
 
@@ -424,22 +469,19 @@ fn bond_internal_rate_of_return() {
     // yield, price the bond at it, then recover the yield by Newton.
     let cashflows = [5.0, 5.0, 5.0, 5.0, 105.0];
     let times = [1, 2, 3, 4, 5];
-    let r_true = 0.04_f64;
+    let true_yield = 0.04_f64;
     let price: f64 = cashflows
         .iter()
         .zip(times.iter())
-        .map(|(cash, t)| cash / (1.0_f64 + r_true).powi(*t))
+        .map(|(cash, time)| cash / (1.0_f64 + true_yield).powi(*time))
         .sum();
-    let report = newton(
-        &BondYield {
-            cashflows,
-            times,
-            price,
-        },
-        0.1_f64,
-    )
-    .unwrap();
-    assert!((report.root - r_true).abs() < 1e-10, "{report:?}");
+    let bond = BondYield {
+        cashflows,
+        times,
+        price,
+    };
+    let report = newton(&bond, 0.1_f64).unwrap();
+    assert!((report.root - true_yield).abs() < 1e-10, "{report:?}");
 }
 
 // Catenary: a uniform cable of length `length` hung between supports a
@@ -451,10 +493,10 @@ struct Catenary {
 }
 
 impl ScalarFn for Catenary {
-    fn eval<S: Numeric>(&self, a: S) -> S {
-        let z = S::from_f64(self.span) / (S::TWO * a);
-        let sinh = (z.exp() - (-z).exp()) * S::HALF;
-        S::TWO * a * sinh - S::from_f64(self.length)
+    fn eval<S: Numeric>(&self, catenary_constant: S) -> S {
+        let scaled_half_span = S::from_f64(self.span) / (S::TWO * catenary_constant);
+        let sinh = (scaled_half_span.exp() - (-scaled_half_span).exp()) * S::HALF;
+        S::TWO * catenary_constant * sinh - S::from_f64(self.length)
     }
 }
 
@@ -463,29 +505,34 @@ fn catenary_constant() {
     // Choose the catenary constant, derive the cable length for a 4 m span,
     // then recover the constant by Newton.
     let span = 4.0_f64;
-    let a_true = 2.0_f64;
-    let z = span / (2.0 * a_true);
-    let length = 2.0 * a_true * z.sinh();
-    let report = newton(&Catenary { span, length }, 1.0_f64).unwrap();
-    assert!((report.root - a_true).abs() < 1e-10, "{report:?}");
+    let true_catenary_constant = 2.0_f64;
+    let scaled_half_span = span / (2.0 * true_catenary_constant);
+    let length = 2.0 * true_catenary_constant * scaled_half_span.sinh();
+    let catenary = Catenary { span, length };
+    let report = newton(&catenary, 1.0_f64).unwrap();
+    assert!(
+        (report.root - true_catenary_constant).abs() < 1e-10,
+        "{report:?}"
+    );
 }
 
 // Diode load line: the node voltage V where the resistor current (Vs-V)/R
 // equals the Shockley diode current Is*(exp(V/Vt) - 1).
 struct DiodeLoadLine {
-    vs: f64,
-    r: f64,
-    is: f64,
-    vt: f64,
+    source_voltage: f64,
+    resistance: f64,
+    saturation_current: f64,
+    thermal_voltage: f64,
 }
 
 impl ScalarFn for DiodeLoadLine {
-    fn eval<S: Numeric>(&self, v: S) -> S {
-        let vs = S::from_f64(self.vs);
-        let r = S::from_f64(self.r);
-        let is = S::from_f64(self.is);
-        let vt = S::from_f64(self.vt);
-        (vs - v) / r - is * ((v / vt).exp() - S::ONE)
+    fn eval<S: Numeric>(&self, node_voltage: S) -> S {
+        let source_voltage = S::from_f64(self.source_voltage);
+        let resistance = S::from_f64(self.resistance);
+        let saturation_current = S::from_f64(self.saturation_current);
+        let thermal_voltage = S::from_f64(self.thermal_voltage);
+        (source_voltage - node_voltage) / resistance
+            - saturation_current * ((node_voltage / thermal_voltage).exp() - S::ONE)
     }
 }
 
@@ -494,14 +541,20 @@ fn diode_load_line_voltage() {
     // 5 V source, 1 kΩ resistor, thermal voltage 25.852 mV. Pick the true
     // node voltage and back out the saturation current so it is the exact
     // root, then bracket the stiff exponential equation with bisection.
-    let vs = 5.0_f64;
-    let r = 1000.0_f64;
-    let vt = 0.025852_f64;
-    let v_true = 0.6_f64;
-    let is = ((vs - v_true) / r) / ((v_true / vt).exp() - 1.0);
-    let diode = DiodeLoadLine { vs, r, is, vt };
+    let source_voltage = 5.0_f64;
+    let resistance = 1000.0_f64;
+    let thermal_voltage = 0.025852_f64;
+    let true_node_voltage = 0.6_f64;
+    let saturation_current = ((source_voltage - true_node_voltage) / resistance)
+        / ((true_node_voltage / thermal_voltage).exp() - 1.0);
+    let diode = DiodeLoadLine {
+        source_voltage,
+        resistance,
+        saturation_current,
+        thermal_voltage,
+    };
     let report = bisect(&diode, 0.0_f64, 1.0).unwrap();
-    assert!((report.root - v_true).abs() < 1e-9, "{report:?}");
+    assert!((report.root - true_node_voltage).abs() < 1e-9, "{report:?}");
 }
 
 #[test]
@@ -509,14 +562,17 @@ fn wien_displacement_constant_from_blackbody_peak() {
     // The wavelength peak of the Planck blackbody spectrum solves
     // x - 5 + 5*e^(-x) = 0. Its root yields Wien's displacement constant
     // b = h*c/(x*k_B) ≈ 2.897771955e-3 m·K.
-    let f = scalar_fn!(|x| c(-5.0) + x + c(5.0) * (-x).exp());
-    let report = newton(&f, 5.0_f64).unwrap();
+    let wien = scalar_fn!(|x| c(-5.0) + x + c(5.0) * (-x).exp());
+    let report = newton(&wien, 5.0_f64).unwrap();
     let x = report.root;
-    let h = 6.62607015e-34_f64;
-    let c_light = 299_792_458.0_f64;
-    let k_b = 1.380649e-23_f64;
-    let b = h * c_light / (x * k_b);
-    assert!((b - 2.897771955e-3).abs() < 1e-9, "b = {b}");
+    let planck_constant = 6.62607015e-34_f64;
+    let speed_of_light = 299_792_458.0_f64;
+    let boltzmann_constant = 1.380649e-23_f64;
+    let wien_constant = planck_constant * speed_of_light / (x * boltzmann_constant);
+    assert!(
+        (wien_constant - 2.897771955e-3).abs() < 1e-9,
+        "b = {wien_constant}"
+    );
 }
 
 // ----- Systems -----
@@ -525,18 +581,18 @@ fn wien_displacement_constant_from_blackbody_peak() {
 fn chemical_equilibrium_three_species() {
     // Mass balance A + B + C = 1 coupled with two equilibria B = K1*A² and
     // C = K2*A*B. The constants are chosen so the solution is (0.4, 0.2, 0.4).
-    let f = scalar_fn_vec!(|v: &[f64; 3]| [
+    let equilibrium = scalar_fn_vec!(|v: &[f64; 3]| [
         c(-1.0) + v[0] + v[1] + v[2],
         v[1] - c(1.25) * v[0] * v[0],
         v[2] - c(5.0) * v[0] * v[1],
     ]);
     let solver: NewtonSystem = NewtonSystem::default();
-    let report = solver.solve(&f, &[0.5_f64, 0.25, 0.25]).unwrap();
+    let report = solver.solve(&equilibrium, &[0.5_f64, 0.25, 0.25]).unwrap();
     assert!(report.residual_norm < 1e-12, "{report:?}");
-    let [a, b, conc_c] = report.root;
-    assert!((a - 0.4).abs() < 1e-10, "{report:?}");
-    assert!((b - 0.2).abs() < 1e-10, "{report:?}");
-    assert!((conc_c - 0.4).abs() < 1e-10, "{report:?}");
+    let [concentration_a, concentration_b, concentration_c] = report.root;
+    assert!((concentration_a - 0.4).abs() < 1e-10, "{report:?}");
+    assert!((concentration_b - 0.2).abs() < 1e-10, "{report:?}");
+    assert!((concentration_c - 0.4).abs() < 1e-10, "{report:?}");
 }
 
 #[test]
@@ -544,21 +600,30 @@ fn two_link_arm_far_start_damped() {
     // A 2 m + 1 m planar arm reaching a target built from true joint angles.
     // Starting far from the solution, damped Newton pulls the tip onto the
     // target; the residual is the tip-to-target error.
-    let (l1, l2) = (2.0_f64, 1.0_f64);
-    let (t1_true, t2_true) = (0.6_f64, 0.9_f64);
-    let px = l1 * t1_true.cos() + l2 * (t1_true + t2_true).cos();
-    let py = l1 * t1_true.sin() + l2 * (t1_true + t2_true).sin();
-    let arm = TwoLinkArm { l1, l2, px, py };
+    let first_link = 2.0_f64;
+    let second_link = 1.0_f64;
+    let true_first_angle = 0.6_f64;
+    let true_second_angle = 0.9_f64;
+    let target_x = first_link * true_first_angle.cos()
+        + second_link * (true_first_angle + true_second_angle).cos();
+    let target_y = first_link * true_first_angle.sin()
+        + second_link * (true_first_angle + true_second_angle).sin();
+    let arm = TwoLinkArm {
+        first_link,
+        second_link,
+        target_x,
+        target_y,
+    };
 
     let solver: NewtonSystem = NewtonSystem::default().with_backtracking(true);
     let report = solver.solve(&arm, &[0.1_f64, 0.5]).unwrap();
     assert!(report.residual_norm < 1e-10, "{report:?}");
     // The recovered angles place the tip on the target.
-    let [t1, t2] = report.root;
-    let tip_x = l1 * t1.cos() + l2 * (t1 + t2).cos();
-    let tip_y = l1 * t1.sin() + l2 * (t1 + t2).sin();
+    let [first_angle, second_angle] = report.root;
+    let tip_x = first_link * first_angle.cos() + second_link * (first_angle + second_angle).cos();
+    let tip_y = first_link * first_angle.sin() + second_link * (first_angle + second_angle).sin();
     assert!(
-        (tip_x - px).abs() < 1e-9 && (tip_y - py).abs() < 1e-9,
+        (tip_x - target_x).abs() < 1e-9 && (tip_y - target_y).abs() < 1e-9,
         "{report:?}"
     );
 }

--- a/crates/multicalc/tests/suite/scalar.rs
+++ b/crates/multicalc/tests/suite/scalar.rs
@@ -44,9 +44,9 @@ mod numeric_methods {
     fn hypot_no_overflow() {
         // naive sqrt(a²+b²) would overflow; the scaled form must stay finite and correct.
         let big = 1e200_f64;
-        let h = Numeric::hypot(big, big);
-        assert!(h.is_finite());
-        assert!((h - big * 2.0_f64.sqrt()).abs() / h < 1e-12);
+        let hypotenuse = Numeric::hypot(big, big);
+        assert!(hypotenuse.is_finite());
+        assert!((hypotenuse - big * 2.0_f64.sqrt()).abs() / hypotenuse < 1e-12);
     }
 
     #[test]
@@ -59,9 +59,15 @@ mod numeric_methods {
         ); // cosh² − sinh² = 1
         assert!((Numeric::tanh(x) - Numeric::sinh(x) / Numeric::cosh(x)).abs() < 1e-5);
         assert!((Numeric::powf(3.0_f32, 2.0) - 9.0).abs() < 1e-3);
-        let (y, xx) = (0.7_f32, 1.3_f32);
         // cos(atan2(y, x))·hypot(y, x) = x
-        assert!((Numeric::atan2(y, xx).cos() * Numeric::hypot(y, xx) - xx).abs() < 1e-4);
+        let opposite = 0.7_f32;
+        let adjacent = 1.3_f32;
+        assert!(
+            (Numeric::atan2(opposite, adjacent).cos() * Numeric::hypot(opposite, adjacent)
+                - adjacent)
+                .abs()
+                < 1e-4
+        );
     }
 
     #[test]
@@ -113,250 +119,252 @@ mod dual {
     const TOL_F32: f32 = 1e-5;
 
     #[test]
-    fn test_polynomial_powi() {
+    fn powi_carries_the_power_rule() {
         // f(x) = x^3, f'(x) = 3x^2; at x = 2 -> 8 and 12
-        let y = Dual::variable(2.0_f64).powi(3);
-        assert!(f64::abs(y.value - 8.0) < TOL);
-        assert!(f64::abs(y.deriv - 12.0) < TOL);
+        let cubed = Dual::variable(2.0_f64).powi(3);
+        assert!(f64::abs(cubed.value - 8.0) < TOL);
+        assert!(f64::abs(cubed.deriv - 12.0) < TOL);
     }
 
     #[test]
-    fn test_polynomial_sum() {
+    fn a_sum_of_terms_differentiates_termwise() {
         // f(x) = 3x^2 + 2x, f'(x) = 6x + 2; at x = 2 -> 16 and 14
         let x = Dual::variable(2.0_f64);
-        let y = Dual::constant(3.0) * x * x + Dual::constant(2.0) * x;
-        assert!(f64::abs(y.value - 16.0) < TOL);
-        assert!(f64::abs(y.deriv - 14.0) < TOL);
+        let sum = Dual::constant(3.0) * x * x + Dual::constant(2.0) * x;
+        assert!(f64::abs(sum.value - 16.0) < TOL);
+        assert!(f64::abs(sum.deriv - 14.0) < TOL);
     }
 
     #[test]
-    fn test_negative_powi() {
+    fn a_negative_power_differentiates_correctly() {
         // f(x) = x^-2, f'(x) = -2 x^-3; at x = 2 -> 0.25 and -0.25
-        let y = Dual::variable(2.0_f64).powi(-2);
-        assert!(f64::abs(y.value - 0.25) < TOL);
-        assert!(f64::abs(y.deriv - (-0.25)) < TOL);
+        let inverse_square = Dual::variable(2.0_f64).powi(-2);
+        assert!(f64::abs(inverse_square.value - 0.25) < TOL);
+        assert!(f64::abs(inverse_square.deriv - (-0.25)) < TOL);
     }
 
     #[test]
-    fn test_sqrt() {
+    fn sqrt_value_and_derivative() {
         // f(x) = sqrt(x), f'(x) = 1/(2 sqrt(x)); at x = 4 -> 2 and 0.25
-        let y = Dual::variable(4.0_f64).sqrt();
-        assert!(f64::abs(y.value - 2.0) < TOL);
-        assert!(f64::abs(y.deriv - 0.25) < TOL);
+        let root = Dual::variable(4.0_f64).sqrt();
+        assert!(f64::abs(root.value - 2.0) < TOL);
+        assert!(f64::abs(root.deriv - 0.25) < TOL);
     }
 
     #[test]
-    fn test_sin_cos_tan() {
-        let x0 = 0.7_f64;
-        let s = Dual::variable(x0).sin();
-        assert!(f64::abs(s.value - f64::sin(x0)) < TOL);
-        assert!(f64::abs(s.deriv - f64::cos(x0)) < TOL);
+    fn sin_cos_and_tan_derivatives() {
+        let x = 0.7_f64;
+        let sine = Dual::variable(x).sin();
+        assert!(f64::abs(sine.value - f64::sin(x)) < TOL);
+        assert!(f64::abs(sine.deriv - f64::cos(x)) < TOL);
 
-        let c = Dual::variable(x0).cos();
-        assert!(f64::abs(c.value - f64::cos(x0)) < TOL);
-        assert!(f64::abs(c.deriv - (-f64::sin(x0))) < TOL);
+        let cosine = Dual::variable(x).cos();
+        assert!(f64::abs(cosine.value - f64::cos(x)) < TOL);
+        assert!(f64::abs(cosine.deriv - (-f64::sin(x))) < TOL);
 
-        let t = Dual::variable(x0).tan();
-        assert!(f64::abs(t.value - f64::tan(x0)) < TOL);
-        assert!(f64::abs(t.deriv - (1.0 + f64::tan(x0) * f64::tan(x0))) < TOL);
+        let tangent = Dual::variable(x).tan();
+        assert!(f64::abs(tangent.value - f64::tan(x)) < TOL);
+        assert!(f64::abs(tangent.deriv - (1.0 + f64::tan(x) * f64::tan(x))) < TOL);
     }
 
     #[test]
-    fn test_exp_ln() {
-        let x0 = 1.3_f64;
-        let e = Dual::variable(x0).exp();
-        assert!(f64::abs(e.value - f64::exp(x0)) < TOL);
-        assert!(f64::abs(e.deriv - f64::exp(x0)) < TOL);
+    fn exp_and_ln_derivatives() {
+        let x = 1.3_f64;
+        let exponential = Dual::variable(x).exp();
+        assert!(f64::abs(exponential.value - f64::exp(x)) < TOL);
+        assert!(f64::abs(exponential.deriv - f64::exp(x)) < TOL);
 
         // f(x) = ln(x), f'(x) = 1/x; at x = 2 -> ln 2 and 0.5
-        let l = Dual::variable(2.0_f64).ln();
-        assert!(f64::abs(l.value - f64::ln(2.0)) < TOL);
-        assert!(f64::abs(l.deriv - 0.5) < TOL);
+        let logarithm = Dual::variable(2.0_f64).ln();
+        assert!(f64::abs(logarithm.value - f64::ln(2.0)) < TOL);
+        assert!(f64::abs(logarithm.deriv - 0.5) < TOL);
     }
 
     #[test]
-    fn test_chain_exp_of_sin() {
+    fn the_chain_rule_holds_through_exp_of_sin() {
         // f(x) = exp(sin(x)), f'(x) = cos(x) exp(sin(x))
-        let x0 = 0.6_f64;
-        let y = Dual::variable(x0).sin().exp();
-        assert!(f64::abs(y.value - f64::exp(f64::sin(x0))) < TOL);
-        assert!(f64::abs(y.deriv - f64::cos(x0) * f64::exp(f64::sin(x0))) < TOL);
+        let x = 0.6_f64;
+        let chained = Dual::variable(x).sin().exp();
+        assert!(f64::abs(chained.value - f64::exp(f64::sin(x))) < TOL);
+        assert!(f64::abs(chained.deriv - f64::cos(x) * f64::exp(f64::sin(x))) < TOL);
     }
 
     #[test]
-    fn test_rational() {
+    fn a_rational_function_uses_the_quotient_rule() {
         // f(x) = x / (1 + x^2), f'(x) = (1 - x^2) / (1 + x^2)^2
-        let x0 = 1.5_f64;
-        let x = Dual::variable(x0);
-        let y = x / (Dual::constant(1.0) + x * x);
-        let denom = (1.0 + x0 * x0) * (1.0 + x0 * x0);
-        assert!(f64::abs(y.value - x0 / (1.0 + x0 * x0)) < TOL);
-        assert!(f64::abs(y.deriv - (1.0 - x0 * x0) / denom) < TOL);
+        let x = 1.5_f64;
+        let variable = Dual::variable(x);
+        let rational = variable / (Dual::constant(1.0) + variable * variable);
+        let denominator = (1.0 + x * x) * (1.0 + x * x);
+        assert!(f64::abs(rational.value - x / (1.0 + x * x)) < TOL);
+        assert!(f64::abs(rational.deriv - (1.0 - x * x) / denominator) < TOL);
     }
 
     #[test]
-    fn test_product_sin_cos() {
+    fn a_product_uses_the_product_rule() {
         // f(x) = sin(x) cos(x), f'(x) = cos^2(x) - sin^2(x)
-        let x0 = 0.9_f64;
-        let x = Dual::variable(x0);
-        let y = x.sin() * x.cos();
-        assert!(f64::abs(y.value - f64::sin(x0) * f64::cos(x0)) < TOL);
-        let expected = f64::cos(x0) * f64::cos(x0) - f64::sin(x0) * f64::sin(x0);
-        assert!(f64::abs(y.deriv - expected) < TOL);
+        let x = 0.9_f64;
+        let variable = Dual::variable(x);
+        let product = variable.sin() * variable.cos();
+        assert!(f64::abs(product.value - f64::sin(x) * f64::cos(x)) < TOL);
+        let expected = f64::cos(x) * f64::cos(x) - f64::sin(x) * f64::sin(x);
+        assert!(f64::abs(product.deriv - expected) < TOL);
     }
 
     #[test]
-    fn test_abs_both_sides() {
+    fn abs_differentiates_to_the_sign() {
         // derivative of |x| is +1 for x > 0 and -1 for x < 0
-        let pos = Dual::variable(2.0_f64).abs();
-        assert!(f64::abs(pos.value - 2.0) < TOL);
-        assert!(f64::abs(pos.deriv - 1.0) < TOL);
+        let positive = Dual::variable(2.0_f64).abs();
+        assert!(f64::abs(positive.value - 2.0) < TOL);
+        assert!(f64::abs(positive.deriv - 1.0) < TOL);
 
-        let neg = Dual::variable(-2.0_f64).abs();
-        assert!(f64::abs(neg.value - 2.0) < TOL);
-        assert!(f64::abs(neg.deriv - (-1.0)) < TOL);
+        let negative = Dual::variable(-2.0_f64).abs();
+        assert!(f64::abs(negative.value - 2.0) < TOL);
+        assert!(f64::abs(negative.deriv - (-1.0)) < TOL);
     }
 
     #[test]
-    fn test_max_min_select_branch_derivative() {
+    fn max_and_min_carry_the_selected_branch_derivative() {
         // max/min pick a branch by value and carry that branch's derivative.
-        let a = Dual::variable(3.0_f64); // value 3, deriv 1
-        let b = Dual::constant(5.0_f64); // value 5, deriv 0
-        let hi = a.max(b);
-        assert!(f64::abs(hi.value - 5.0) < TOL && f64::abs(hi.deriv) < TOL);
-        let lo = a.min(b);
-        assert!(f64::abs(lo.value - 3.0) < TOL && f64::abs(lo.deriv - 1.0) < TOL);
+        let variable = Dual::variable(3.0_f64); // value 3, deriv 1
+        let constant = Dual::constant(5.0_f64); // value 5, deriv 0
+        let higher = variable.max(constant);
+        assert!(f64::abs(higher.value - 5.0) < TOL && f64::abs(higher.deriv) < TOL);
+        let lower = variable.min(constant);
+        assert!(f64::abs(lower.value - 3.0) < TOL && f64::abs(lower.deriv - 1.0) < TOL);
     }
 
     #[test]
-    fn test_generic_over_numeric() {
+    fn generic_over_numeric() {
         // The same function runs with a plain float or with a Dual.
         fn poly<T: Numeric>(t: T) -> T {
             t.powi(3) + T::from_f64(2.0) * t
         }
 
-        let x0 = 1.7_f64;
-        let plain = poly(x0);
-        let dual = poly(Dual::variable(x0));
+        let x = 1.7_f64;
+        let plain = poly(x);
+        let dual = poly(Dual::variable(x));
         assert!(f64::abs(dual.value - plain) < TOL);
         // f'(x) = 3x^2 + 2
-        assert!(f64::abs(dual.deriv - (3.0 * x0 * x0 + 2.0)) < TOL);
+        assert!(f64::abs(dual.deriv - (3.0 * x * x + 2.0)) < TOL);
     }
 
     #[test]
-    fn test_partial_derivatives() {
+    fn seeding_one_variable_gives_its_partial_derivative() {
         // f(x, y) = x^2 * y + sin(x)
-        fn f<T: Numeric>(v: &[T; 2]) -> T {
-            v[0] * v[0] * v[1] + v[0].sin()
+        fn function<T: Numeric>(point: &[T; 2]) -> T {
+            point[0] * point[0] * point[1] + point[0].sin()
         }
 
-        let (x0, y0) = (1.0_f64, 2.0_f64);
+        let x = 1.0_f64;
+        let y = 2.0_f64;
 
         // seed x: df/dx = 2xy + cos(x)
-        let dfdx = f(&[Dual::variable(x0), Dual::constant(y0)]).deriv;
-        assert!(f64::abs(dfdx - (2.0 * x0 * y0 + f64::cos(x0))) < TOL);
+        let partial_x = function(&[Dual::variable(x), Dual::constant(y)]).deriv;
+        assert!(f64::abs(partial_x - (2.0 * x * y + f64::cos(x))) < TOL);
 
         // seed y: df/dy = x^2
-        let dfdy = f(&[Dual::constant(x0), Dual::variable(y0)]).deriv;
-        assert!(f64::abs(dfdy - x0 * x0) < TOL);
+        let partial_y = function(&[Dual::constant(x), Dual::variable(y)]).deriv;
+        assert!(f64::abs(partial_y - x * x) < TOL);
     }
 
     #[test]
-    fn test_generic_over_f32() {
+    fn generic_over_f32() {
         // Dual is generic over the scalar; here it carries f32.
-        let y = Dual::variable(2.0_f32).powi(3);
-        assert!(f32::abs(y.value - 8.0) < TOL_F32);
-        assert!(f32::abs(y.deriv - 12.0) < TOL_F32);
+        let cubed = Dual::variable(2.0_f32).powi(3);
+        assert!(f32::abs(cubed.value - 8.0) < TOL_F32);
+        assert!(f32::abs(cubed.deriv - 12.0) < TOL_F32);
     }
 
     #[test]
-    fn test_powi_zero() {
+    fn the_zeroth_power_has_no_derivative() {
         // x^0 = 1, derivative 0
-        let y = Dual::variable(3.0_f64).powi(0);
-        assert!(f64::abs(y.value - 1.0) < TOL);
-        assert!(f64::abs(y.deriv) < TOL);
+        let zeroth_power = Dual::variable(3.0_f64).powi(0);
+        assert!(f64::abs(zeroth_power.value - 1.0) < TOL);
+        assert!(f64::abs(zeroth_power.deriv) < TOL);
     }
 
     #[test]
-    fn test_constant_has_zero_derivative() {
+    fn a_constant_has_zero_derivative() {
         // a constant carries no derivative through any operation
-        let c = Dual::constant(1.3_f64);
-        let y = c.exp() * c.sin() + c.powi(2);
-        assert!(f64::abs(y.deriv) < TOL);
+        let constant = Dual::constant(1.3_f64);
+        let combined = constant.exp() * constant.sin() + constant.powi(2);
+        assert!(f64::abs(combined.deriv) < TOL);
     }
 
     #[test]
-    fn test_sqrt_zero_derivative_is_infinite() {
+    fn sqrt_at_zero_has_an_infinite_derivative() {
         // the derivative of sqrt at 0 is unbounded, while the value stays finite
-        let y = Dual::variable(0.0_f64).sqrt();
-        assert!(f64::abs(y.value) < TOL);
-        assert!(y.deriv.is_infinite());
+        let root = Dual::variable(0.0_f64).sqrt();
+        assert!(f64::abs(root.value) < TOL);
+        assert!(root.deriv.is_infinite());
         // is_finite reflects the value only, so it still reports finite here
-        assert!(y.is_finite());
+        assert!(root.is_finite());
     }
 
     #[test]
-    fn test_ln_zero_blows_up() {
+    fn ln_at_zero_blows_up() {
         // ln(0) = -inf with an unbounded derivative
-        let y = Dual::variable(0.0_f64).ln();
-        assert!(y.value.is_infinite() && y.value < 0.0);
-        assert!(y.deriv.is_infinite() && y.deriv > 0.0);
+        let logarithm = Dual::variable(0.0_f64).ln();
+        assert!(logarithm.value.is_infinite() && logarithm.value < 0.0);
+        assert!(logarithm.deriv.is_infinite() && logarithm.deriv > 0.0);
     }
 
     #[test]
-    fn test_atan2_derivative() {
+    fn atan2_derivative_in_its_first_argument() {
         // f(y) = atan2(y, x), x constant: f'(y) = x/(x²+y²)
-        let (y0, x0) = (1.0_f64, 2.0_f64);
-        let r = Dual::variable(y0).atan2(Dual::constant(x0));
-        assert!(f64::abs(r.value - y0.atan2(x0)) < TOL);
-        assert!(f64::abs(r.deriv - x0 / (x0 * x0 + y0 * y0)) < TOL);
+        let y = 1.0_f64;
+        let x = 2.0_f64;
+        let angle = Dual::variable(y).atan2(Dual::constant(x));
+        assert!(f64::abs(angle.value - y.atan2(x)) < TOL);
+        assert!(f64::abs(angle.deriv - x / (x * x + y * y)) < TOL);
     }
 
     #[test]
-    fn test_inverse_trig_derivatives() {
-        let x0 = 0.3_f64;
-        let s = Dual::variable(x0).asin();
-        assert!(f64::abs(s.value - x0.asin()) < TOL);
-        assert!(f64::abs(s.deriv - 1.0 / (1.0 - x0 * x0).sqrt()) < TOL); // asin' = 1/√(1−x²)
-        let c = Dual::variable(x0).acos();
-        assert!(f64::abs(c.deriv + 1.0 / (1.0 - x0 * x0).sqrt()) < TOL); // acos' = −asin'
-        let a = Dual::variable(x0).atan();
-        assert!(f64::abs(a.deriv - 1.0 / (1.0 + x0 * x0)) < TOL); // atan' = 1/(1+x²)
+    fn inverse_trig_derivatives() {
+        let x = 0.3_f64;
+        let arcsine = Dual::variable(x).asin();
+        assert!(f64::abs(arcsine.value - x.asin()) < TOL);
+        assert!(f64::abs(arcsine.deriv - 1.0 / (1.0 - x * x).sqrt()) < TOL); // asin' = 1/√(1−x²)
+        let arccosine = Dual::variable(x).acos();
+        assert!(f64::abs(arccosine.deriv + 1.0 / (1.0 - x * x).sqrt()) < TOL); // acos' = −asin'
+        let arctangent = Dual::variable(x).atan();
+        assert!(f64::abs(arctangent.deriv - 1.0 / (1.0 + x * x)) < TOL); // atan' = 1/(1+x²)
     }
 
     #[test]
-    fn test_hyperbolic_derivatives() {
-        let x0 = 0.8_f64;
-        let sh = Dual::variable(x0).sinh();
-        assert!(f64::abs(sh.deriv - x0.cosh()) < TOL); // sinh' = cosh
-        let ch = Dual::variable(x0).cosh();
-        assert!(f64::abs(ch.deriv - x0.sinh()) < TOL); // cosh' = sinh
-        let th = Dual::variable(x0).tanh();
-        assert!(f64::abs(th.deriv - (1.0 - x0.tanh() * x0.tanh())) < 1e-10); // tanh' = 1−tanh²
+    fn hyperbolic_derivatives() {
+        let x = 0.8_f64;
+        let sinh = Dual::variable(x).sinh();
+        assert!(f64::abs(sinh.deriv - x.cosh()) < TOL); // sinh' = cosh
+        let cosh = Dual::variable(x).cosh();
+        assert!(f64::abs(cosh.deriv - x.sinh()) < TOL); // cosh' = sinh
+        let tanh = Dual::variable(x).tanh();
+        assert!(f64::abs(tanh.deriv - (1.0 - x.tanh() * x.tanh())) < 1e-10); // tanh' = 1−tanh²
     }
 
     #[test]
-    fn test_powf_recip_hypot_derivatives() {
-        let x0 = 2.0_f64;
-        let p = Dual::variable(x0).powf(Dual::constant(3.5)); // d/dx x^3.5 = 3.5 x^2.5
-        assert!(f64::abs(p.deriv - 3.5 * x0.powf(2.5)) < 1e-10);
-        let r = Dual::variable(x0).recip(); // d/dx 1/x = −1/x²
-        assert!(f64::abs(r.deriv + 0.25) < TOL);
+    fn powf_recip_and_hypot_derivatives() {
+        let x = 2.0_f64;
+        let power = Dual::variable(x).powf(Dual::constant(3.5)); // d/dx x^3.5 = 3.5 x^2.5
+        assert!(f64::abs(power.deriv - 3.5 * x.powf(2.5)) < 1e-10);
+        let reciprocal = Dual::variable(x).recip(); // d/dx 1/x = −1/x²
+        assert!(f64::abs(reciprocal.deriv + 0.25) < TOL);
         // hypot(x, 4) with x variable: d/dx = x/hypot
-        let h = Dual::variable(3.0_f64).hypot(Dual::constant(4.0));
-        assert!(f64::abs(h.value - 5.0) < TOL);
-        assert!(f64::abs(h.deriv - 3.0 / 5.0) < TOL);
+        let hypotenuse = Dual::variable(3.0_f64).hypot(Dual::constant(4.0));
+        assert!(f64::abs(hypotenuse.value - 5.0) < TOL);
+        assert!(f64::abs(hypotenuse.deriv - 3.0 / 5.0) < TOL);
     }
 
     #[test]
-    fn test_floor_derivative_is_zero() {
-        let y = Dual::variable(2.7_f64).floor();
-        assert!(f64::abs(y.value - 2.0) < TOL);
-        assert!(f64::abs(y.deriv) < TOL);
+    fn floor_has_zero_derivative() {
+        let floored = Dual::variable(2.7_f64).floor();
+        assert!(f64::abs(floored.value - 2.0) < TOL);
+        assert!(f64::abs(floored.deriv) < TOL);
     }
 
     #[test]
-    fn test_copysign_derivative() {
+    fn copysign_carries_the_sign_into_the_derivative() {
         let same = Dual::variable(3.0_f64).copysign(Dual::constant(1.0));
         assert!(f64::abs(same.value - 3.0) < TOL && f64::abs(same.deriv - 1.0) < TOL);
         let flip = Dual::variable(3.0_f64).copysign(Dual::constant(-1.0));
@@ -364,7 +372,7 @@ mod dual {
     }
 
     #[test]
-    fn test_atan2_derivative_random() {
+    fn atan2_derivatives_match_the_closed_form_across_the_plane() {
         use rand::rngs::StdRng;
         use rand::{Rng, SeedableRng};
 
@@ -372,19 +380,19 @@ mod dual {
         // quadrants and near the axes, comparing AD to the closed form.
         let mut rng = StdRng::seed_from_u64(0xA7A2);
         for _ in 0..1000 {
-            let y0: f64 = rng.gen_range(-5.0..5.0);
-            let x0: f64 = rng.gen_range(-5.0..5.0);
-            let denom = x0 * x0 + y0 * y0;
-            if denom < 1e-6 {
+            let y: f64 = rng.gen_range(-5.0..5.0);
+            let x: f64 = rng.gen_range(-5.0..5.0);
+            let denominator = x * x + y * y;
+            if denominator < 1e-6 {
                 continue; // origin is the documented singularity
             }
-            // seed y (x constant): expect x/denom
-            let dy = Dual::variable(y0).atan2(Dual::constant(x0));
-            assert!(f64::abs(dy.value - y0.atan2(x0)) < TOL);
-            assert!(f64::abs(dy.deriv - x0 / denom) < 1e-9);
-            // seed x (y constant): expect −y/denom
-            let dx = Dual::constant(y0).atan2(Dual::variable(x0));
-            assert!(f64::abs(dx.deriv + y0 / denom) < 1e-9);
+            // seed y (x constant): expect x/denominator
+            let seeded_y = Dual::variable(y).atan2(Dual::constant(x));
+            assert!(f64::abs(seeded_y.value - y.atan2(x)) < TOL);
+            assert!(f64::abs(seeded_y.deriv - x / denominator) < 1e-9);
+            // seed x (y constant): expect −y/denominator
+            let seeded_x = Dual::constant(y).atan2(Dual::variable(x));
+            assert!(f64::abs(seeded_x.deriv + y / denominator) < 1e-9);
         }
     }
 }
@@ -398,168 +406,171 @@ mod hyper_dual {
     const TOL_F32: f32 = 1e-3;
 
     #[test]
-    fn test_single_var_cubic() {
+    fn a_cubic_carries_both_derivative_directions() {
         // f(x) = x^3 -> f'(x) = 3x^2, f''(x) = 6x; at x = 3: 27, 27, 18
-        let y = HyperDual::variable(3.0_f64).powi(3);
-        assert!(f64::abs(y.real - 27.0) < TOL);
-        assert!(f64::abs(y.eps1 - 27.0) < TOL);
-        assert!(f64::abs(y.eps2 - 27.0) < TOL);
-        assert!(f64::abs(y.eps1eps2 - 18.0) < TOL);
+        let cubed = HyperDual::variable(3.0_f64).powi(3);
+        assert!(f64::abs(cubed.real - 27.0) < TOL);
+        assert!(f64::abs(cubed.eps1 - 27.0) < TOL);
+        assert!(f64::abs(cubed.eps2 - 27.0) < TOL);
+        assert!(f64::abs(cubed.eps1eps2 - 18.0) < TOL);
     }
 
     #[test]
-    fn test_powi_second_order() {
+    fn powi_second_derivative() {
         // f(x) = x^4 -> f'(x) = 4x^3, f''(x) = 12x^2; at x = 2: 16, 32, 48
-        let y = HyperDual::variable(2.0_f64).powi(4);
-        assert!(f64::abs(y.real - 16.0) < TOL);
-        assert!(f64::abs(y.eps1 - 32.0) < TOL);
-        assert!(f64::abs(y.eps1eps2 - 48.0) < TOL);
+        let quartic = HyperDual::variable(2.0_f64).powi(4);
+        assert!(f64::abs(quartic.real - 16.0) < TOL);
+        assert!(f64::abs(quartic.eps1 - 32.0) < TOL);
+        assert!(f64::abs(quartic.eps1eps2 - 48.0) < TOL);
     }
 
     #[test]
-    fn test_sin_second_order() {
+    fn sin_second_derivative() {
         // f(x) = sin(x) -> f' = cos(x), f'' = -sin(x)
-        let x0 = 0.7_f64;
-        let y = HyperDual::variable(x0).sin();
-        assert!(f64::abs(y.real - f64::sin(x0)) < TOL);
-        assert!(f64::abs(y.eps1 - f64::cos(x0)) < TOL);
-        assert!(f64::abs(y.eps1eps2 - (-f64::sin(x0))) < TOL);
+        let x = 0.7_f64;
+        let sine = HyperDual::variable(x).sin();
+        assert!(f64::abs(sine.real - f64::sin(x)) < TOL);
+        assert!(f64::abs(sine.eps1 - f64::cos(x)) < TOL);
+        assert!(f64::abs(sine.eps1eps2 - (-f64::sin(x))) < TOL);
     }
 
     #[test]
-    fn test_exp_second_order() {
+    fn exp_is_its_own_second_derivative() {
         // f(x) = exp(x) is its own derivative to all orders
-        let x0 = 1.3_f64;
-        let y = HyperDual::variable(x0).exp();
-        assert!(f64::abs(y.real - f64::exp(x0)) < TOL);
-        assert!(f64::abs(y.eps1 - f64::exp(x0)) < TOL);
-        assert!(f64::abs(y.eps1eps2 - f64::exp(x0)) < TOL);
+        let x = 1.3_f64;
+        let exponential = HyperDual::variable(x).exp();
+        assert!(f64::abs(exponential.real - f64::exp(x)) < TOL);
+        assert!(f64::abs(exponential.eps1 - f64::exp(x)) < TOL);
+        assert!(f64::abs(exponential.eps1eps2 - f64::exp(x)) < TOL);
     }
 
     #[test]
-    fn test_reciprocal_second_order() {
+    fn reciprocal_second_derivative() {
         // f(x) = 1/x -> f' = -1/x^2, f'' = 2/x^3; at x = 2: 0.5, -0.25, 0.25
-        let y = HyperDual::constant(1.0_f64) / HyperDual::variable(2.0_f64);
-        assert!(f64::abs(y.real - 0.5) < TOL);
-        assert!(f64::abs(y.eps1 - (-0.25)) < TOL);
-        assert!(f64::abs(y.eps1eps2 - 0.25) < TOL);
+        let reciprocal = HyperDual::constant(1.0_f64) / HyperDual::variable(2.0_f64);
+        assert!(f64::abs(reciprocal.real - 0.5) < TOL);
+        assert!(f64::abs(reciprocal.eps1 - (-0.25)) < TOL);
+        assert!(f64::abs(reciprocal.eps1eps2 - 0.25) < TOL);
     }
 
     #[test]
-    fn test_full_hessian_matches_analytic() {
+    fn seeding_two_directions_gives_the_full_hessian() {
         // f(x, y) = x^2 * y + sin(x)
         // grad  = [2xy + cos x, x^2]
         // H     = [[2y - sin x, 2x], [2x, 0]]
-        fn f<T: Numeric>(v: &[T; 2]) -> T {
-            v[0] * v[0] * v[1] + v[0].sin()
+        fn function<T: Numeric>(point: &[T; 2]) -> T {
+            point[0] * point[0] * point[1] + point[0].sin()
         }
 
-        let (x0, y0) = (1.0_f64, 2.0_f64);
+        let x = 1.0_f64;
+        let y = 2.0_f64;
 
         // diagonal Hxx and the x-gradient: seed x on both directions, y constant
-        let hxx = f(&[HyperDual::variable(x0), HyperDual::constant(y0)]);
-        assert!(f64::abs(hxx.eps1 - (2.0 * x0 * y0 + f64::cos(x0))) < TOL); // df/dx
-        assert!(f64::abs(hxx.eps1eps2 - (2.0 * y0 - f64::sin(x0))) < TOL); // d2f/dx2
+        let seeded_x = function(&[HyperDual::variable(x), HyperDual::constant(y)]);
+        assert!(f64::abs(seeded_x.eps1 - (2.0 * x * y + f64::cos(x))) < TOL); // df/dx
+        assert!(f64::abs(seeded_x.eps1eps2 - (2.0 * y - f64::sin(x))) < TOL); // d2f/dx2
 
         // diagonal Hyy and the y-gradient: seed y on both directions, x constant
-        let hyy = f(&[HyperDual::constant(x0), HyperDual::variable(y0)]);
-        assert!(f64::abs(hyy.eps1 - x0 * x0) < TOL); // df/dy
-        assert!(f64::abs(hyy.eps1eps2) < TOL); // d2f/dy2 = 0
+        let seeded_y = function(&[HyperDual::constant(x), HyperDual::variable(y)]);
+        assert!(f64::abs(seeded_y.eps1 - x * x) < TOL); // df/dy
+        assert!(f64::abs(seeded_y.eps1eps2) < TOL); // d2f/dy2 = 0
 
         // mixed Hxy: seed x on direction 1, y on direction 2
-        let hxy = f(&[
-            HyperDual::new(x0, 1.0, 0.0, 0.0),
-            HyperDual::new(y0, 0.0, 1.0, 0.0),
+        let mixed = function(&[
+            HyperDual::new(x, 1.0, 0.0, 0.0),
+            HyperDual::new(y, 0.0, 1.0, 0.0),
         ]);
-        assert!(f64::abs(hxy.eps1eps2 - 2.0 * x0) < TOL);
+        assert!(f64::abs(mixed.eps1eps2 - 2.0 * x) < TOL);
 
         // symmetry: swapping the directions gives the same mixed partial
-        let hyx = f(&[
-            HyperDual::new(x0, 0.0, 1.0, 0.0),
-            HyperDual::new(y0, 1.0, 0.0, 0.0),
+        let mixed_swapped = function(&[
+            HyperDual::new(x, 0.0, 1.0, 0.0),
+            HyperDual::new(y, 1.0, 0.0, 0.0),
         ]);
-        assert!(f64::abs(hxy.eps1eps2 - hyx.eps1eps2) < TOL);
+        assert!(f64::abs(mixed.eps1eps2 - mixed_swapped.eps1eps2) < TOL);
     }
 
     #[test]
-    fn test_generic_over_numeric() {
+    fn generic_over_numeric() {
         // The same function runs with a plain float or with a HyperDual.
-        fn g<T: Numeric>(t: T) -> T {
+        fn polynomial<T: Numeric>(t: T) -> T {
             t.powi(3) + T::from_f64(2.0) * t
         }
 
-        let x0 = 1.7_f64;
-        let plain = g(x0);
-        let hd = g(HyperDual::variable(x0));
-        assert!(f64::abs(hd.real - plain) < TOL);
-        assert!(f64::abs(hd.eps1 - (3.0 * x0 * x0 + 2.0)) < TOL); // f'
-        assert!(f64::abs(hd.eps1eps2 - 6.0 * x0) < TOL); // f''
+        let x = 1.7_f64;
+        let plain = polynomial(x);
+        let hyper_dual = polynomial(HyperDual::variable(x));
+        assert!(f64::abs(hyper_dual.real - plain) < TOL);
+        assert!(f64::abs(hyper_dual.eps1 - (3.0 * x * x + 2.0)) < TOL); // f'
+        assert!(f64::abs(hyper_dual.eps1eps2 - 6.0 * x) < TOL); // f''
     }
 
     #[test]
-    fn test_generic_over_f32() {
+    fn generic_over_f32() {
         // HyperDual is generic over the scalar; here it carries f32.
-        let y = HyperDual::variable(2.0_f32).powi(4);
-        assert!(f32::abs(y.real - 16.0) < TOL_F32);
-        assert!(f32::abs(y.eps1 - 32.0) < TOL_F32);
-        assert!(f32::abs(y.eps1eps2 - 48.0) < TOL_F32);
+        let quartic = HyperDual::variable(2.0_f32).powi(4);
+        assert!(f32::abs(quartic.real - 16.0) < TOL_F32);
+        assert!(f32::abs(quartic.eps1 - 32.0) < TOL_F32);
+        assert!(f32::abs(quartic.eps1eps2 - 48.0) < TOL_F32);
     }
 
     #[test]
-    fn test_powi_zero() {
+    fn the_zeroth_power_has_no_derivatives() {
         // x^0 = 1 with all derivatives 0
-        let y = HyperDual::variable(3.0_f64).powi(0);
-        assert!(f64::abs(y.real - 1.0) < TOL);
-        assert!(f64::abs(y.eps1) < TOL);
-        assert!(f64::abs(y.eps1eps2) < TOL);
+        let zeroth_power = HyperDual::variable(3.0_f64).powi(0);
+        assert!(f64::abs(zeroth_power.real - 1.0) < TOL);
+        assert!(f64::abs(zeroth_power.eps1) < TOL);
+        assert!(f64::abs(zeroth_power.eps1eps2) < TOL);
     }
 
     #[test]
-    fn test_constant_has_zero_derivatives() {
+    fn a_constant_has_zero_derivatives() {
         // a constant carries no derivative through any operation
-        let c = HyperDual::constant(1.3_f64);
-        let y = c.exp() * c.sin() + c.powi(2);
-        assert!(f64::abs(y.eps1) < TOL);
-        assert!(f64::abs(y.eps2) < TOL);
-        assert!(f64::abs(y.eps1eps2) < TOL);
+        let constant = HyperDual::constant(1.3_f64);
+        let combined = constant.exp() * constant.sin() + constant.powi(2);
+        assert!(f64::abs(combined.eps1) < TOL);
+        assert!(f64::abs(combined.eps2) < TOL);
+        assert!(f64::abs(combined.eps1eps2) < TOL);
     }
 
     #[test]
-    fn test_sqrt_zero_blows_up() {
+    fn sqrt_at_zero_blows_up() {
         // the derivative of sqrt at 0 is unbounded, while the value stays finite
-        let y = HyperDual::variable(0.0_f64).sqrt();
-        assert!(f64::abs(y.real) < TOL);
-        assert!(y.eps1.is_infinite());
+        let root = HyperDual::variable(0.0_f64).sqrt();
+        assert!(f64::abs(root.real) < TOL);
+        assert!(root.eps1.is_infinite());
         // is_finite reflects the real part only
-        assert!(y.is_finite());
+        assert!(root.is_finite());
     }
 
     #[test]
-    fn test_ln_zero_blows_up() {
+    fn ln_at_zero_blows_up() {
         // ln(0) = -inf with an unbounded first derivative
-        let y = HyperDual::variable(0.0_f64).ln();
-        assert!(y.real.is_infinite() && y.real < 0.0);
-        assert!(y.eps1.is_infinite() && y.eps1 > 0.0);
+        let logarithm = HyperDual::variable(0.0_f64).ln();
+        assert!(logarithm.real.is_infinite() && logarithm.real < 0.0);
+        assert!(logarithm.eps1.is_infinite() && logarithm.eps1 > 0.0);
     }
 
     #[test]
-    fn test_atan2_second_order() {
+    fn atan2_second_derivative() {
         // f(y) = atan2(y, x), x constant: f' = x/(x²+y²), f'' = −2xy/(x²+y²)²
-        let (y0, x0) = (1.0_f64, 2.0_f64);
-        let r = HyperDual::variable(y0).atan2(HyperDual::constant(x0));
-        let d = x0 * x0 + y0 * y0;
-        assert!(f64::abs(r.real - y0.atan2(x0)) < TOL);
-        assert!(f64::abs(r.eps1 - x0 / d) < TOL);
-        assert!(f64::abs(r.eps1eps2 - (-2.0 * x0 * y0) / (d * d)) < TOL);
+        let y = 1.0_f64;
+        let x = 2.0_f64;
+        let angle = HyperDual::variable(y).atan2(HyperDual::constant(x));
+        let denominator = x * x + y * y;
+        assert!(f64::abs(angle.real - y.atan2(x)) < TOL);
+        assert!(f64::abs(angle.eps1 - x / denominator) < TOL);
+        assert!(f64::abs(angle.eps1eps2 - (-2.0 * x * y) / (denominator * denominator)) < TOL);
     }
 
     #[test]
-    fn test_atan2_mixed_partial() {
+    fn atan2_mixed_partial_derivative() {
         // ∂²/∂y∂x atan2(y, x) = (y²−x²)/(x²+y²)²; seed y on dir 1, x on dir 2.
-        let (y0, x0) = (1.0_f64, 2.0_f64);
-        let r = HyperDual::new(y0, 1.0, 0.0, 0.0).atan2(HyperDual::new(x0, 0.0, 1.0, 0.0));
-        let d = x0 * x0 + y0 * y0;
-        assert!(f64::abs(r.eps1eps2 - (y0 * y0 - x0 * x0) / (d * d)) < TOL);
+        let y = 1.0_f64;
+        let x = 2.0_f64;
+        let angle = HyperDual::new(y, 1.0, 0.0, 0.0).atan2(HyperDual::new(x, 0.0, 1.0, 0.0));
+        let denominator = x * x + y * y;
+        assert!(f64::abs(angle.eps1eps2 - (y * y - x * x) / (denominator * denominator)) < TOL);
     }
 }
 
@@ -571,174 +582,179 @@ mod jet {
     const TOL_F32: f32 = 1e-3;
 
     #[test]
-    fn test_exp_all_orders() {
+    fn every_derivative_of_exp_is_exp() {
         // every derivative of exp(x) is exp(x)
-        let x0 = 0.4_f64;
-        let y = Jet::<f64, 6>::variable(x0).exp();
-        for k in 0..6 {
-            assert!(f64::abs(y.derivative(k) - f64::exp(x0)) < TOL);
+        let x = 0.4_f64;
+        let exponential = Jet::<f64, 6>::variable(x).exp();
+        for order in 0..6 {
+            assert!(f64::abs(exponential.derivative(order) - f64::exp(x)) < TOL);
         }
     }
 
     #[test]
-    fn test_high_order_polynomial() {
+    fn a_quartic_terminates_after_four_derivatives() {
         // f(x) = x^4: f'=4x^3, f''=12x^2, f'''=24x, f''''=24, f'''''=0
-        let x0 = 2.0_f64;
-        let y = Jet::<f64, 6>::variable(x0).powi(4);
-        assert!(f64::abs(y.value() - 16.0) < TOL);
-        assert!(f64::abs(y.derivative(1) - 32.0) < TOL);
-        assert!(f64::abs(y.derivative(2) - 48.0) < TOL);
-        assert!(f64::abs(y.derivative(3) - 48.0) < TOL);
-        assert!(f64::abs(y.derivative(4) - 24.0) < TOL);
-        assert!(f64::abs(y.derivative(5)) < TOL);
+        let x = 2.0_f64;
+        let quartic = Jet::<f64, 6>::variable(x).powi(4);
+        assert!(f64::abs(quartic.value() - 16.0) < TOL);
+        assert!(f64::abs(quartic.derivative(1) - 32.0) < TOL);
+        assert!(f64::abs(quartic.derivative(2) - 48.0) < TOL);
+        assert!(f64::abs(quartic.derivative(3) - 48.0) < TOL);
+        assert!(f64::abs(quartic.derivative(4) - 24.0) < TOL);
+        assert!(f64::abs(quartic.derivative(5)) < TOL);
     }
 
     #[test]
-    fn test_sin_derivative_cycle() {
+    fn sin_derivatives_cycle_through_four_terms() {
         // derivatives of sin cycle: sin, cos, -sin, -cos, sin
-        let x0 = 0.6_f64;
-        let y = Jet::<f64, 5>::variable(x0).sin();
-        assert!(f64::abs(y.derivative(0) - f64::sin(x0)) < TOL);
-        assert!(f64::abs(y.derivative(1) - f64::cos(x0)) < TOL);
-        assert!(f64::abs(y.derivative(2) - (-f64::sin(x0))) < TOL);
-        assert!(f64::abs(y.derivative(3) - (-f64::cos(x0))) < TOL);
-        assert!(f64::abs(y.derivative(4) - f64::sin(x0)) < TOL);
+        let x = 0.6_f64;
+        let sine = Jet::<f64, 5>::variable(x).sin();
+        assert!(f64::abs(sine.derivative(0) - f64::sin(x)) < TOL);
+        assert!(f64::abs(sine.derivative(1) - f64::cos(x)) < TOL);
+        assert!(f64::abs(sine.derivative(2) - (-f64::sin(x))) < TOL);
+        assert!(f64::abs(sine.derivative(3) - (-f64::cos(x))) < TOL);
+        assert!(f64::abs(sine.derivative(4) - f64::sin(x)) < TOL);
     }
 
     #[test]
-    fn test_reciprocal_all_orders() {
+    fn reciprocal_derivatives_follow_the_factorial_rule() {
         // f(x) = 1/(1+x): f^(k) = (-1)^k k! / (1+x)^(k+1)
-        let x0 = 0.3_f64;
-        let denom = Jet::<f64, 5>::constant(1.0) + Jet::variable(x0);
-        let y = Jet::<f64, 5>::constant(1.0) / denom;
+        let x = 0.3_f64;
+        let denominator = Jet::<f64, 5>::constant(1.0) + Jet::variable(x);
+        let reciprocal = Jet::<f64, 5>::constant(1.0) / denominator;
         let mut sign = 1.0;
         let mut factorial = 1.0;
-        for k in 0..5 {
-            if k >= 1 {
-                factorial *= k as f64;
+        for order in 0..5 {
+            if order >= 1 {
+                factorial *= order as f64;
             }
-            let expected = sign * factorial / (1.0 + x0).powi(k as i32 + 1);
-            assert!(f64::abs(y.derivative(k) - expected) < TOL);
+            let expected = sign * factorial / (1.0 + x).powi(order as i32 + 1);
+            assert!(f64::abs(reciprocal.derivative(order) - expected) < TOL);
             sign = -sign;
         }
     }
 
     #[test]
-    fn test_sqrt_orders() {
+    fn sqrt_derivatives_to_third_order() {
         // f(x) = sqrt(x): f'=1/(2√x), f''=-1/(4 x^{3/2}), f'''=3/(8 x^{5/2})
-        let x0 = 1.7_f64;
-        let y = Jet::<f64, 4>::variable(x0).sqrt();
-        assert!(f64::abs(y.derivative(0) - f64::sqrt(x0)) < TOL);
-        assert!(f64::abs(y.derivative(1) - 1.0 / (2.0 * f64::sqrt(x0))) < TOL);
-        assert!(f64::abs(y.derivative(2) - (-1.0 / (4.0 * x0 * f64::sqrt(x0)))) < TOL);
-        assert!(f64::abs(y.derivative(3) - 3.0 / (8.0 * x0 * x0 * f64::sqrt(x0))) < TOL);
+        let x = 1.7_f64;
+        let root = Jet::<f64, 4>::variable(x).sqrt();
+        assert!(f64::abs(root.derivative(0) - f64::sqrt(x)) < TOL);
+        assert!(f64::abs(root.derivative(1) - 1.0 / (2.0 * f64::sqrt(x))) < TOL);
+        assert!(f64::abs(root.derivative(2) - (-1.0 / (4.0 * x * f64::sqrt(x)))) < TOL);
+        assert!(f64::abs(root.derivative(3) - 3.0 / (8.0 * x * x * f64::sqrt(x))) < TOL);
     }
 
     #[test]
-    fn test_ln_orders() {
+    fn ln_derivatives_to_third_order() {
         // f(x) = ln(x): f'=1/x, f''=-1/x^2, f'''=2/x^3
-        let x0 = 2.0_f64;
-        let y = Jet::<f64, 4>::variable(x0).ln();
-        assert!(f64::abs(y.derivative(0) - f64::ln(x0)) < TOL);
-        assert!(f64::abs(y.derivative(1) - 1.0 / x0) < TOL);
-        assert!(f64::abs(y.derivative(2) - (-1.0 / (x0 * x0))) < TOL);
-        assert!(f64::abs(y.derivative(3) - 2.0 / (x0 * x0 * x0)) < TOL);
+        let x = 2.0_f64;
+        let logarithm = Jet::<f64, 4>::variable(x).ln();
+        assert!(f64::abs(logarithm.derivative(0) - f64::ln(x)) < TOL);
+        assert!(f64::abs(logarithm.derivative(1) - 1.0 / x) < TOL);
+        assert!(f64::abs(logarithm.derivative(2) - (-1.0 / (x * x))) < TOL);
+        assert!(f64::abs(logarithm.derivative(3) - 2.0 / (x * x * x)) < TOL);
     }
 
     #[test]
-    fn test_tan_orders() {
+    fn tan_derivatives_to_second_order() {
         // f(x) = tan(x): f' = 1+tan^2, f'' = 2 tan (1+tan^2)
-        let x0 = 0.5_f64;
-        let t = f64::tan(x0);
-        let y = Jet::<f64, 3>::variable(x0).tan();
-        assert!(f64::abs(y.derivative(0) - t) < TOL);
-        assert!(f64::abs(y.derivative(1) - (1.0 + t * t)) < TOL);
-        assert!(f64::abs(y.derivative(2) - 2.0 * t * (1.0 + t * t)) < TOL);
+        let x = 0.5_f64;
+        let tangent = f64::tan(x);
+        let jet = Jet::<f64, 3>::variable(x).tan();
+        assert!(f64::abs(jet.derivative(0) - tangent) < TOL);
+        assert!(f64::abs(jet.derivative(1) - (1.0 + tangent * tangent)) < TOL);
+        assert!(f64::abs(jet.derivative(2) - 2.0 * tangent * (1.0 + tangent * tangent)) < TOL);
     }
 
     #[test]
-    fn test_matches_dual_at_order_one() {
+    fn matches_dual_at_first_order() {
         // Jet<T,2> carries the same first derivative as Dual.
-        fn f<T: Numeric>(t: T) -> T {
+        fn function<T: Numeric>(t: T) -> T {
             t.sin() * t.exp() + t.powi(3)
         }
-        let x0 = 0.8_f64;
-        let j = f(Jet::<f64, 2>::variable(x0));
-        let d = f(Dual::<f64>::variable(x0));
-        assert!(f64::abs(j.value() - d.value) < TOL);
-        assert!(f64::abs(j.coeffs[1] - d.deriv) < TOL);
+        let x = 0.8_f64;
+        let jet = function(Jet::<f64, 2>::variable(x));
+        let dual = function(Dual::<f64>::variable(x));
+        assert!(f64::abs(jet.value() - dual.value) < TOL);
+        assert!(f64::abs(jet.coeffs[1] - dual.deriv) < TOL);
     }
 
     #[test]
-    fn test_generic_over_numeric() {
+    fn generic_over_numeric() {
         // The same function runs with a plain float or with a Jet.
-        fn g<T: Numeric>(t: T) -> T {
+        fn polynomial<T: Numeric>(t: T) -> T {
             t.powi(3) + T::from_f64(2.0) * t
         }
-        let x0 = 1.5_f64;
-        let plain = g(x0);
-        let j = g(Jet::<f64, 4>::variable(x0));
-        assert!(f64::abs(j.value() - plain) < TOL);
-        assert!(f64::abs(j.derivative(1) - (3.0 * x0 * x0 + 2.0)) < TOL); // f'
-        assert!(f64::abs(j.derivative(2) - 6.0 * x0) < TOL); // f''
-        assert!(f64::abs(j.derivative(3) - 6.0) < TOL); // f'''
+        let x = 1.5_f64;
+        let plain = polynomial(x);
+        let jet = polynomial(Jet::<f64, 4>::variable(x));
+        assert!(f64::abs(jet.value() - plain) < TOL);
+        assert!(f64::abs(jet.derivative(1) - (3.0 * x * x + 2.0)) < TOL); // f'
+        assert!(f64::abs(jet.derivative(2) - 6.0 * x) < TOL); // f''
+        assert!(f64::abs(jet.derivative(3) - 6.0) < TOL); // f'''
     }
 
     #[test]
-    fn test_generic_over_f32() {
+    fn generic_over_f32() {
         // Jet is generic over the scalar; here it carries f32.
-        let y = Jet::<f32, 4>::variable(2.0).powi(3);
-        assert!(f32::abs(y.derivative(0) - 8.0) < TOL_F32);
-        assert!(f32::abs(y.derivative(1) - 12.0) < TOL_F32);
-        assert!(f32::abs(y.derivative(2) - 12.0) < TOL_F32);
-        assert!(f32::abs(y.derivative(3) - 6.0) < TOL_F32);
+        let cubed = Jet::<f32, 4>::variable(2.0).powi(3);
+        assert!(f32::abs(cubed.derivative(0) - 8.0) < TOL_F32);
+        assert!(f32::abs(cubed.derivative(1) - 12.0) < TOL_F32);
+        assert!(f32::abs(cubed.derivative(2) - 12.0) < TOL_F32);
+        assert!(f32::abs(cubed.derivative(3) - 6.0) < TOL_F32);
     }
 
     #[test]
-    fn test_single_coefficient_is_scalar() {
+    fn a_single_coefficient_behaves_like_a_bare_scalar() {
         // N = 1 carries only the value and behaves like the bare scalar.
-        let y = Jet::<f64, 1>::constant(2.0) * Jet::<f64, 1>::constant(3.0);
-        assert!(f64::abs(y.value() - 6.0) < TOL);
+        let product = Jet::<f64, 1>::constant(2.0) * Jet::<f64, 1>::constant(3.0);
+        assert!(f64::abs(product.value() - 6.0) < TOL);
         assert!(f64::abs(Jet::<f64, 1>::constant(1.0).exp().value() - f64::exp(1.0)) < TOL);
     }
 
     #[test]
-    fn test_constant_has_zero_higher_coeffs() {
-        let c = Jet::<f64, 4>::constant(2.0);
-        for k in 1..4 {
-            assert!(f64::abs(c.coeffs[k]) < TOL);
+    fn a_constant_has_zero_higher_coefficients() {
+        let constant = Jet::<f64, 4>::constant(2.0);
+        for order in 1..4 {
+            assert!(f64::abs(constant.coeffs[order]) < TOL);
         }
     }
 
     #[test]
-    fn test_sqrt_zero_blows_up() {
+    fn sqrt_at_zero_blows_up() {
         // the derivative of sqrt at 0 is unbounded, while the value stays finite
-        let y = Jet::<f64, 3>::variable(0.0).sqrt();
-        assert!(f64::abs(y.value()) < TOL);
-        assert!(y.coeffs[1].is_infinite());
+        let root = Jet::<f64, 3>::variable(0.0).sqrt();
+        assert!(f64::abs(root.value()) < TOL);
+        assert!(root.coeffs[1].is_infinite());
         // is_finite reflects the value only
-        assert!(y.is_finite());
+        assert!(root.is_finite());
     }
 
     #[test]
-    fn test_atan2_orders() {
+    fn atan2_derivatives_to_third_order() {
         // atan2(y, 1) = atan(y): f'=1/(1+y²), f''=−2y/(1+y²)², f'''=(6y²−2)/(1+y²)³
-        let y0 = 0.5_f64;
-        let j = Jet::<f64, 4>::variable(y0).atan2(Jet::constant(1.0));
-        let d = 1.0 + y0 * y0;
-        assert!(f64::abs(j.derivative(0) - y0.atan()) < TOL);
-        assert!(f64::abs(j.derivative(1) - 1.0 / d) < TOL);
-        assert!(f64::abs(j.derivative(2) - (-2.0 * y0) / (d * d)) < TOL);
-        assert!(f64::abs(j.derivative(3) - (6.0 * y0 * y0 - 2.0) / (d * d * d)) < TOL);
+        let y = 0.5_f64;
+        let jet = Jet::<f64, 4>::variable(y).atan2(Jet::constant(1.0));
+        let denominator = 1.0 + y * y;
+        assert!(f64::abs(jet.derivative(0) - y.atan()) < TOL);
+        assert!(f64::abs(jet.derivative(1) - 1.0 / denominator) < TOL);
+        assert!(f64::abs(jet.derivative(2) - (-2.0 * y) / (denominator * denominator)) < TOL);
+        assert!(
+            f64::abs(
+                jet.derivative(3) - (6.0 * y * y - 2.0) / (denominator * denominator * denominator)
+            ) < TOL
+        );
     }
 
     #[test]
-    fn test_atan2_matches_dual_first_order() {
-        let (y0, x0) = (1.3_f64, 0.7_f64);
-        let j = Jet::<f64, 2>::variable(y0).atan2(Jet::constant(x0));
-        let d = Dual::variable(y0).atan2(Dual::constant(x0));
-        assert!(f64::abs(j.value() - d.value) < TOL);
-        assert!(f64::abs(j.coeffs[1] - d.deriv) < TOL);
+    fn atan2_matches_dual_at_first_order() {
+        let y = 1.3_f64;
+        let x = 0.7_f64;
+        let jet = Jet::<f64, 2>::variable(y).atan2(Jet::constant(x));
+        let dual = Dual::variable(y).atan2(Dual::constant(x));
+        assert!(f64::abs(jet.value() - dual.value) < TOL);
+        assert!(f64::abs(jet.coeffs[1] - dual.deriv) < TOL);
     }
 }
 
@@ -757,31 +773,31 @@ mod function {
 
     #[test]
     fn one_function_drives_every_backend() {
-        let f = Cubic;
+        let cubic = Cubic;
         // plain f64 (finite-difference path): 4*8 - 3*4 = 20
-        assert!(f64::abs(f.eval(2.0_f64) - 20.0) < 1e-12);
+        assert!(f64::abs(cubic.eval(2.0_f64) - 20.0) < 1e-12);
         // Dual: f'(x) = 12x^2 - 6x = 36 at x = 2
-        assert!(f64::abs(f.eval(Dual::variable(2.0_f64)).deriv - 36.0) < 1e-12);
+        assert!(f64::abs(cubic.eval(Dual::variable(2.0_f64)).deriv - 36.0) < 1e-12);
         // HyperDual: f''(x) = 24x - 6 = 42 at x = 2
-        assert!(f64::abs(f.eval(HyperDual::variable(2.0_f64)).eps1eps2 - 42.0) < 1e-12);
+        assert!(f64::abs(cubic.eval(HyperDual::variable(2.0_f64)).eps1eps2 - 42.0) < 1e-12);
         // Jet: f'''(x) = 24
-        assert!(f64::abs(f.eval(Jet::<f64, 4>::variable(2.0_f64)).derivative(3) - 24.0) < 1e-9);
+        assert!(f64::abs(cubic.eval(Jet::<f64, 4>::variable(2.0_f64)).derivative(3) - 24.0) < 1e-9);
     }
 
     // g(x, y, z) = y*sin(x) + 2*x*e^z, hand-written over the scalar.
     struct Mixed;
     impl ScalarFnN<3> for Mixed {
-        fn eval<S: Numeric>(&self, v: &[S; 3]) -> S {
-            v[1] * v[0].sin() + S::from_f64(2.0) * v[0] * v[2].exp()
+        fn eval<S: Numeric>(&self, point: &[S; 3]) -> S {
+            point[1] * point[0].sin() + S::from_f64(2.0) * point[0] * point[2].exp()
         }
     }
 
     #[test]
     fn multivariable_partial_via_seeding() {
-        let g = Mixed;
+        let mixed = Mixed;
         let point = [1.0_f64, 2.0, 0.5];
         let expected = 2.0 * f64::sin(1.0) + 2.0 * f64::exp(0.5);
-        assert!(f64::abs(g.eval(&point) - expected) < 1e-12);
+        assert!(f64::abs(mixed.eval(&point) - expected) < 1e-12);
 
         // partial dg/dx via Dual seeding of index 0:
         // dg/dx = y*cos(x) + 2*e^z = 2*cos(1) + 2*e^0.5
@@ -791,45 +807,45 @@ mod function {
             Dual::constant(0.5),
         ];
         let expected_dx = 2.0 * f64::cos(1.0) + 2.0 * f64::exp(0.5);
-        assert!(f64::abs(g.eval(&seeded).deriv - expected_dx) < 1e-12);
+        assert!(f64::abs(mixed.eval(&seeded).deriv - expected_dx) < 1e-12);
     }
 
     #[test]
     fn macro_single_var() {
         // f(x) = 4x^3 - 3x^2, authored via the macro.
-        let f = scalar_fn!(|x| c(4.0) * x * x * x - c(3.0) * x * x);
-        assert!(f64::abs(f.eval(2.0_f64) - 20.0) < 1e-12);
-        assert!(f64::abs(f.eval(Dual::variable(2.0_f64)).deriv - 36.0) < 1e-12);
-        assert!(f64::abs(f.eval(HyperDual::variable(2.0_f64)).eps1eps2 - 42.0) < 1e-12);
-        assert!(f64::abs(f.eval(Jet::<f64, 4>::variable(2.0_f64)).derivative(3) - 24.0) < 1e-9);
+        let cubic = scalar_fn!(|x| c(4.0) * x * x * x - c(3.0) * x * x);
+        assert!(f64::abs(cubic.eval(2.0_f64) - 20.0) < 1e-12);
+        assert!(f64::abs(cubic.eval(Dual::variable(2.0_f64)).deriv - 36.0) < 1e-12);
+        assert!(f64::abs(cubic.eval(HyperDual::variable(2.0_f64)).eps1eps2 - 42.0) < 1e-12);
+        assert!(f64::abs(cubic.eval(Jet::<f64, 4>::variable(2.0_f64)).derivative(3) - 24.0) < 1e-9);
     }
 
     #[test]
     fn macro_single_var_typed_param() {
-        let f = scalar_fn!(|x: f64| c(2.0) * x.sin());
-        assert!(f64::abs(f.eval(0.5_f64) - 2.0 * f64::sin(0.5)) < 1e-12);
+        let scaled_sine = scalar_fn!(|x: f64| c(2.0) * x.sin());
+        assert!(f64::abs(scaled_sine.eval(0.5_f64) - 2.0 * f64::sin(0.5)) < 1e-12);
     }
 
     #[test]
     fn macro_multivariable() {
-        let f = scalar_fn!(|v: &[f64; 3]| v[1] * v[0].sin() + c(2.0) * v[0] * v[2].exp());
+        let mixed = scalar_fn!(|v: &[f64; 3]| v[1] * v[0].sin() + c(2.0) * v[0] * v[2].exp());
         let point = [1.0_f64, 2.0, 0.5];
         let expected = 2.0 * f64::sin(1.0) + 2.0 * f64::exp(0.5);
-        assert!(f64::abs(f.eval(&point) - expected) < 1e-12);
+        assert!(f64::abs(mixed.eval(&point) - expected) < 1e-12);
     }
 
     #[test]
     fn macro_vector_valued() {
         // f(x, y) = [x*y, sin(y)]
-        let f = scalar_fn_vec!(|v: &[f64; 2]| [v[0] * v[1], v[1].sin()]);
-        let out = f.eval(&[3.0_f64, 0.5]);
-        assert!(f64::abs(out[0] - 1.5) < 1e-12);
-        assert!(f64::abs(out[1] - f64::sin(0.5)) < 1e-12);
+        let function = scalar_fn_vec!(|v: &[f64; 2]| [v[0] * v[1], v[1].sin()]);
+        let outputs = function.eval(&[3.0_f64, 0.5]);
+        assert!(f64::abs(outputs[0] - 1.5) < 1e-12);
+        assert!(f64::abs(outputs[1] - f64::sin(0.5)) < 1e-12);
 
         // a Jacobian column via Dual: d/dx [x*y, sin(y)] = [y, 0] at (3, 0.5)
         let seeded = [Dual::variable(3.0_f64), Dual::constant(0.5)];
-        let col = f.eval(&seeded);
-        assert!(f64::abs(col[0].deriv - 0.5) < 1e-12);
-        assert!(f64::abs(col[1].deriv) < 1e-12);
+        let column = function.eval(&seeded);
+        assert!(f64::abs(column[0].deriv - 0.5) < 1e-12);
+        assert!(f64::abs(column[1].deriv) < 1e-12);
     }
 }

--- a/crates/multicalc/tests/suite/spatial/lie.rs
+++ b/crates/multicalc/tests/suite/spatial/lie.rs
@@ -14,7 +14,7 @@ const TOL: f64 = 1e-10;
 
 // ---- helpers ----------------------------------------------------------------
 
-fn rand_vec3(rng: &mut StdRng) -> Vector<3, f64> {
+fn random_vector3(rng: &mut StdRng) -> Vector<3, f64> {
     Vector::new([
         rng.gen_range(-1.0..1.0),
         rng.gen_range(-1.0..1.0),
@@ -22,17 +22,17 @@ fn rand_vec3(rng: &mut StdRng) -> Vector<3, f64> {
     ])
 }
 
-fn rand_unit_vec3(rng: &mut StdRng) -> Vector<3, f64> {
+fn random_unit_vector3(rng: &mut StdRng) -> Vector<3, f64> {
     loop {
-        let v = rand_vec3(rng);
-        let n = v.dot(v).sqrt();
-        if n > 1e-3 {
-            return v * n.recip();
+        let vector = random_vector3(rng);
+        let norm = vector.dot(vector).sqrt();
+        if norm > 1e-3 {
+            return vector * norm.recip();
         }
     }
 }
 
-fn rand_twist6(rng: &mut StdRng) -> Vector<6, f64> {
+fn random_twist6(rng: &mut StdRng) -> Vector<6, f64> {
     Vector::new([
         rng.gen_range(-1.0..1.0),
         rng.gen_range(-1.0..1.0),
@@ -43,13 +43,13 @@ fn rand_twist6(rng: &mut StdRng) -> Vector<6, f64> {
     ])
 }
 
-fn rand_so3(rng: &mut StdRng) -> SO3<f64> {
-    SO3::exp(rand_unit_vec3(rng) * rng.gen_range(-2.5..2.5))
+fn random_so3(rng: &mut StdRng) -> SO3<f64> {
+    SO3::exp(random_unit_vector3(rng) * rng.gen_range(-2.5..2.5))
 }
 
-fn rand_se3(rng: &mut StdRng) -> SE3<f64> {
+fn random_se3(rng: &mut StdRng) -> SE3<f64> {
     SE3::from_parts(
-        rand_so3(rng),
+        random_so3(rng),
         Vector::new([
             rng.gen_range(-2.0..2.0),
             rng.gen_range(-2.0..2.0),
@@ -58,34 +58,46 @@ fn rand_se3(rng: &mut StdRng) -> SE3<f64> {
     )
 }
 
-fn rand_so2(rng: &mut StdRng) -> SO2<f64> {
+fn random_so2(rng: &mut StdRng) -> SO2<f64> {
     SO2::from_angle(rng.gen_range(-PI..PI))
 }
 
-fn rand_se2(rng: &mut StdRng) -> SE2<f64> {
+fn random_se2(rng: &mut StdRng) -> SE2<f64> {
     SE2::from_parts(
-        rand_so2(rng),
+        random_so2(rng),
         Vector::new([rng.gen_range(-2.0..2.0), rng.gen_range(-2.0..2.0)]),
     )
 }
 
-fn assert_mat_close<const R: usize, const C: usize>(
-    a: Matrix<R, C, f64>,
-    b: Matrix<R, C, f64>,
-    tol: f64,
+fn assert_entries_close<const R: usize, const C: usize>(
+    first: Matrix<R, C, f64>,
+    second: Matrix<R, C, f64>,
+    tolerance: f64,
 ) {
-    for i in 0..R {
-        for j in 0..C {
-            let (aij, bij) = (a[(i, j)], b[(i, j)]);
-            assert!((aij - bij).abs() < tol, "({i},{j}): {aij} vs {bij}");
+    for row in 0..R {
+        for column in 0..C {
+            let left = first[(row, column)];
+            let right = second[(row, column)];
+            assert!(
+                (left - right).abs() < tolerance,
+                "({row},{column}): {left} vs {right}"
+            );
         }
     }
 }
 
-fn assert_vec_close<const N: usize>(a: Vector<N, f64>, b: Vector<N, f64>, tol: f64) {
-    for i in 0..N {
-        let (ai, bi) = (a[i], b[i]);
-        assert!((ai - bi).abs() < tol, "[{i}]: {ai} vs {bi}");
+fn assert_components_close<const N: usize>(
+    first: Vector<N, f64>,
+    second: Vector<N, f64>,
+    tolerance: f64,
+) {
+    for index in 0..N {
+        let left = first[index];
+        let right = second[index];
+        assert!(
+            (left - right).abs() < tolerance,
+            "[{index}]: {left} vs {right}"
+        );
     }
 }
 
@@ -95,11 +107,21 @@ fn assert_vec_close<const N: usize>(a: Vector<N, f64>, b: Vector<N, f64>, tol: f
 fn so3_group_laws() {
     let mut rng = StdRng::seed_from_u64(1);
     for _ in 0..200 {
-        let (a, b, c) = (rand_so3(&mut rng), rand_so3(&mut rng), rand_so3(&mut rng));
-        assert_mat_close(((a * b) * c).to_matrix(), (a * (b * c)).to_matrix(), TOL);
-        assert_mat_close((a * SO3::identity()).to_matrix(), a.to_matrix(), TOL);
-        assert_mat_close(
-            (a * a.inverse()).to_matrix(),
+        let first = random_so3(&mut rng);
+        let second = random_so3(&mut rng);
+        let third = random_so3(&mut rng);
+        assert_entries_close(
+            ((first * second) * third).to_matrix(),
+            (first * (second * third)).to_matrix(),
+            TOL,
+        );
+        assert_entries_close(
+            (first * SO3::identity()).to_matrix(),
+            first.to_matrix(),
+            TOL,
+        );
+        assert_entries_close(
+            (first * first.inverse()).to_matrix(),
             SO3::identity().to_matrix(),
             TOL,
         );
@@ -110,10 +132,10 @@ fn so3_group_laws() {
 fn so3_exp_log_roundtrip() {
     let mut rng = StdRng::seed_from_u64(2);
     for _ in 0..200 {
-        let axis = rand_unit_vec3(&mut rng);
+        let axis = random_unit_vector3(&mut rng);
         for &angle in &[1e-9, 1e-4, 0.5, 2.0, PI - 1e-6] {
-            let phi = axis * angle;
-            assert_vec_close(SO3::exp(phi).log(), phi, 1e-7);
+            let rotation_vector = axis * angle;
+            assert_components_close(SO3::exp(rotation_vector).log(), rotation_vector, 1e-7);
         }
     }
 }
@@ -122,11 +144,11 @@ fn so3_exp_log_roundtrip() {
 fn so3_adjoint_identity() {
     let mut rng = StdRng::seed_from_u64(3);
     for _ in 0..200 {
-        let r = rand_so3(&mut rng);
-        let xi = rand_vec3(&mut rng) * 0.5;
-        let lhs = SO3::exp(r.adjoint() * xi).to_matrix();
-        let rhs = (r * SO3::exp(xi) * r.inverse()).to_matrix();
-        assert_mat_close(lhs, rhs, 1e-9);
+        let rotation = random_so3(&mut rng);
+        let twist = random_vector3(&mut rng) * 0.5;
+        let left_side = SO3::exp(rotation.adjoint() * twist).to_matrix();
+        let right_side = (rotation * SO3::exp(twist) * rotation.inverse()).to_matrix();
+        assert_entries_close(left_side, right_side, 1e-9);
     }
 }
 
@@ -134,8 +156,8 @@ fn so3_adjoint_identity() {
 fn so3_hat_vee_roundtrip() {
     let mut rng = StdRng::seed_from_u64(4);
     for _ in 0..100 {
-        let phi = rand_vec3(&mut rng);
-        assert_vec_close(SO3::vee(SO3::hat(phi)), phi, TOL);
+        let rotation_vector = random_vector3(&mut rng);
+        assert_components_close(SO3::vee(SO3::hat(rotation_vector)), rotation_vector, TOL);
     }
 }
 
@@ -143,9 +165,9 @@ fn so3_hat_vee_roundtrip() {
 fn so3_act_matches_matrix() {
     let mut rng = StdRng::seed_from_u64(5);
     for _ in 0..100 {
-        let r = rand_so3(&mut rng);
-        let p = rand_vec3(&mut rng);
-        assert_vec_close(r.act(p), r.to_matrix() * p, TOL);
+        let rotation = random_so3(&mut rng);
+        let point = random_vector3(&mut rng);
+        assert_components_close(rotation.act(point), rotation.to_matrix() * point, TOL);
     }
 }
 
@@ -153,9 +175,18 @@ fn so3_act_matches_matrix() {
 fn so3_interpolate_endpoints() {
     let mut rng = StdRng::seed_from_u64(6);
     for _ in 0..100 {
-        let (a, b) = (rand_so3(&mut rng), rand_so3(&mut rng));
-        assert_mat_close(a.interpolate(b, 0.0).to_matrix(), a.to_matrix(), TOL);
-        assert_mat_close(a.interpolate(b, 1.0).to_matrix(), b.to_matrix(), 1e-9);
+        let first = random_so3(&mut rng);
+        let second = random_so3(&mut rng);
+        assert_entries_close(
+            first.interpolate(second, 0.0).to_matrix(),
+            first.to_matrix(),
+            TOL,
+        );
+        assert_entries_close(
+            first.interpolate(second, 1.0).to_matrix(),
+            second.to_matrix(),
+            1e-9,
+        );
     }
 }
 
@@ -163,11 +194,11 @@ fn so3_interpolate_endpoints() {
 fn so3_left_right_jacobian_relation() {
     let mut rng = StdRng::seed_from_u64(7);
     for _ in 0..100 {
-        let phi = rand_vec3(&mut rng) * 1.5;
+        let rotation_vector = random_vector3(&mut rng) * 1.5;
         // J_l(φ) = exp(φ) · J_r(φ)
-        assert_mat_close(
-            SO3::left_jacobian(phi),
-            SO3::exp(phi).to_matrix() * SO3::right_jacobian(phi),
+        assert_entries_close(
+            SO3::left_jacobian(rotation_vector),
+            SO3::exp(rotation_vector).to_matrix() * SO3::right_jacobian(rotation_vector),
             1e-9,
         );
     }
@@ -179,11 +210,21 @@ fn so3_left_right_jacobian_relation() {
 fn se3_group_laws() {
     let mut rng = StdRng::seed_from_u64(10);
     for _ in 0..200 {
-        let (a, b, c) = (rand_se3(&mut rng), rand_se3(&mut rng), rand_se3(&mut rng));
-        assert_mat_close(((a * b) * c).to_matrix(), (a * (b * c)).to_matrix(), 1e-9);
-        assert_mat_close((a * SE3::identity()).to_matrix(), a.to_matrix(), TOL);
-        assert_mat_close(
-            (a * a.inverse()).to_matrix(),
+        let first = random_se3(&mut rng);
+        let second = random_se3(&mut rng);
+        let third = random_se3(&mut rng);
+        assert_entries_close(
+            ((first * second) * third).to_matrix(),
+            (first * (second * third)).to_matrix(),
+            1e-9,
+        );
+        assert_entries_close(
+            (first * SE3::identity()).to_matrix(),
+            first.to_matrix(),
+            TOL,
+        );
+        assert_entries_close(
+            (first * first.inverse()).to_matrix(),
             SE3::identity().to_matrix(),
             1e-9,
         );
@@ -194,18 +235,18 @@ fn se3_group_laws() {
 fn se3_exp_log_roundtrip() {
     let mut rng = StdRng::seed_from_u64(11);
     for _ in 0..300 {
-        let axis = rand_unit_vec3(&mut rng);
+        let axis = random_unit_vector3(&mut rng);
         for &angle in &[1e-9, 1e-4, 0.7, 2.0, PI - 1e-6] {
-            let v = rand_vec3(&mut rng);
-            let xi = Vector::new([
-                v[0],
-                v[1],
-                v[2],
+            let translation = random_vector3(&mut rng);
+            let twist = Vector::new([
+                translation[0],
+                translation[1],
+                translation[2],
                 axis[0] * angle,
                 axis[1] * angle,
                 axis[2] * angle,
             ]);
-            assert_vec_close(SE3::exp(xi).log(), xi, 1e-6);
+            assert_components_close(SE3::exp(twist).log(), twist, 1e-6);
         }
     }
 }
@@ -214,11 +255,11 @@ fn se3_exp_log_roundtrip() {
 fn se3_adjoint_identity() {
     let mut rng = StdRng::seed_from_u64(12);
     for _ in 0..200 {
-        let x = rand_se3(&mut rng);
-        let xi = rand_twist6(&mut rng) * 0.3;
-        let lhs = SE3::exp(x.adjoint() * xi).to_matrix();
-        let rhs = (x * SE3::exp(xi) * x.inverse()).to_matrix();
-        assert_mat_close(lhs, rhs, 1e-8);
+        let pose = random_se3(&mut rng);
+        let twist = random_twist6(&mut rng) * 0.3;
+        let left_side = SE3::exp(pose.adjoint() * twist).to_matrix();
+        let right_side = (pose * SE3::exp(twist) * pose.inverse()).to_matrix();
+        assert_entries_close(left_side, right_side, 1e-8);
     }
 }
 
@@ -226,11 +267,15 @@ fn se3_adjoint_identity() {
 fn se3_act_matches_homogeneous_matrix() {
     let mut rng = StdRng::seed_from_u64(13);
     for _ in 0..100 {
-        let x = rand_se3(&mut rng);
-        let p = rand_vec3(&mut rng);
-        let hp = Vector::new([p[0], p[1], p[2], 1.0]);
-        let m = x.to_matrix() * hp;
-        assert_vec_close(x.act(p), Vector::new([m[0], m[1], m[2]]), TOL);
+        let pose = random_se3(&mut rng);
+        let point = random_vector3(&mut rng);
+        let homogeneous = Vector::new([point[0], point[1], point[2], 1.0]);
+        let product = pose.to_matrix() * homogeneous;
+        assert_components_close(
+            pose.act(point),
+            Vector::new([product[0], product[1], product[2]]),
+            TOL,
+        );
     }
 }
 
@@ -238,9 +283,9 @@ fn se3_act_matches_homogeneous_matrix() {
 fn se3_matrix_roundtrip() {
     let mut rng = StdRng::seed_from_u64(14);
     for _ in 0..100 {
-        let x = rand_se3(&mut rng);
-        let back = SE3::try_from_matrix(x.to_matrix()).unwrap();
-        assert_mat_close(back.to_matrix(), x.to_matrix(), 1e-9);
+        let pose = random_se3(&mut rng);
+        let recovered = SE3::try_from_matrix(pose.to_matrix()).unwrap();
+        assert_entries_close(recovered.to_matrix(), pose.to_matrix(), 1e-9);
     }
 }
 
@@ -248,8 +293,8 @@ fn se3_matrix_roundtrip() {
 fn se3_hat_vee_roundtrip() {
     let mut rng = StdRng::seed_from_u64(15);
     for _ in 0..100 {
-        let xi = rand_twist6(&mut rng);
-        assert_vec_close(SE3::vee(SE3::hat(xi)), xi, TOL);
+        let twist = random_twist6(&mut rng);
+        assert_components_close(SE3::vee(SE3::hat(twist)), twist, TOL);
     }
 }
 
@@ -257,9 +302,18 @@ fn se3_hat_vee_roundtrip() {
 fn se3_interpolate_endpoints() {
     let mut rng = StdRng::seed_from_u64(16);
     for _ in 0..100 {
-        let (a, b) = (rand_se3(&mut rng), rand_se3(&mut rng));
-        assert_mat_close(a.interpolate(b, 0.0).to_matrix(), a.to_matrix(), 1e-9);
-        assert_mat_close(a.interpolate(b, 1.0).to_matrix(), b.to_matrix(), 1e-8);
+        let first = random_se3(&mut rng);
+        let second = random_se3(&mut rng);
+        assert_entries_close(
+            first.interpolate(second, 0.0).to_matrix(),
+            first.to_matrix(),
+            1e-9,
+        );
+        assert_entries_close(
+            first.interpolate(second, 1.0).to_matrix(),
+            second.to_matrix(),
+            1e-8,
+        );
     }
 }
 
@@ -269,18 +323,24 @@ fn se3_interpolate_endpoints() {
 fn so2_group_and_roundtrip() {
     let mut rng = StdRng::seed_from_u64(20);
     for _ in 0..200 {
-        let (a, b, c) = (rand_so2(&mut rng), rand_so2(&mut rng), rand_so2(&mut rng));
-        assert_mat_close(((a * b) * c).to_matrix(), (a * (b * c)).to_matrix(), TOL);
-        assert_mat_close(
-            (a * a.inverse()).to_matrix(),
+        let first = random_so2(&mut rng);
+        let second = random_so2(&mut rng);
+        let third = random_so2(&mut rng);
+        assert_entries_close(
+            ((first * second) * third).to_matrix(),
+            (first * (second * third)).to_matrix(),
+            TOL,
+        );
+        assert_entries_close(
+            (first * first.inverse()).to_matrix(),
             SO2::identity().to_matrix(),
             TOL,
         );
-        for &th in &[1e-9, 0.3, PI - 1e-6] {
-            assert!((SO2::exp(th).log() - th).abs() < 1e-9);
+        for &angle in &[1e-9, 0.3, PI - 1e-6] {
+            assert!((SO2::exp(angle).log() - angle).abs() < 1e-9);
         }
-        let p = Vector::new([rng.gen_range(-1.0..1.0), rng.gen_range(-1.0..1.0)]);
-        assert_vec_close(a.act(p), a.to_matrix() * p, TOL);
+        let point = Vector::new([rng.gen_range(-1.0..1.0), rng.gen_range(-1.0..1.0)]);
+        assert_components_close(first.act(point), first.to_matrix() * point, TOL);
     }
 }
 
@@ -288,21 +348,27 @@ fn so2_group_and_roundtrip() {
 fn se2_group_and_roundtrip() {
     let mut rng = StdRng::seed_from_u64(21);
     for _ in 0..300 {
-        let (a, b, c) = (rand_se2(&mut rng), rand_se2(&mut rng), rand_se2(&mut rng));
-        assert_mat_close(((a * b) * c).to_matrix(), (a * (b * c)).to_matrix(), TOL);
-        assert_mat_close(
-            (a * a.inverse()).to_matrix(),
+        let first = random_se2(&mut rng);
+        let second = random_se2(&mut rng);
+        let third = random_se2(&mut rng);
+        assert_entries_close(
+            ((first * second) * third).to_matrix(),
+            (first * (second * third)).to_matrix(),
+            TOL,
+        );
+        assert_entries_close(
+            (first * first.inverse()).to_matrix(),
             SE2::identity().to_matrix(),
             TOL,
         );
-        for &th in &[1e-9, 0.4, PI - 1e-6] {
-            let xi = Vector::new([rng.gen_range(-1.0..1.0), rng.gen_range(-1.0..1.0), th]);
-            assert_vec_close(SE2::exp(xi).log(), xi, 1e-7);
+        for &angle in &[1e-9, 0.4, PI - 1e-6] {
+            let twist = Vector::new([rng.gen_range(-1.0..1.0), rng.gen_range(-1.0..1.0), angle]);
+            assert_components_close(SE2::exp(twist).log(), twist, 1e-7);
         }
-        let p = Vector::new([rng.gen_range(-1.0..1.0), rng.gen_range(-1.0..1.0)]);
-        let hp = Vector::new([p[0], p[1], 1.0]);
-        let m = a.to_matrix() * hp;
-        assert_vec_close(a.act(p), Vector::new([m[0], m[1]]), TOL);
+        let point = Vector::new([rng.gen_range(-1.0..1.0), rng.gen_range(-1.0..1.0)]);
+        let homogeneous = Vector::new([point[0], point[1], 1.0]);
+        let product = first.to_matrix() * homogeneous;
+        assert_components_close(first.act(point), Vector::new([product[0], product[1]]), TOL);
     }
 }
 
@@ -310,15 +376,15 @@ fn se2_group_and_roundtrip() {
 fn se2_adjoint_identity() {
     let mut rng = StdRng::seed_from_u64(22);
     for _ in 0..200 {
-        let x = rand_se2(&mut rng);
-        let xi = Vector::new([
+        let pose = random_se2(&mut rng);
+        let twist = Vector::new([
             rng.gen_range(-0.5..0.5),
             rng.gen_range(-0.5..0.5),
             rng.gen_range(-0.5..0.5),
         ]);
-        let lhs = SE2::exp(x.adjoint() * xi).to_matrix();
-        let rhs = (x * SE2::exp(xi) * x.inverse()).to_matrix();
-        assert_mat_close(lhs, rhs, 1e-9);
+        let left_side = SE2::exp(pose.adjoint() * twist).to_matrix();
+        let right_side = (pose * SE2::exp(twist) * pose.inverse()).to_matrix();
+        assert_entries_close(left_side, right_side, 1e-9);
     }
 }
 
@@ -327,47 +393,48 @@ fn se2_adjoint_identity() {
 #[test]
 fn so3_exp_ad_vs_fd() {
     // d/dφ_k of exp(φ).act(p): autodiff (Dual) vs central finite difference.
-    let phi0 = [0.2_f64, -0.1, 0.35];
-    let p = [0.5_f64, 0.3, -0.7];
-    let h = 1e-6;
-    for k in 0..3 {
-        let phi = Vector::new([
-            if k == 0 {
-                Dual::variable(phi0[0])
+    let base_rotation_vector = [0.2_f64, -0.1, 0.35];
+    let point = [0.5_f64, 0.3, -0.7];
+    let step = 1e-6;
+    for variable_index in 0..3 {
+        let rotation_vector = Vector::new([
+            if variable_index == 0 {
+                Dual::variable(base_rotation_vector[0])
             } else {
-                Dual::constant(phi0[0])
+                Dual::constant(base_rotation_vector[0])
             },
-            if k == 1 {
-                Dual::variable(phi0[1])
+            if variable_index == 1 {
+                Dual::variable(base_rotation_vector[1])
             } else {
-                Dual::constant(phi0[1])
+                Dual::constant(base_rotation_vector[1])
             },
-            if k == 2 {
-                Dual::variable(phi0[2])
+            if variable_index == 2 {
+                Dual::variable(base_rotation_vector[2])
             } else {
-                Dual::constant(phi0[2])
+                Dual::constant(base_rotation_vector[2])
             },
         ]);
-        let pv = Vector::new([
-            Dual::constant(p[0]),
-            Dual::constant(p[1]),
-            Dual::constant(p[2]),
+        let dual_point = Vector::new([
+            Dual::constant(point[0]),
+            Dual::constant(point[1]),
+            Dual::constant(point[2]),
         ]);
-        let out = SO3::exp(phi).act(pv);
+        let outputs = SO3::exp(rotation_vector).act(dual_point);
 
-        let mut phi_p = phi0;
-        let mut phi_m = phi0;
-        phi_p[k] += h;
-        phi_m[k] -= h;
-        let fp = SO3::exp(Vector::new(phi_p)).act(Vector::new(p));
-        let fm = SO3::exp(Vector::new(phi_m)).act(Vector::new(p));
-        for i in 0..3 {
-            let fd = (fp[i] - fm[i]) / (2.0 * h);
+        let mut plus = base_rotation_vector;
+        let mut minus = base_rotation_vector;
+        plus[variable_index] += step;
+        minus[variable_index] -= step;
+        let outputs_at_plus = SO3::exp(Vector::new(plus)).act(Vector::new(point));
+        let outputs_at_minus = SO3::exp(Vector::new(minus)).act(Vector::new(point));
+        for output_index in 0..3 {
+            let finite_difference =
+                (outputs_at_plus[output_index] - outputs_at_minus[output_index]) / (2.0 * step);
             assert!(
-                (out[i].deriv - fd).abs() < 1e-6,
-                "k={k} i={i}: {} vs {}",
-                out[i].deriv,
-                fd
+                (outputs[output_index].deriv - finite_difference).abs() < 1e-6,
+                "variable {variable_index} output {output_index}: {} vs {}",
+                outputs[output_index].deriv,
+                finite_difference
             );
         }
     }
@@ -376,19 +443,19 @@ fn so3_exp_ad_vs_fd() {
 #[test]
 fn so3_exp_derivative_finite_at_zero() {
     // At φ = 0 the exp map is smooth; a naive sqrt-based path would give a NaN derivative here.
-    let phi = Vector::new([
+    let rotation_vector = Vector::new([
         Dual::variable(0.0),
         Dual::constant(0.0),
         Dual::constant(0.0),
     ]);
-    let pv = Vector::new([
+    let dual_point = Vector::new([
         Dual::constant(1.0),
         Dual::constant(0.0),
         Dual::constant(0.0),
     ]);
-    let out = SO3::exp(phi).act(pv);
-    for i in 0..3 {
-        assert!(out[i].deriv.is_finite());
+    let outputs = SO3::exp(rotation_vector).act(dual_point);
+    for output_index in 0..3 {
+        assert!(outputs[output_index].deriv.is_finite());
     }
 }
 
@@ -396,25 +463,25 @@ fn so3_exp_derivative_finite_at_zero() {
 
 #[test]
 fn f32_identity_coverage() {
-    let phi = Vector::new([0.2_f32, -0.3, 0.5]);
-    let back = SO3::exp(phi).log();
-    for i in 0..3 {
-        assert!((back[i] - phi[i]).abs() < 1e-4);
+    let rotation_vector = Vector::new([0.2_f32, -0.3, 0.5]);
+    let recovered = SO3::exp(rotation_vector).log();
+    for index in 0..3 {
+        assert!((recovered[index] - rotation_vector[index]).abs() < 1e-4);
     }
 
-    let xi = Vector::new([0.1_f32, -0.2, 0.3, 0.2, -0.3, 0.5]);
-    let back6 = SE3::exp(xi).log();
-    for i in 0..6 {
-        assert!((back6[i] - xi[i]).abs() < 1e-4);
+    let twist = Vector::new([0.1_f32, -0.2, 0.3, 0.2, -0.3, 0.5]);
+    let recovered_twist = SE3::exp(twist).log();
+    for index in 0..6 {
+        assert!((recovered_twist[index] - twist[index]).abs() < 1e-4);
     }
 
     // Rotation matrix orthonormality: RᵀR = I.
-    let r = SO3::exp(phi).to_matrix();
-    let rtr = r.transpose() * r;
-    for i in 0..3 {
-        for j in 0..3 {
-            let expect = if i == j { 1.0 } else { 0.0 };
-            assert!((rtr[(i, j)] - expect).abs() < 1e-5);
+    let rotation = SO3::exp(rotation_vector).to_matrix();
+    let should_be_identity = rotation.transpose() * rotation;
+    for row in 0..3 {
+        for column in 0..3 {
+            let expected = if row == column { 1.0 } else { 0.0 };
+            assert!((should_be_identity[(row, column)] - expected).abs() < 1e-5);
         }
     }
 }
@@ -424,21 +491,21 @@ fn f32_identity_coverage() {
 #[test]
 fn so3_exp_goldens() {
     // exp(θ·axis).to_matrix() == R.from_rotvec([...]).as_matrix()
-    let rz = SO3::<f64>::exp(Vector::new([0.0, 0.0, PI / 2.0]));
-    assert_mat_close(
-        rz.to_matrix(),
+    let rotation_about_z = SO3::<f64>::exp(Vector::new([0.0, 0.0, PI / 2.0]));
+    assert_entries_close(
+        rotation_about_z.to_matrix(),
         Matrix::new([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
         1e-12,
     );
-    let rx = SO3::<f64>::exp(Vector::new([PI / 2.0, 0.0, 0.0]));
-    assert_mat_close(
-        rx.to_matrix(),
+    let rotation_about_x = SO3::<f64>::exp(Vector::new([PI / 2.0, 0.0, 0.0]));
+    assert_entries_close(
+        rotation_about_x.to_matrix(),
         Matrix::new([[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]]),
         1e-12,
     );
-    let ry = SO3::<f64>::exp(Vector::new([0.0, PI / 2.0, 0.0]));
-    assert_mat_close(
-        ry.to_matrix(),
+    let rotation_about_y = SO3::<f64>::exp(Vector::new([0.0, PI / 2.0, 0.0]));
+    assert_entries_close(
+        rotation_about_y.to_matrix(),
         Matrix::new([[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [-1.0, 0.0, 0.0]]),
         1e-12,
     );
@@ -450,16 +517,16 @@ fn so3_exp_goldens() {
 fn so3_jacobian_inverse_roundtrip() {
     let mut rng = StdRng::seed_from_u64(20);
     for _ in 0..200 {
-        let axis = rand_unit_vec3(&mut rng);
+        let axis = random_unit_vector3(&mut rng);
         for &angle in &[1e-9, 1e-4, 0.5, 2.0, PI - 1e-6] {
-            let phi = axis * angle;
-            assert_mat_close(
-                SO3::left_jacobian(phi) * SO3::left_jacobian_inverse(phi),
+            let rotation_vector = axis * angle;
+            assert_entries_close(
+                SO3::left_jacobian(rotation_vector) * SO3::left_jacobian_inverse(rotation_vector),
                 Matrix::identity(),
                 1e-9,
             );
-            assert_mat_close(
-                SO3::right_jacobian(phi) * SO3::right_jacobian_inverse(phi),
+            assert_entries_close(
+                SO3::right_jacobian(rotation_vector) * SO3::right_jacobian_inverse(rotation_vector),
                 Matrix::identity(),
                 1e-9,
             );
@@ -471,18 +538,18 @@ fn so3_jacobian_inverse_roundtrip() {
 fn se3_jacobian_identities() {
     let mut rng = StdRng::seed_from_u64(21);
     for _ in 0..200 {
-        let xi = rand_twist6(&mut rng);
+        let twist = random_twist6(&mut rng);
         // J_l · J_l⁻¹ = I and J_r = J_l(−ξ).
-        assert_mat_close(
-            SE3::left_jacobian(xi) * SE3::left_jacobian_inverse(xi),
+        assert_entries_close(
+            SE3::left_jacobian(twist) * SE3::left_jacobian_inverse(twist),
             Matrix::identity(),
             1e-8,
         );
-        assert_mat_close(SE3::right_jacobian(xi), SE3::left_jacobian(-xi), TOL);
+        assert_entries_close(SE3::right_jacobian(twist), SE3::left_jacobian(-twist), TOL);
         // Adjoint identity: Ad_{exp(ξ)} = J_l(ξ) · J_r(ξ)⁻¹.
-        assert_mat_close(
-            SE3::exp(xi).adjoint(),
-            SE3::left_jacobian(xi) * SE3::right_jacobian_inverse(xi),
+        assert_entries_close(
+            SE3::exp(twist).adjoint(),
+            SE3::left_jacobian(twist) * SE3::right_jacobian_inverse(twist),
             1e-8,
         );
     }
@@ -491,22 +558,25 @@ fn se3_jacobian_identities() {
 #[test]
 fn se3_left_jacobian_matches_finite_difference() {
     // Defining property: log(exp(ξ + h·eᵢ) · exp(ξ)⁻¹)/h → column i of J_l(ξ).
-    let xi = Vector::new([0.2_f64, -0.1, 0.3, 0.25, -0.15, 0.4]);
-    let jl = SE3::left_jacobian(xi);
-    let h = 1e-6;
-    for col in 0..6 {
-        let mut plus = xi;
-        plus[col] += h;
-        let d = (SE3::exp(plus) * SE3::exp(xi).inverse()).log() * (1.0 / h);
+    let twist = Vector::new([0.2_f64, -0.1, 0.3, 0.25, -0.15, 0.4]);
+    let left_jacobian = SE3::left_jacobian(twist);
+    let step = 1e-6;
+    for column in 0..6 {
+        let mut plus = twist;
+        plus[column] += step;
+        let difference = (SE3::exp(plus) * SE3::exp(twist).inverse()).log() * (1.0 / step);
         for row in 0..6 {
-            assert!((d[row] - jl[(row, col)]).abs() < 1e-4, "({row},{col})");
+            assert!(
+                (difference[row] - left_jacobian[(row, column)]).abs() < 1e-4,
+                "({row},{column})"
+            );
         }
     }
 }
 
 #[test]
 fn se3_left_jacobian_finite_at_zero_under_dual() {
-    let xi = Vector::new([
+    let twist = Vector::new([
         Dual::variable(0.0),
         Dual::constant(0.0),
         Dual::constant(0.0),
@@ -514,10 +584,10 @@ fn se3_left_jacobian_finite_at_zero_under_dual() {
         Dual::constant(0.0),
         Dual::constant(0.0),
     ]);
-    let jl = SE3::left_jacobian(xi);
-    for i in 0..6 {
-        for j in 0..6 {
-            let cell = jl[(i, j)];
+    let left_jacobian = SE3::left_jacobian(twist);
+    for row in 0..6 {
+        for column in 0..6 {
+            let cell = left_jacobian[(row, column)];
             assert!(cell.value.is_finite() && cell.deriv.is_finite());
         }
     }
@@ -527,32 +597,35 @@ fn se3_left_jacobian_finite_at_zero_under_dual() {
 fn se2_jacobian_identities_and_fd() {
     let mut rng = StdRng::seed_from_u64(22);
     for _ in 0..200 {
-        let xi = Vector::new([
+        let twist = Vector::new([
             rng.gen_range(-1.0..1.0),
             rng.gen_range(-1.0..1.0),
             rng.gen_range(-2.5..2.5),
         ]);
-        assert_mat_close(
-            SE2::left_jacobian(xi) * SE2::left_jacobian_inverse(xi),
+        assert_entries_close(
+            SE2::left_jacobian(twist) * SE2::left_jacobian_inverse(twist),
             Matrix::identity(),
             1e-9,
         );
-        assert_mat_close(
-            SE2::exp(xi).adjoint(),
-            SE2::left_jacobian(xi) * SE2::right_jacobian_inverse(xi),
+        assert_entries_close(
+            SE2::exp(twist).adjoint(),
+            SE2::left_jacobian(twist) * SE2::right_jacobian_inverse(twist),
             1e-8,
         );
     }
     // Finite-difference ground truth on one configuration.
-    let xi = Vector::new([0.3_f64, -0.4, 0.5]);
-    let jl = SE2::left_jacobian(xi);
-    let h = 1e-6;
-    for col in 0..3 {
-        let mut plus = xi;
-        plus[col] += h;
-        let d = (SE2::exp(plus) * SE2::exp(xi).inverse()).log() * (1.0 / h);
+    let twist = Vector::new([0.3_f64, -0.4, 0.5]);
+    let left_jacobian = SE2::left_jacobian(twist);
+    let step = 1e-6;
+    for column in 0..3 {
+        let mut plus = twist;
+        plus[column] += step;
+        let difference = (SE2::exp(plus) * SE2::exp(twist).inverse()).log() * (1.0 / step);
         for row in 0..3 {
-            assert!((d[row] - jl[(row, col)]).abs() < 1e-4, "({row},{col})");
+            assert!(
+                (difference[row] - left_jacobian[(row, column)]).abs() < 1e-4,
+                "({row},{column})"
+            );
         }
     }
 }
@@ -568,9 +641,9 @@ fn so2_jacobians_are_one() {
 #[test]
 fn se3_to_matrix_goldens() {
     // Pure translation: identity rotation, translation (1, 2, 3).
-    let t = SE3::<f64>::exp(Vector::new([1.0, 2.0, 3.0, 0.0, 0.0, 0.0]));
-    assert_mat_close(
-        t.to_matrix(),
+    let translation_only = SE3::<f64>::exp(Vector::new([1.0, 2.0, 3.0, 0.0, 0.0, 0.0]));
+    assert_entries_close(
+        translation_only.to_matrix(),
         Matrix::new([
             [1.0, 0.0, 0.0, 1.0],
             [0.0, 1.0, 0.0, 2.0],
@@ -580,9 +653,9 @@ fn se3_to_matrix_goldens() {
         1e-12,
     );
     // Pure rotation twist: Rz(90°), zero translation (J_l · 0 = 0).
-    let r = SE3::<f64>::exp(Vector::new([0.0, 0.0, 0.0, 0.0, 0.0, PI / 2.0]));
-    assert_mat_close(
-        r.to_matrix(),
+    let rotation = SE3::<f64>::exp(Vector::new([0.0, 0.0, 0.0, 0.0, 0.0, PI / 2.0]));
+    assert_entries_close(
+        rotation.to_matrix(),
         Matrix::new([
             [0.0, -1.0, 0.0, 0.0],
             [1.0, 0.0, 0.0, 0.0],

--- a/crates/multicalc/tests/suite/spatial/quaternion.rs
+++ b/crates/multicalc/tests/suite/spatial/quaternion.rs
@@ -13,7 +13,7 @@ const TOL: f64 = 1e-12;
 
 // ---- helpers ----------------------------------------------------------------
 
-fn rand_quat(rng: &mut StdRng) -> Quaternion<f64> {
+fn random_quaternion(rng: &mut StdRng) -> Quaternion<f64> {
     Quaternion::new(
         rng.gen_range(-1.0..1.0),
         rng.gen_range(-1.0..1.0),
@@ -22,48 +22,50 @@ fn rand_quat(rng: &mut StdRng) -> Quaternion<f64> {
     )
 }
 
-fn rand_unit(rng: &mut StdRng) -> Quaternion<f64> {
+fn random_unit_quaternion(rng: &mut StdRng) -> Quaternion<f64> {
     loop {
-        let q = rand_quat(rng);
-        if q.norm() > 1e-3 {
-            return q.normalized();
+        let quaternion = random_quaternion(rng);
+        if quaternion.norm() > 1e-3 {
+            return quaternion.normalized();
         }
     }
 }
 
-fn rand_unit_vec(rng: &mut StdRng) -> Vector<3, f64> {
+fn random_unit_vector(rng: &mut StdRng) -> Vector<3, f64> {
     loop {
-        let v = Vector::new([
+        let vector = Vector::new([
             rng.gen_range(-1.0..1.0),
             rng.gen_range(-1.0..1.0),
             rng.gen_range(-1.0..1.0),
         ]);
-        let n = v.dot(v).sqrt();
-        if n > 1e-3 {
-            return v * n.recip();
+        let norm = vector.dot(vector).sqrt();
+        if norm > 1e-3 {
+            return vector * norm.recip();
         }
     }
 }
 
-fn assert_close_q(a: Quaternion<f64>, b: Quaternion<f64>, tol: f64) {
-    for (x, y) in a.as_array().iter().zip(b.as_array().iter()) {
-        assert!((x - y).abs() < tol, "{x} vs {y}");
+fn assert_quaternions_close(first: Quaternion<f64>, second: Quaternion<f64>, tolerance: f64) {
+    for (left, right) in first.as_array().iter().zip(second.as_array().iter()) {
+        assert!((left - right).abs() < tolerance, "{left} vs {right}");
     }
 }
 
-fn assert_close_v(a: Vector<3, f64>, b: Vector<3, f64>, tol: f64) {
-    for i in 0..3 {
-        let (ai, bi) = (a[i], b[i]);
-        assert!((ai - bi).abs() < tol, "{ai} vs {bi}");
+fn assert_vectors_close(first: Vector<3, f64>, second: Vector<3, f64>, tolerance: f64) {
+    for index in 0..3 {
+        let left = first[index];
+        let right = second[index];
+        assert!((left - right).abs() < tolerance, "{left} vs {right}");
     }
 }
 
 /// Compares two rotations (sign-insensitive) via their rotation matrices.
-fn assert_rot_close(a: Quaternion<f64>, b: Quaternion<f64>, tol: f64) {
-    let (ra, rb) = (a.to_rotation_matrix(), b.to_rotation_matrix());
-    for r in 0..3 {
-        for c in 0..3 {
-            assert!((ra[(r, c)] - rb[(r, c)]).abs() < tol);
+fn assert_rotations_close(first: Quaternion<f64>, second: Quaternion<f64>, tolerance: f64) {
+    let left_matrix = first.to_rotation_matrix();
+    let right_matrix = second.to_rotation_matrix();
+    for row in 0..3 {
+        for column in 0..3 {
+            assert!((left_matrix[(row, column)] - right_matrix[(row, column)]).abs() < tolerance);
         }
     }
 }
@@ -80,24 +82,38 @@ fn assert_rot_close(a: Quaternion<f64>, b: Quaternion<f64>, tol: f64) {
 // The cases below are exact, so they are written inline rather than as a fixture file.
 #[test]
 fn rotation_matrix_goldens() {
-    let s = std::f64::consts::FRAC_1_SQRT_2; // sin/cos of 45°
+    let half_root_two = std::f64::consts::FRAC_1_SQRT_2; // sin/cos of 45°
 
     // 90° about x.
-    let qx = Quaternion::from_axis_angle(Vector::new([1.0, 0.0, 0.0]), PI / 2.0);
-    assert_close_q(qx, Quaternion::new(s, s, 0.0, 0.0), TOL);
-    let expect_x = Matrix::new([[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]]);
-    for r in 0..3 {
-        for c in 0..3 {
-            assert!((qx.to_rotation_matrix()[(r, c)] - expect_x[(r, c)]).abs() < TOL);
+    let quarter_turn_about_x = Quaternion::from_axis_angle(Vector::new([1.0, 0.0, 0.0]), PI / 2.0);
+    assert_quaternions_close(
+        quarter_turn_about_x,
+        Quaternion::new(half_root_two, half_root_two, 0.0, 0.0),
+        TOL,
+    );
+    let expected_x = Matrix::new([[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]]);
+    for row in 0..3 {
+        for column in 0..3 {
+            assert!(
+                (quarter_turn_about_x.to_rotation_matrix()[(row, column)]
+                    - expected_x[(row, column)])
+                    .abs()
+                    < TOL
+            );
         }
     }
 
     // The 120° rotation q = (0.5, 0.5, 0.5, 0.5): a cyclic axis permutation.
-    let qc = Quaternion::new(0.5, 0.5, 0.5, 0.5).normalized();
-    let expect_c = Matrix::new([[0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]);
-    for r in 0..3 {
-        for c in 0..3 {
-            assert!((qc.to_rotation_matrix()[(r, c)] - expect_c[(r, c)]).abs() < TOL);
+    let cyclic_permutation = Quaternion::new(0.5, 0.5, 0.5, 0.5).normalized();
+    let expected_cyclic = Matrix::new([[0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]);
+    for row in 0..3 {
+        for column in 0..3 {
+            assert!(
+                (cyclic_permutation.to_rotation_matrix()[(row, column)]
+                    - expected_cyclic[(row, column)])
+                    .abs()
+                    < TOL
+            );
         }
     }
 }
@@ -105,10 +121,14 @@ fn rotation_matrix_goldens() {
 #[test]
 fn euler_golden_yaw_90() {
     // 90° about z is pure yaw in ZYX.
-    let q = Quaternion::from_euler_zyx(0.0, 0.0, PI / 2.0);
-    let s = std::f64::consts::FRAC_1_SQRT_2;
-    assert_close_q(q, Quaternion::new(s, 0.0, 0.0, s), TOL);
-    let (roll, pitch, yaw) = q.to_euler_zyx();
+    let quaternion = Quaternion::from_euler_zyx(0.0, 0.0, PI / 2.0);
+    let half_root_two = std::f64::consts::FRAC_1_SQRT_2;
+    assert_quaternions_close(
+        quaternion,
+        Quaternion::new(half_root_two, 0.0, 0.0, half_root_two),
+        TOL,
+    );
+    let (roll, pitch, yaw) = quaternion.to_euler_zyx();
     assert!(roll.abs() < TOL);
     assert!(pitch.abs() < TOL);
     assert!((yaw - PI / 2.0).abs() < TOL);
@@ -119,10 +139,14 @@ fn euler_gimbal_lock_poles() {
     // At pitch = ±π/2 the roll/yaw split is not unique; check the clamp branch reports the pole
     // exactly and that the reconstructed rotation still matches.
     for &sign in &[1.0, -1.0] {
-        let q = Quaternion::from_euler_zyx(0.3, sign * PI / 2.0, 0.7);
-        let (r2, p2, y2) = q.to_euler_zyx();
-        assert!((p2 - sign * PI / 2.0).abs() < 1e-9);
-        assert_rot_close(Quaternion::from_euler_zyx(r2, p2, y2), q, 1e-9);
+        let quaternion = Quaternion::from_euler_zyx(0.3, sign * PI / 2.0, 0.7);
+        let (recovered_roll, recovered_pitch, recovered_yaw) = quaternion.to_euler_zyx();
+        assert!((recovered_pitch - sign * PI / 2.0).abs() < 1e-9);
+        assert_rotations_close(
+            Quaternion::from_euler_zyx(recovered_roll, recovered_pitch, recovered_yaw),
+            quaternion,
+            1e-9,
+        );
     }
 }
 
@@ -132,12 +156,10 @@ fn euler_gimbal_lock_poles() {
 fn hamilton_associative() {
     let mut rng = StdRng::seed_from_u64(1);
     for _ in 0..2000 {
-        let (a, b, c) = (
-            rand_quat(&mut rng),
-            rand_quat(&mut rng),
-            rand_quat(&mut rng),
-        );
-        assert_close_q((a * b) * c, a * (b * c), 1e-11);
+        let first = random_quaternion(&mut rng);
+        let second = random_quaternion(&mut rng);
+        let third = random_quaternion(&mut rng);
+        assert_quaternions_close((first * second) * third, first * (second * third), 1e-11);
     }
 }
 
@@ -145,8 +167,13 @@ fn hamilton_associative() {
 fn conjugate_antihomomorphism() {
     let mut rng = StdRng::seed_from_u64(2);
     for _ in 0..2000 {
-        let (a, b) = (rand_quat(&mut rng), rand_quat(&mut rng));
-        assert_close_q((a * b).conjugate(), b.conjugate() * a.conjugate(), 1e-12);
+        let first = random_quaternion(&mut rng);
+        let second = random_quaternion(&mut rng);
+        assert_quaternions_close(
+            (first * second).conjugate(),
+            second.conjugate() * first.conjugate(),
+            1e-12,
+        );
     }
 }
 
@@ -154,8 +181,9 @@ fn conjugate_antihomomorphism() {
 fn norm_multiplicative() {
     let mut rng = StdRng::seed_from_u64(3);
     for _ in 0..2000 {
-        let (a, b) = (rand_quat(&mut rng), rand_quat(&mut rng));
-        assert!(((a * b).norm() - a.norm() * b.norm()).abs() < 1e-12);
+        let first = random_quaternion(&mut rng);
+        let second = random_quaternion(&mut rng);
+        assert!(((first * second).norm() - first.norm() * second.norm()).abs() < 1e-12);
     }
 }
 
@@ -163,16 +191,16 @@ fn norm_multiplicative() {
 fn rotation_matrix_orthonormal() {
     let mut rng = StdRng::seed_from_u64(4);
     for _ in 0..2000 {
-        let q = rand_unit(&mut rng);
-        let m = q.to_rotation_matrix();
-        let should_be_i = m.transpose() * m;
-        for r in 0..3 {
-            for c in 0..3 {
-                let expect = if r == c { 1.0 } else { 0.0 };
-                assert!((should_be_i[(r, c)] - expect).abs() < 1e-12);
+        let quaternion = random_unit_quaternion(&mut rng);
+        let rotation_matrix = quaternion.to_rotation_matrix();
+        let should_be_identity = rotation_matrix.transpose() * rotation_matrix;
+        for row in 0..3 {
+            for column in 0..3 {
+                let expected = if row == column { 1.0 } else { 0.0 };
+                assert!((should_be_identity[(row, column)] - expected).abs() < 1e-12);
             }
         }
-        assert!((m.determinant() - 1.0).abs() < 1e-12);
+        assert!((rotation_matrix.determinant() - 1.0).abs() < 1e-12);
     }
 }
 
@@ -180,9 +208,10 @@ fn rotation_matrix_orthonormal() {
 fn matrix_roundtrip() {
     let mut rng = StdRng::seed_from_u64(5);
     for _ in 0..2000 {
-        let q = rand_unit(&mut rng);
-        let back = Quaternion::try_from_rotation_matrix(q.to_rotation_matrix()).unwrap();
-        assert_rot_close(q, back, 1e-11);
+        let quaternion = random_unit_quaternion(&mut rng);
+        let recovered =
+            Quaternion::try_from_rotation_matrix(quaternion.to_rotation_matrix()).unwrap();
+        assert_rotations_close(quaternion, recovered, 1e-11);
     }
 }
 
@@ -190,19 +219,19 @@ fn matrix_roundtrip() {
 fn scaled_axis_roundtrip() {
     let mut rng = StdRng::seed_from_u64(6);
     for _ in 0..2000 {
-        let theta = rng.gen_range(0.0..0.99 * PI);
-        let phi = rand_unit_vec(&mut rng) * theta;
-        assert_close_v(
-            Quaternion::from_scaled_axis(phi).to_scaled_axis(),
-            phi,
+        let angle = rng.gen_range(0.0..0.99 * PI);
+        let rotation_vector = random_unit_vector(&mut rng) * angle;
+        assert_vectors_close(
+            Quaternion::from_scaled_axis(rotation_vector).to_scaled_axis(),
+            rotation_vector,
             1e-10,
         );
     }
     // Small-angle branch.
-    let tiny = Vector::new([1e-8, -2e-8, 0.5e-8]);
-    assert_close_v(
-        Quaternion::from_scaled_axis(tiny).to_scaled_axis(),
-        tiny,
+    let tiny_rotation = Vector::new([1e-8, -2e-8, 0.5e-8]);
+    assert_vectors_close(
+        Quaternion::from_scaled_axis(tiny_rotation).to_scaled_axis(),
+        tiny_rotation,
         1e-18,
     );
 }
@@ -211,11 +240,12 @@ fn scaled_axis_roundtrip() {
 fn axis_angle_roundtrip() {
     let mut rng = StdRng::seed_from_u64(7);
     for _ in 0..2000 {
-        let axis = rand_unit_vec(&mut rng);
+        let axis = random_unit_vector(&mut rng);
         let angle = rng.gen_range(0.01..0.99 * PI);
-        let (a2, t2) = Quaternion::from_axis_angle(axis, angle).to_axis_angle();
-        assert!((t2 - angle).abs() < 1e-10);
-        assert_close_v(a2, axis, 1e-9);
+        let (recovered_axis, recovered_angle) =
+            Quaternion::from_axis_angle(axis, angle).to_axis_angle();
+        assert!((recovered_angle - angle).abs() < 1e-10);
+        assert_vectors_close(recovered_axis, axis, 1e-9);
     }
 }
 
@@ -226,10 +256,11 @@ fn euler_roundtrip() {
         let roll = rng.gen_range(-0.99 * PI..0.99 * PI); // clear of the ±π wrap boundary
         let pitch = rng.gen_range(-0.49 * PI..0.49 * PI); // clear of gimbal lock
         let yaw = rng.gen_range(-0.99 * PI..0.99 * PI);
-        let (r2, p2, y2) = Quaternion::from_euler_zyx(roll, pitch, yaw).to_euler_zyx();
-        assert!((r2 - roll).abs() < 1e-10);
-        assert!((p2 - pitch).abs() < 1e-10);
-        assert!((y2 - yaw).abs() < 1e-10);
+        let (recovered_roll, recovered_pitch, recovered_yaw) =
+            Quaternion::from_euler_zyx(roll, pitch, yaw).to_euler_zyx();
+        assert!((recovered_roll - roll).abs() < 1e-10);
+        assert!((recovered_pitch - pitch).abs() < 1e-10);
+        assert!((recovered_yaw - yaw).abs() < 1e-10);
     }
 }
 
@@ -241,22 +272,22 @@ fn exp_ln_roundtrip() {
     for _ in 0..2000 {
         // ln ∘ exp on a general (small) quaternion. Keep the vector part below π so exp stays
         // inside the principal branch that ln inverts.
-        let q = Quaternion::new(
+        let quaternion = Quaternion::new(
             rng.gen_range(-1.0..1.0),
             rng.gen_range(-1.0..1.0),
             rng.gen_range(-1.0..1.0),
             rng.gen_range(-1.0..1.0),
         );
-        assert_close_q(q.exp().ln(), q, 1e-10);
+        assert_quaternions_close(quaternion.exp().ln(), quaternion, 1e-10);
 
         // exp ∘ ln on a quaternion with positive real part (clear of the negative-real branch cut).
-        let p = Quaternion::new(
+        let positive_real = Quaternion::new(
             rng.gen_range(0.2..1.0),
             rng.gen_range(-1.0..1.0),
             rng.gen_range(-1.0..1.0),
             rng.gen_range(-1.0..1.0),
         );
-        assert_close_q(p.ln().exp(), p, 1e-10);
+        assert_quaternions_close(positive_real.ln().exp(), positive_real, 1e-10);
     }
 }
 
@@ -265,14 +296,18 @@ fn exp_matches_from_scaled_axis() {
     let mut rng = StdRng::seed_from_u64(21);
     for _ in 0..2000 {
         // For a pure-vector quaternion v, exp(v) is the rotation from_scaled_axis(2v).
-        let theta = rng.gen_range(0.0..0.49 * PI);
-        let v = rand_unit_vec(&mut rng) * theta;
-        let qv = Quaternion::new(0.0, v[0], v[1], v[2]);
-        assert_rot_close(qv.exp(), Quaternion::from_scaled_axis(v * 2.0), 1e-11);
+        let angle = rng.gen_range(0.0..0.49 * PI);
+        let vector = random_unit_vector(&mut rng) * angle;
+        let pure_vector = Quaternion::new(0.0, vector[0], vector[1], vector[2]);
+        assert_rotations_close(
+            pure_vector.exp(),
+            Quaternion::from_scaled_axis(vector * 2.0),
+            1e-11,
+        );
     }
     // Both branches stay finite and unit at exactly zero.
-    let z = Quaternion::<f64>::new(0.0, 0.0, 0.0, 0.0);
-    assert!((z.exp().norm() - 1.0).abs() < TOL);
+    let zero_quaternion = Quaternion::<f64>::new(0.0, 0.0, 0.0, 0.0);
+    assert!((zero_quaternion.exp().norm() - 1.0).abs() < TOL);
 }
 
 // ---- interpolation and point action ----------------------------------------
@@ -281,10 +316,11 @@ fn exp_matches_from_scaled_axis() {
 fn slerp_endpoints_shortest_path() {
     let mut rng = StdRng::seed_from_u64(9);
     for _ in 0..2000 {
-        let (a, b) = (rand_unit(&mut rng), rand_unit(&mut rng));
+        let first = random_unit_quaternion(&mut rng);
+        let second = random_unit_quaternion(&mut rng);
         // Endpoints reproduce the input rotation even when dot < 0 (sign-flip branch).
-        assert_rot_close(a.slerp(b, 0.0), a, 1e-10);
-        assert_rot_close(a.slerp(b, 1.0), b, 1e-10);
+        assert_rotations_close(first.slerp(second, 0.0), first, 1e-10);
+        assert_rotations_close(first.slerp(second, 1.0), second, 1e-10);
     }
 }
 
@@ -292,42 +328,43 @@ fn slerp_endpoints_shortest_path() {
 fn slerp_constant_rate() {
     let mut rng = StdRng::seed_from_u64(10);
     for _ in 0..1000 {
-        let a = rand_unit(&mut rng);
-        let delta = Quaternion::from_axis_angle(rand_unit_vec(&mut rng), rng.gen_range(0.1..2.0));
-        let b = a * delta;
+        let first = random_unit_quaternion(&mut rng);
+        let delta =
+            Quaternion::from_axis_angle(random_unit_vector(&mut rng), rng.gen_range(0.1..2.0));
+        let second = first * delta;
         // The midpoint of the geodesic is half the relative rotation.
-        let mid = a.slerp(b, 0.5);
-        let half = a * Quaternion::from_scaled_axis(delta.to_scaled_axis() * 0.5);
-        assert_rot_close(mid, half, 1e-9);
+        let midpoint = first.slerp(second, 0.5);
+        let half_rotation = first * Quaternion::from_scaled_axis(delta.to_scaled_axis() * 0.5);
+        assert_rotations_close(midpoint, half_rotation, 1e-9);
     }
 }
 
 #[test]
 fn slerp_small_angle_finite() {
-    let a = Quaternion::<f64>::identity();
-    let b = Quaternion::from_axis_angle(Vector::new([0.0, 0.0, 1.0]), 1e-9);
-    let m = a.slerp(b, 0.5);
-    assert!(m.norm().is_finite());
-    assert!((m.norm() - 1.0).abs() < 1e-12);
+    let first = Quaternion::<f64>::identity();
+    let second = Quaternion::from_axis_angle(Vector::new([0.0, 0.0, 1.0]), 1e-9);
+    let midpoint = first.slerp(second, 0.5);
+    assert!(midpoint.norm().is_finite());
+    assert!((midpoint.norm() - 1.0).abs() < 1e-12);
 }
 
 #[test]
 fn transform_point_properties() {
     let mut rng = StdRng::seed_from_u64(11);
     for _ in 0..2000 {
-        let q = rand_unit(&mut rng);
-        let v = Vector::new([
+        let quaternion = random_unit_quaternion(&mut rng);
+        let vector = Vector::new([
             rng.gen_range(-5.0..5.0),
             rng.gen_range(-5.0..5.0),
             rng.gen_range(-5.0..5.0),
         ]);
-        let rv = q.transform_point(v);
+        let rotated = quaternion.transform_point(vector);
         // Norm-preserving.
-        assert!((rv.dot(rv).sqrt() - v.dot(v).sqrt()).abs() < 1e-11);
+        assert!((rotated.dot(rotated).sqrt() - vector.dot(vector).sqrt()).abs() < 1e-11);
         // Inverse undoes it.
-        assert_close_v(q.inverse().transform_point(rv), v, 1e-10);
+        assert_vectors_close(quaternion.inverse().transform_point(rotated), vector, 1e-10);
         // Matches the matrix action.
-        assert_close_v(rv, q.to_rotation_matrix() * v, 1e-11);
+        assert_vectors_close(rotated, quaternion.to_rotation_matrix() * vector, 1e-11);
     }
 }
 
@@ -335,44 +372,45 @@ fn transform_point_properties() {
 
 /// Rotates x̂ by `angle` about ẑ and returns the x-component, which is `cos(angle)`.
 fn rotated_component<T: Numeric>(angle: T) -> T {
-    let q = Quaternion::from_axis_angle(Vector::new([T::ZERO, T::ZERO, T::ONE]), angle);
-    q.transform_point(Vector::new([T::ONE, T::ZERO, T::ZERO]))[0]
+    let quaternion = Quaternion::from_axis_angle(Vector::new([T::ZERO, T::ZERO, T::ONE]), angle);
+    quaternion.transform_point(Vector::new([T::ONE, T::ZERO, T::ZERO]))[0]
 }
 
 #[test]
 fn ad_matches_finite_difference() {
     let mut rng = StdRng::seed_from_u64(12);
     for _ in 0..1000 {
-        let a = rng.gen_range(-PI..PI);
-        let ad = rotated_component(Dual::variable(a)).deriv;
-        let h = 1e-6;
-        let fd = (rotated_component(a + h) - rotated_component(a - h)) / (2.0 * h);
-        assert!((ad + a.sin()).abs() < 1e-9); // exact derivative is -sin(a)
-        assert!((ad - fd).abs() < 1e-6); // FD's own error floor
+        let angle = rng.gen_range(-PI..PI);
+        let autodiff = rotated_component(Dual::variable(angle)).deriv;
+        let step = 1e-6;
+        let finite_difference =
+            (rotated_component(angle + step) - rotated_component(angle - step)) / (2.0 * step);
+        assert!((autodiff + angle.sin()).abs() < 1e-9); // exact derivative is -sin(angle)
+        assert!((autodiff - finite_difference).abs() < 1e-6); // FD's own error floor
     }
 }
 
-/// Rotates x̂ by `from_scaled_axis(t·ẑ)` and returns the y-component, which is `sin(t)` (chosen so
-/// the derivative at `t = 0` is a non-zero 1). Differentiating here exercises the small-angle
-/// branch that once produced NaN via `sqrt(0)`.
-fn scaled_axis_component<T: Numeric>(t: T) -> T {
-    let phi = Vector::new([T::ZERO, T::ZERO, T::ONE]) * t;
-    let q = Quaternion::from_scaled_axis(phi);
-    q.transform_point(Vector::new([T::ONE, T::ZERO, T::ZERO]))[1]
+/// Rotates x̂ by `from_scaled_axis(angle·ẑ)` and returns the y-component, which is `sin(angle)`
+/// (chosen so the derivative at `angle = 0` is a non-zero 1). Differentiating here exercises the
+/// small-angle branch that once produced NaN via `sqrt(0)`.
+fn scaled_axis_component<T: Numeric>(angle: T) -> T {
+    let rotation_vector = Vector::new([T::ZERO, T::ZERO, T::ONE]) * angle;
+    let quaternion = Quaternion::from_scaled_axis(rotation_vector);
+    quaternion.transform_point(Vector::new([T::ONE, T::ZERO, T::ZERO]))[1]
 }
 
 #[test]
 fn ad_through_scaled_axis_finite_at_zero() {
     // Regression: from_scaled_axis must give a finite derivative at and near ω = 0. The mapped
-    // component is sin(t) about ẑ, whose derivative at 0 is 1.
-    let d0 = scaled_axis_component(Dual::variable(0.0)).deriv;
-    assert!(d0.is_finite());
-    assert!((d0 - 1.0).abs() < 1e-12);
+    // component is sin(angle) about ẑ, whose derivative at 0 is 1.
+    let derivative_at_zero = scaled_axis_component(Dual::variable(0.0)).deriv;
+    assert!(derivative_at_zero.is_finite());
+    assert!((derivative_at_zero - 1.0).abs() < 1e-12);
 
-    for &t in &[1e-9, 1e-6, 1e-3, 0.5] {
-        let ad = scaled_axis_component(Dual::variable(t)).deriv;
-        assert!(ad.is_finite());
-        assert!((ad - t.cos()).abs() < 1e-6);
+    for &angle in &[1e-9, 1e-6, 1e-3, 0.5] {
+        let autodiff = scaled_axis_component(Dual::variable(angle)).deriv;
+        assert!(autodiff.is_finite());
+        assert!((autodiff - angle.cos()).abs() < 1e-6);
     }
 }
 
@@ -388,24 +426,25 @@ fn f32_identities() {
             rng.gen_range(-1.0..1.0),
         ]);
         let angle = rng.gen_range(0.01f32..0.99 * std::f32::consts::PI);
-        let q = Quaternion::from_axis_angle(axis, angle);
+        let quaternion = Quaternion::from_axis_angle(axis, angle);
 
         // Orthonormal rotation matrix.
-        let m = q.to_rotation_matrix();
-        let i = m.transpose() * m;
-        for r in 0..3 {
-            for c in 0..3 {
-                let expect = if r == c { 1.0 } else { 0.0 };
-                assert!((i[(r, c)] - expect).abs() < 1e-4);
+        let rotation_matrix = quaternion.to_rotation_matrix();
+        let should_be_identity = rotation_matrix.transpose() * rotation_matrix;
+        for row in 0..3 {
+            for column in 0..3 {
+                let expected = if row == column { 1.0 } else { 0.0 };
+                assert!((should_be_identity[(row, column)] - expected).abs() < 1e-4);
             }
         }
 
         // from_scaled_axis ∘ to_scaled_axis round trip within f32 tolerance.
-        let back = Quaternion::from_scaled_axis(q.to_scaled_axis());
-        let (ra, rb) = (q.to_rotation_matrix(), back.to_rotation_matrix());
-        for r in 0..3 {
-            for c in 0..3 {
-                assert!((ra[(r, c)] - rb[(r, c)]).abs() < 1e-4);
+        let recovered = Quaternion::from_scaled_axis(quaternion.to_scaled_axis());
+        let left_matrix = quaternion.to_rotation_matrix();
+        let right_matrix = recovered.to_rotation_matrix();
+        for row in 0..3 {
+            for column in 0..3 {
+                assert!((left_matrix[(row, column)] - right_matrix[(row, column)]).abs() < 1e-4);
             }
         }
     }

--- a/crates/multicalc/tests/suite/spatial/twist_wrench.rs
+++ b/crates/multicalc/tests/suite/spatial/twist_wrench.rs
@@ -6,78 +6,102 @@ use multicalc::spatial::{Twist, Wrench};
 
 #[test]
 fn twist_ordering_is_linear_first() {
-    let v = Vector::new([1.0, 2.0, 3.0]);
-    let w = Vector::new([4.0, 5.0, 6.0]);
-    let t = Twist::new(v, w);
-    assert_eq!(t.linear(), v);
-    assert_eq!(t.angular(), w);
+    let linear = Vector::new([1.0, 2.0, 3.0]);
+    let angular = Vector::new([4.0, 5.0, 6.0]);
+    let twist = Twist::new(linear, angular);
+    assert_eq!(twist.linear(), linear);
+    assert_eq!(twist.angular(), angular);
     // to_vector lays the parts out as [v; ω].
-    assert_eq!(t.to_vector(), Vector::new([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]));
-    assert_eq!(t.as_array(), [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    assert_eq!(
+        twist.to_vector(),
+        Vector::new([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    );
+    assert_eq!(twist.as_array(), [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
 }
 
 #[test]
 fn wrench_ordering_is_force_first() {
-    let f = Vector::new([1.0, 2.0, 3.0]);
-    let tau = Vector::new([4.0, 5.0, 6.0]);
-    let w = Wrench::new(f, tau);
-    assert_eq!(w.force(), f);
-    assert_eq!(w.torque(), tau);
-    assert_eq!(w.to_vector(), Vector::new([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]));
-    assert_eq!(w.as_array(), [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let force = Vector::new([1.0, 2.0, 3.0]);
+    let torque = Vector::new([4.0, 5.0, 6.0]);
+    let wrench = Wrench::new(force, torque);
+    assert_eq!(wrench.force(), force);
+    assert_eq!(wrench.torque(), torque);
+    assert_eq!(
+        wrench.to_vector(),
+        Vector::new([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    );
+    assert_eq!(wrench.as_array(), [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
 }
 
 #[test]
 fn twist_converter_roundtrips() {
-    let a = [1.0, -2.0, 3.0, -4.0, 5.0, -6.0];
-    let t = Twist::from_array(a);
-    assert_eq!(t.as_array(), a);
+    let components = [1.0, -2.0, 3.0, -4.0, 5.0, -6.0];
+    let twist = Twist::from_array(components);
+    assert_eq!(twist.as_array(), components);
     // vector <-> twist round trip, both explicit and via From/Into.
-    let vec = t.to_vector();
-    assert_eq!(Twist::from_vector(vec).as_array(), a);
-    let via_into: Twist<f64> = vec.into();
-    assert_eq!(via_into, t);
-    assert_eq!(Vector::from(t), vec);
+    let as_vector = twist.to_vector();
+    assert_eq!(Twist::from_vector(as_vector).as_array(), components);
+    let via_into: Twist<f64> = as_vector.into();
+    assert_eq!(via_into, twist);
+    assert_eq!(Vector::from(twist), as_vector);
     // named-part construction agrees with the flat form.
-    assert_eq!(Twist::new(t.linear(), t.angular()), t);
+    assert_eq!(Twist::new(twist.linear(), twist.angular()), twist);
 }
 
 #[test]
 fn wrench_converter_roundtrips() {
-    let a = [1.0, -2.0, 3.0, -4.0, 5.0, -6.0];
-    let w = Wrench::from_array(a);
-    assert_eq!(w.as_array(), a);
-    let vec = w.to_vector();
-    assert_eq!(Wrench::from_vector(vec).as_array(), a);
-    let via_into: Wrench<f64> = vec.into();
-    assert_eq!(via_into, w);
-    assert_eq!(Vector::from(w), vec);
-    assert_eq!(Wrench::new(w.force(), w.torque()), w);
+    let components = [1.0, -2.0, 3.0, -4.0, 5.0, -6.0];
+    let wrench = Wrench::from_array(components);
+    assert_eq!(wrench.as_array(), components);
+    let as_vector = wrench.to_vector();
+    assert_eq!(Wrench::from_vector(as_vector).as_array(), components);
+    let via_into: Wrench<f64> = as_vector.into();
+    assert_eq!(via_into, wrench);
+    assert_eq!(Vector::from(wrench), as_vector);
+    assert_eq!(Wrench::new(wrench.force(), wrench.torque()), wrench);
 }
 
 #[test]
 fn ops_are_componentwise_and_match_vector() {
-    let a = Twist::from_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    let b = Twist::from_array([6.0, 5.0, 4.0, 3.0, 2.0, 1.0]);
+    let first_twist = Twist::from_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let second_twist = Twist::from_array([6.0, 5.0, 4.0, 3.0, 2.0, 1.0]);
     // Each op agrees with doing the same on the underlying Vector<6>.
-    assert_eq!((a + b).to_vector(), a.to_vector() + b.to_vector());
-    assert_eq!((a - b).to_vector(), a.to_vector() - b.to_vector());
-    assert_eq!((-a).to_vector(), -a.to_vector());
-    assert_eq!(a.scale(2.5).to_vector(), a.to_vector().scale(2.5));
+    assert_eq!(
+        (first_twist + second_twist).to_vector(),
+        first_twist.to_vector() + second_twist.to_vector()
+    );
+    assert_eq!(
+        (first_twist - second_twist).to_vector(),
+        first_twist.to_vector() - second_twist.to_vector()
+    );
+    assert_eq!((-first_twist).to_vector(), -first_twist.to_vector());
+    assert_eq!(
+        first_twist.scale(2.5).to_vector(),
+        first_twist.to_vector().scale(2.5)
+    );
     assert_eq!(Twist::<f64>::zeros().as_array(), [0.0; 6]);
 
-    let c = Wrench::from_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    let d = Wrench::from_array([6.0, 5.0, 4.0, 3.0, 2.0, 1.0]);
-    assert_eq!((c + d).to_vector(), c.to_vector() + d.to_vector());
-    assert_eq!((c - d).to_vector(), c.to_vector() - d.to_vector());
-    assert_eq!((-c).to_vector(), -c.to_vector());
-    assert_eq!(c.scale(2.5).to_vector(), c.to_vector().scale(2.5));
+    let first_wrench = Wrench::from_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let second_wrench = Wrench::from_array([6.0, 5.0, 4.0, 3.0, 2.0, 1.0]);
+    assert_eq!(
+        (first_wrench + second_wrench).to_vector(),
+        first_wrench.to_vector() + second_wrench.to_vector()
+    );
+    assert_eq!(
+        (first_wrench - second_wrench).to_vector(),
+        first_wrench.to_vector() - second_wrench.to_vector()
+    );
+    assert_eq!((-first_wrench).to_vector(), -first_wrench.to_vector());
+    assert_eq!(
+        first_wrench.scale(2.5).to_vector(),
+        first_wrench.to_vector().scale(2.5)
+    );
 }
 
 #[test]
 fn ad_transparent_under_dual() {
     // A Twist of Duals carries derivatives through construction, ops, and conversion untouched.
-    let t = Twist::new(
+    let twist = Twist::new(
         Vector::new([
             Dual::variable(2.0_f64),
             Dual::constant(0.0),
@@ -89,14 +113,14 @@ fn ad_transparent_under_dual() {
             Dual::constant(0.0),
         ]),
     );
-    let scaled = t.scale(Dual::constant(3.0));
-    let out = scaled.to_vector();
+    let scaled = twist.scale(Dual::constant(3.0));
+    let outputs = scaled.to_vector();
     // d/dx (3·x) = 3 in the seeded component; the rest stay finite with zero derivative.
-    assert!((out[0].value - 6.0).abs() < 1e-12);
-    assert!((out[0].deriv - 3.0).abs() < 1e-12);
-    for i in 1..6 {
-        let oi = out[i];
-        assert!(oi.value.is_finite() && oi.deriv.is_finite());
-        assert!(oi.deriv.abs() < 1e-12);
+    assert!((outputs[0].value - 6.0).abs() < 1e-12);
+    assert!((outputs[0].deriv - 3.0).abs() < 1e-12);
+    for index in 1..6 {
+        let output = outputs[index];
+        assert!(output.value.is_finite() && output.deriv.is_finite());
+        assert!(output.deriv.abs() < 1e-12);
     }
 }

--- a/crates/multicalc/tests/suite/support.rs
+++ b/crates/multicalc/tests/suite/support.rs
@@ -1,0 +1,16 @@
+//! Small matrix helpers shared by more than one test file in this suite.
+
+use multicalc::linear_algebra::Matrix;
+
+/// Builds a symmetric positive-definite matrix from arbitrary entries as `M·Mᵀ`, ridged so the
+/// factorization is well conditioned rather than merely non-singular.
+pub fn symmetric_positive_definite<const N: usize>(entries: &[f64]) -> Matrix<N, N> {
+    let factor = Matrix::<N, N>::from_fn(|row, column| entries[row * N + column]);
+    factor * factor.transpose() + Matrix::<N, N>::identity().scale(0.25)
+}
+
+/// Sums the diagonal entries of a square matrix.
+#[must_use]
+pub fn trace<const N: usize>(matrix: Matrix<N, N>) -> f64 {
+    (0..N).map(|index| matrix[(index, index)]).sum()
+}

--- a/crates/multicalc/tests/suite/vector_field.rs
+++ b/crates/multicalc/tests/suite/vector_field.rs
@@ -12,123 +12,112 @@ use multicalc::vector_field::{
 use multicalc::error::IntegrateError;
 
 #[test]
-fn test_line_integral_1() {
+fn line_integral_of_a_rotational_field_around_the_unit_circle() {
     //vector field is (y, -x)
-    //curve is a unit circle, defined by (Cos(t), Sin(t))
+    //curve is defined by (Cos(t), Sin(t))
     //limit t goes from 0->2*pi
 
-    let vector_field_matrix: [&dyn Fn(&[f64; 2]) -> f64; 2] = [
-        &(|args: &[f64; 2]| -> f64 { args[1] }),
-        &(|args: &[f64; 2]| -> f64 { -args[0] }),
+    let field_components: [&dyn Fn(&[f64; 2]) -> f64; 2] = [
+        &(|point: &[f64; 2]| -> f64 { point[1] }),
+        &(|point: &[f64; 2]| -> f64 { -point[0] }),
     ];
 
-    let transformation_matrix: [&dyn Fn(f64) -> f64; 2] = [
+    let curve: [&dyn Fn(f64) -> f64; 2] = [
         &(|t: f64| -> f64 { t.cos() }),
         &(|t: f64| -> f64 { t.sin() }),
     ];
 
     let integration_limit = [0.0, core::f64::consts::TAU];
+    let total_iterations = 100;
 
-    //line integral of a unit circle curve on our vector field from 0 to 2*pi, expect an answer of -2.0*pi
-    let val = line_integral_2d_custom(
-        &vector_field_matrix,
-        &transformation_matrix,
+    //expect an answer of -2.0*pi
+    let circulation = line_integral_2d_custom(
+        &field_components,
+        &curve,
         &integration_limit,
-        100,
+        total_iterations,
     )
     .unwrap();
-    assert!(f64::abs(val + core::f64::consts::TAU) < 0.01);
+    assert!(f64::abs(circulation + core::f64::consts::TAU) < 0.01);
 }
 
 #[test]
-fn test_line_integral_error_1() {
+fn line_integral_rejects_a_zero_interval_count() {
     //vector field is (y, -x)
     //curve is a unit circle, defined by (Cos(t), Sin(t))
     //limit t goes from 0->2*pi
 
-    let vector_field_matrix: [&dyn Fn(&[f64; 2]) -> f64; 2] = [
-        &(|args: &[f64; 2]| -> f64 { args[1] }),
-        &(|args: &[f64; 2]| -> f64 { -args[0] }),
+    let field_components: [&dyn Fn(&[f64; 2]) -> f64; 2] = [
+        &(|point: &[f64; 2]| -> f64 { point[1] }),
+        &(|point: &[f64; 2]| -> f64 { -point[0] }),
     ];
 
-    let transformation_matrix: [&dyn Fn(f64) -> f64; 2] = [
+    let curve: [&dyn Fn(f64) -> f64; 2] = [
         &(|t: f64| -> f64 { t.cos() }),
         &(|t: f64| -> f64 { t.sin() }),
     ];
 
     let integration_limit = [0.0, core::f64::consts::TAU];
 
-    //expect error because number of steps is zero
-    let val = line_integral_2d_custom(
-        &vector_field_matrix,
-        &transformation_matrix,
-        &integration_limit,
-        0,
-    );
-    assert!(val.is_err());
-    assert!(val.unwrap_err() == IntegrateError::IterationsZero);
+    let result = line_integral_2d_custom(&field_components, &curve, &integration_limit, 0);
+    assert!(result.is_err());
+    assert!(result.unwrap_err() == IntegrateError::IterationsZero);
 }
 
 #[test]
-fn test_line_integral_error_2() {
+fn line_integral_rejects_reversed_limits() {
     //vector field is (y, -x)
     //curve is a unit circle, defined by (Cos(t), Sin(t))
-    //limit t goes from 0->2*pi
 
-    let vector_field_matrix: [&dyn Fn(&[f64; 2]) -> f64; 2] = [
-        &(|args: &[f64; 2]| -> f64 { args[1] }),
-        &(|args: &[f64; 2]| -> f64 { -args[0] }),
+    let field_components: [&dyn Fn(&[f64; 2]) -> f64; 2] = [
+        &(|point: &[f64; 2]| -> f64 { point[1] }),
+        &(|point: &[f64; 2]| -> f64 { -point[0] }),
     ];
 
-    let transformation_matrix: [&dyn Fn(f64) -> f64; 2] = [
+    let curve: [&dyn Fn(f64) -> f64; 2] = [
         &(|t: f64| -> f64 { t.cos() }),
         &(|t: f64| -> f64 { t.sin() }),
     ];
 
+    //lower limit higher than upper limit
     let integration_limit = [10.0, 0.0];
 
-    //expect error because integration limits are ill-defined (lower limit higher than upper limit)
-    let val = line_integral_2d_custom(
-        &vector_field_matrix,
-        &transformation_matrix,
-        &integration_limit,
-        100,
-    );
-    assert!(val.is_err());
-    assert!(val.unwrap_err() == IntegrateError::LimitsIllDefined);
+    let result = line_integral_2d_custom(&field_components, &curve, &integration_limit, 100);
+    assert!(result.is_err());
+    assert!(result.unwrap_err() == IntegrateError::LimitsIllDefined);
 }
 
 #[test]
-fn test_flux_integral_1() {
+fn flux_of_a_rotational_field_through_the_unit_circle_is_zero() {
     //vector field is (y, -x)
-    //curve is a unit circle, defined by (Cos(t), Sin(t))
+    //curve is defined by (Cos(t), Sin(t))
     //limit t goes from 0->2*pi
 
-    let vector_field_matrix: [&dyn Fn(&[f64; 2]) -> f64; 2] = [
-        &(|args: &[f64; 2]| -> f64 { args[1] }),
-        &(|args: &[f64; 2]| -> f64 { -args[0] }),
+    let field_components: [&dyn Fn(&[f64; 2]) -> f64; 2] = [
+        &(|point: &[f64; 2]| -> f64 { point[1] }),
+        &(|point: &[f64; 2]| -> f64 { -point[0] }),
     ];
 
-    let transformation_matrix: [&dyn Fn(f64) -> f64; 2] = [
+    let curve: [&dyn Fn(f64) -> f64; 2] = [
         &(|t: f64| -> f64 { t.cos() }),
         &(|t: f64| -> f64 { t.sin() }),
     ];
 
     let integration_limit = [0.0, core::f64::consts::TAU];
+    let total_iterations = 100;
 
-    //flux integral of a unit circle curve on our vector field from 0 to 2*pi, expect an answer of 0.0
-    let val = flux_integral_2d_custom(
-        &vector_field_matrix,
-        &transformation_matrix,
+    let flux = flux_integral_2d_custom(
+        &field_components,
+        &curve,
         &integration_limit,
-        100,
+        total_iterations,
     )
     .unwrap();
-    assert!(f64::abs(val + 0.0) < 0.01);
+    assert!(f64::abs(flux + 0.0) < 0.01);
 }
 
 #[test]
-fn test_flux_integral_3d_helix() {
+fn flux_along_a_helix_matches_its_closed_form() {
     // Curve r(t) = (cos(t), sin(t), t)
     // Vector field = (0, 0, z)
     //
@@ -139,13 +128,13 @@ fn test_flux_integral_3d_helix() {
     //
     // Flux = partial_x - partial_y - partial_z = -2*pi^2
 
-    let vector_field_matrix: [&dyn Fn(&[f64; 3]) -> f64; 3] = [
+    let field_components: [&dyn Fn(&[f64; 3]) -> f64; 3] = [
         &(|_: &[f64; 3]| -> f64 { 0.0 }),
         &(|_: &[f64; 3]| -> f64 { 0.0 }),
-        &(|args: &[f64; 3]| -> f64 { args[2] }),
+        &(|point: &[f64; 3]| -> f64 { point[2] }),
     ];
 
-    let transformation_matrix: [&dyn Fn(f64) -> f64; 3] = [
+    let curve: [&dyn Fn(f64) -> f64; 3] = [
         &(|t: f64| -> f64 { t.cos() }),
         &(|t: f64| -> f64 { t.sin() }),
         &(|t: f64| -> f64 { t }),
@@ -153,73 +142,74 @@ fn test_flux_integral_3d_helix() {
 
     let two_pi = 2.0 * core::f64::consts::PI;
     let integration_limit = [0.0, two_pi];
+    let total_iterations = 100;
 
-    let val = flux_integral_3d_custom(
-        &vector_field_matrix,
-        &transformation_matrix,
+    let flux = flux_integral_3d_custom(
+        &field_components,
+        &curve,
         &integration_limit,
-        100,
+        total_iterations,
     )
     .unwrap();
 
     let expected = -2.0 * core::f64::consts::PI * core::f64::consts::PI;
 
-    assert!(f64::abs(val - expected) < 1e-6);
+    assert!(f64::abs(flux - expected) < 1e-6);
 }
 
 #[test]
-fn test_curl_2d_1() {
+fn curl_2d_matches_its_closed_form() {
     //vector field is (2*x*y, 3*cos(y)); curl is known to be -2*x, so -2.0 at x = 1
-    let vf = scalar_fn_vec!(|v: &[f64; 2]| [c(2.0) * v[0] * v[1], c(3.0) * v[1].cos()]);
+    let vector_field = scalar_fn_vec!(|v: &[f64; 2]| [c(2.0) * v[0] * v[1], c(3.0) * v[1].cos()]);
     let point = [1.0, core::f64::consts::PI];
 
-    let val = curl_2d(AutoDiffMulti::default(), &vf, &point).unwrap();
-    assert!(f64::abs(val + 2.0) < 1e-12);
+    let curl = curl_2d(AutoDiffMulti::default(), &vector_field, &point).unwrap();
+    assert!(f64::abs(curl + 2.0) < 1e-12);
 }
 
 #[test]
-fn test_curl_3d_1() {
+fn curl_3d_matches_its_closed_form() {
     //vector field is (y, -x, 2*z); curl is known to be (0, 0, -2)
-    let vf = scalar_fn_vec!(|v: &[f64; 3]| [v[1], -v[0], c(2.0) * v[2]]);
+    let vector_field = scalar_fn_vec!(|v: &[f64; 3]| [v[1], -v[0], c(2.0) * v[2]]);
     let point = [1.0, 2.0, 3.0];
 
-    let val = curl_3d(AutoDiffMulti::default(), &vf, &point).unwrap();
-    assert!(f64::abs(val[0]) < 1e-12);
-    assert!(f64::abs(val[1]) < 1e-12);
-    assert!(f64::abs(val[2] + 2.0) < 1e-12);
+    let curl = curl_3d(AutoDiffMulti::default(), &vector_field, &point).unwrap();
+    assert!(f64::abs(curl[0]) < 1e-12);
+    assert!(f64::abs(curl[1]) < 1e-12);
+    assert!(f64::abs(curl[2] + 2.0) < 1e-12);
 }
 
 #[test]
-fn test_divergence_2d_1() {
+fn divergence_2d_matches_its_closed_form() {
     //vector field is (2*x*y, 3*cos(y)); divergence is 2*y - 3*sin(y), which is 2*pi at y = pi
-    let vf = scalar_fn_vec!(|v: &[f64; 2]| [c(2.0) * v[0] * v[1], c(3.0) * v[1].cos()]);
+    let vector_field = scalar_fn_vec!(|v: &[f64; 2]| [c(2.0) * v[0] * v[1], c(3.0) * v[1].cos()]);
     let point = [1.0, core::f64::consts::PI];
 
-    let val = divergence_2d(AutoDiffMulti::default(), &vf, &point).unwrap();
-    assert!(f64::abs(val - core::f64::consts::TAU) < 1e-12);
+    let divergence = divergence_2d(AutoDiffMulti::default(), &vector_field, &point).unwrap();
+    assert!(f64::abs(divergence - core::f64::consts::TAU) < 1e-12);
 }
 
 #[test]
-fn test_divergence_3d_1() {
+fn divergence_3d_matches_its_closed_form() {
     //vector field is (y, -x, 2*z); divergence is known to be 2.0
-    let vf = scalar_fn_vec!(|v: &[f64; 3]| [v[1], -v[0], c(2.0) * v[2]]);
+    let vector_field = scalar_fn_vec!(|v: &[f64; 3]| [v[1], -v[0], c(2.0) * v[2]]);
     let point = [0.0, 1.0, 3.0];
 
-    let val = divergence_3d(AutoDiffMulti::default(), &vf, &point).unwrap();
-    assert!(f64::abs(val - 2.0) < 1e-12);
+    let divergence = divergence_3d(AutoDiffMulti::default(), &vector_field, &point).unwrap();
+    assert!(f64::abs(divergence - 2.0) < 1e-12);
 }
 
 #[test]
-fn test_line_integral_3d_helix() {
+fn line_integral_along_a_helix_matches_its_closed_form() {
     //helix r(t) = (cos t, sin t, t), with a real z-component (regression for the 3D z typo)
     //vector field is (0, 0, z); the line integral is ∫ z dz = ∫_0^{2π} t dt = 2π²
-    let vector_field_matrix: [&dyn Fn(&[f64; 3]) -> f64; 3] = [
+    let field_components: [&dyn Fn(&[f64; 3]) -> f64; 3] = [
         &(|_: &[f64; 3]| -> f64 { 0.0 }),
         &(|_: &[f64; 3]| -> f64 { 0.0 }),
-        &(|args: &[f64; 3]| -> f64 { args[2] }),
+        &(|point: &[f64; 3]| -> f64 { point[2] }),
     ];
 
-    let transformation_matrix: [&dyn Fn(f64) -> f64; 3] = [
+    let curve: [&dyn Fn(f64) -> f64; 3] = [
         &(|t: f64| -> f64 { t.cos() }),
         &(|t: f64| -> f64 { t.sin() }),
         &(|t: f64| -> f64 { t }),
@@ -227,51 +217,53 @@ fn test_line_integral_3d_helix() {
 
     let two_pi = 2.0 * core::f64::consts::PI;
     let integration_limit = [0.0, two_pi];
+    let total_iterations = 100;
 
-    let val = line_integral_3d_custom(
-        &vector_field_matrix,
-        &transformation_matrix,
+    let circulation = line_integral_3d_custom(
+        &field_components,
+        &curve,
         &integration_limit,
-        100,
+        total_iterations,
     )
     .unwrap();
 
     let expected = 2.0 * core::f64::consts::PI * core::f64::consts::PI;
-    assert!(f64::abs(val - expected) < 1e-6);
+    assert!(f64::abs(circulation - expected) < 1e-6);
 }
 
 #[test]
-fn test_line_integral_negative_limits() {
+fn line_integral_accepts_a_negative_lower_limit() {
     //a [-2.0, 1.0] parameter range must be accepted (regression for the old .abs() check)
     //vector field is (y, x), curve is x = t, y = t. The line integral is
     //∫ y dx + x dy = ∫ t dt + ∫ t dt = 2 * (1/2 - 2) = -3
-    let vector_field_matrix: [&dyn Fn(&[f64; 2]) -> f64; 2] = [
-        &(|args: &[f64; 2]| -> f64 { args[1] }),
-        &(|args: &[f64; 2]| -> f64 { args[0] }),
+    let field_components: [&dyn Fn(&[f64; 2]) -> f64; 2] = [
+        &(|point: &[f64; 2]| -> f64 { point[1] }),
+        &(|point: &[f64; 2]| -> f64 { point[0] }),
     ];
 
-    let transformation_matrix: [&dyn Fn(f64) -> f64; 2] =
-        [&(|t: f64| -> f64 { t }), &(|t: f64| -> f64 { t })];
+    let curve: [&dyn Fn(f64) -> f64; 2] = [&(|t: f64| -> f64 { t }), &(|t: f64| -> f64 { t })];
 
     let integration_limit = [-2.0, 1.0];
+    let total_iterations = 100;
 
-    let val = line_integral_2d_custom(
-        &vector_field_matrix,
-        &transformation_matrix,
+    let circulation = line_integral_2d_custom(
+        &field_components,
+        &curve,
         &integration_limit,
-        100,
+        total_iterations,
     )
     .unwrap();
 
-    assert!(f64::abs(val - (-3.0)) < 1e-9);
+    let expected = -3.0;
+    assert!(f64::abs(circulation - expected) < 1e-9);
 }
 
 #[test]
-fn test_divergence_3d_f32() {
+fn divergence_3d_matches_its_closed_form_at_f32() {
     //field (y, -x, 2z); divergence is 0 + 0 + 2 = 2. The same authored field evaluates at f32.
-    let vf = scalar_fn_vec!(|v: &[f64; 3]| [v[1], -v[0], c(2.0) * v[2]]);
+    let vector_field = scalar_fn_vec!(|v: &[f64; 3]| [v[1], -v[0], c(2.0) * v[2]]);
     let point = [0.0_f32, 1.0, 3.0];
 
-    let val = divergence_3d(AutoDiffMulti::<f32>::default(), &vf, &point).unwrap();
-    assert!(f32::abs(val - 2.0) < 1e-6, "got {val}");
+    let divergence = divergence_3d(AutoDiffMulti::<f32>::default(), &vector_field, &point).unwrap();
+    assert!(f32::abs(divergence - 2.0) < 1e-6, "got {divergence}");
 }


### PR DESCRIPTION
## What & why

1. Each test name should be more descriptive so we get better failure diagnostics.
2. Tests should use clear descriptive variable names for easier debugging.

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
