### PR TITLE
fix(estimation): handle empty resampling weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `ResamplingScheme::resample_indices` now leaves output indices untouched for empty weights
+  instead of panicking. (#204)
+
 ## [0.9.0] - 2026-07-26
 
 A feature release adding state estimation, feedback control, wheeled kinematics, and

--- a/crates/multicalc/src/estimation/particle_filter.rs
+++ b/crates/multicalc/src/estimation/particle_filter.rs
@@ -49,18 +49,24 @@ pub enum ResamplingScheme {
 impl ResamplingScheme {
     /// Fills `indices` with the chosen sample positions for `weights`.
     ///
-    /// `weights` must be normalized and the same length as `indices`. Uniforms are drawn from
-    /// `random` in a fixed order and count so a recorded draw sequence reproduces the result exactly:
-    /// one draw for [`Systematic`](Self::Systematic); one per element for
+    /// For non-empty inputs, `weights` must be normalized and the same length as `indices`. Uniforms
+    /// are drawn from `random` in a fixed order and count so a recorded draw sequence reproduces the
+    /// result exactly: one draw for [`Systematic`](Self::Systematic); one per element for
     /// [`Stratified`](Self::Stratified) and [`Multinomial`](Self::Multinomial); and, for
     /// [`Residual`](Self::Residual), one per leftover slot after the whole-number copies are laid
     /// down.
+    ///
+    /// An empty `weights` slice returns without consuming randomness or modifying `indices`.
     pub fn resample_indices<T: Numeric, R: RandomSource>(
         self,
         weights: &[T],
         random: &mut R,
         indices: &mut [usize],
     ) {
+        if weights.is_empty() {
+            return;
+        }
+
         match self {
             ResamplingScheme::Systematic => systematic(weights, random, indices),
             ResamplingScheme::Stratified => stratified(weights, random, indices),

--- a/crates/multicalc/tests/suite/estimation/particle_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/particle_filter.rs
@@ -182,6 +182,32 @@ fn every_scheme_covers_heavy_particles() {
 }
 
 #[test]
+fn every_scheme_leaves_indices_unchanged_for_empty_weights() {
+    let schemes = [
+        ResamplingScheme::Systematic,
+        ResamplingScheme::Stratified,
+        ResamplingScheme::Multinomial,
+        ResamplingScheme::Residual,
+    ];
+    let weights: [f64; 0] = [];
+
+    for scheme in schemes {
+        let mut random = Pcg32::new(5);
+        let initial_random = random.clone();
+        let mut indices = [7usize, 8, 9];
+
+        scheme.resample_indices(&weights, &mut random, &mut indices);
+
+        assert_eq!(random, initial_random);
+        assert_eq!(
+            indices,
+            [7, 8, 9],
+            "empty weights should leave indices untouched for {scheme:?}"
+        );
+    }
+}
+
+#[test]
 fn incompatible_measurement_degenerates() {
     let particle_count = 200;
     let seed = 3;


### PR DESCRIPTION
## What & why

`ResamplingScheme::resample_indices` dispatched empty weight slices into implementations that index or subtract from the empty slice, causing a panic on a public library path. This adds one guard before scheme dispatch, so all four schemes preserve both output indices and RNG state for empty weights. It also documents the behavior, adds public-API regression coverage, and records the fix in the changelog.

Fixes #204.

## Validation

- `cargo test -p multicalc --features alloc`
- `cargo test`
- `cargo clippy -p multicalc --all-targets --features alloc -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The host-side suite is clean; the repository's cross-target and QEMU matrix remains for CI.

## Checklist

- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] No new public API was added
- [x] No `unwrap`/`expect`/`panic` on library paths

AI assistance: this contribution was prepared and validated with OpenAI Codex.
