### PR TITLE
fix: make tanh and powf work on the autodiff scalars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`tanh` and `powf` on the autodiff scalars.** The `Numeric` defaults broke on exactly
+  the types the crate exists for: `tanh` was `sinh/cosh`, which is `inf/inf` — NaN — once
+  `|x|` passes the `exp` overflow point, and `powf` was `exp(n · ln self)`, which is NaN
+  for every negative base and gives a NaN derivative at zero. `f32`/`f64` override both
+  with `libm` and were unaffected; `Dual`, `HyperDual` and `Jet` took the defaults. `tanh`
+  now saturates to ±1 with a vanishing derivative, and `powf` handles zero and negative
+  bases with integral exponents, keeping the derivatives correct. @DPS0340 (#228)
+
 ## [0.9.0] - 2026-07-26
 
 A feature release adding state estimation, feedback control, wheeled kinematics, and

--- a/crates/multicalc/src/scalar/numeric.rs
+++ b/crates/multicalc/src/scalar/numeric.rs
@@ -173,9 +173,27 @@ pub trait Numeric:
     }
 
     /// Hyperbolic tangent.
+    ///
+    /// Evaluated as `(1 − e^(−2x)) / (1 + e^(−2x))` for `x ≥ 0`, mirrored for
+    /// `x < 0`, rather than as `sinh/cosh`. The quotient form overflows to
+    /// `inf/inf` — that is, NaN — once `|x|` passes about 88 in `f32` or 709
+    /// in `f64`, where the true value has simply settled at ±1. Taking `exp`
+    /// of a non-positive argument cannot overflow: it underflows to zero,
+    /// giving exactly ±1 with a derivative that decays to zero, both correct
+    /// in the limit.
+    ///
+    /// The branch is on the sign rather than a multiply by `signum`, because
+    /// `signum(0)` is zero and would wipe out the derivative at the origin,
+    /// where `tanh'(0) = 1`.
     #[inline]
     fn tanh(self) -> Self {
-        self.sinh() / self.cosh()
+        if self < Self::ZERO {
+            let e = (self * Self::TWO).exp();
+            (e - Self::ONE) / (e + Self::ONE)
+        } else {
+            let e = (-(self * Self::TWO)).exp();
+            (Self::ONE - e) / (Self::ONE + e)
+        }
     }
 
     /// Euclidean distance `√(self² + other²)`, scaled to avoid overflow and underflow.
@@ -192,11 +210,61 @@ pub trait Numeric:
         }
     }
 
-    /// `self` raised to a floating-point power, via `exp(n · ln self)`. Defined for
-    /// `self > 0`; the `f32`/`f64` impls override for negative bases and edge cases.
+    /// `self` raised to a floating-point power.
+    ///
+    /// `exp(n · ln self)` alone is only valid for `self > 0`: `ln` of zero is `-inf` and
+    /// `ln` of a negative is NaN, so the plain form returns NaN — or the right value with
+    /// a NaN derivative — for cases that are perfectly well defined. `x.powf(2.0)` is the
+    /// obvious one; it should agree with `x * x` everywhere, and on the autodiff scalars
+    /// it did not.
+    ///
+    /// Non-positive bases are handled explicitly:
+    ///
+    /// - `self == 0`: the value is `0` for `n > 0` and the derivative is `n · 0^(n−1)`,
+    ///   which is `0` for `n > 1`, `1` for `n == 1`, and divergent below that. Computed
+    ///   directly rather than through `ln 0 = -inf`.
+    /// - `self < 0` with an integral `n`: real-valued, equal to `|self|^n` with the sign
+    ///   of `(-1)^n`. The derivative is `n · self^(n−1)`, carried by rebuilding the
+    ///   expression from `|self|` and applying the sign, so the chain rule stays intact.
+    /// - `self < 0` with a fractional `n`: no real value; stays NaN, matching `libm::pow`.
     #[inline]
     fn powf(self, n: Self) -> Self {
-        (n * self.ln()).exp()
+        if self > Self::ZERO {
+            return (n * self.ln()).exp();
+        }
+
+        if self == Self::ZERO {
+            // 0^0 is 1 by convention; 0^n is 0 for n > 0 and diverges for n < 0.
+            // The derivative n·0^(n-1) is 0 for n > 1, 1 for n == 1, and divergent
+            // otherwise — all of which fall out of powi for integral n.
+            if n == Self::ZERO {
+                return Self::ONE;
+            }
+            if n == Self::ONE {
+                return self;
+            }
+            if n > Self::ONE && n == n.floor() {
+                return self * self * (n - Self::ONE);
+            }
+            return (n * self.ln()).exp();
+        }
+
+        // self < 0. Only an integral exponent has a real value.
+        if n != n.floor() || !n.is_finite() {
+            return (n * self.ln()).exp(); // NaN, as libm::pow gives
+        }
+
+        // |self|^n carries the correct magnitude and the correct |derivative|; the sign
+        // of both follows (-1)^n. Recovering n's parity without leaving the scalar type:
+        // n - 2·floor(n/2) is 0 for even n and 1 for odd n.
+        let magnitude = (n * (-self).ln()).exp();
+        let half = n * Self::HALF;
+        let parity = n - Self::TWO * half.floor();
+        if parity == Self::ZERO {
+            magnitude
+        } else {
+            -magnitude
+        }
     }
 
     /// `self * a + b`. The `f32`/`f64` impls fuse the operation for extra precision.

--- a/crates/multicalc/tests/suite/scalar.rs
+++ b/crates/multicalc/tests/suite/scalar.rs
@@ -356,6 +356,105 @@ mod dual {
         assert!(f64::abs(hypotenuse.deriv - 3.0 / 5.0) < TOL);
     }
 
+    /// #228: `tanh` was built from `sinh/cosh`, so once `|x|` passed the `exp`
+    /// overflow point it computed `inf/inf` — NaN — where the true value has
+    /// simply settled at ±1. `f32`/`f64` override with `libm` and were fine;
+    /// the autodiff scalars took the default and were not.
+    #[test]
+    fn tanh_saturates_on_the_autodiff_scalars() {
+        for &x in &[800.0_f64, -800.0, 90.0, 710.0] {
+            let t = Dual::variable(x).tanh();
+            assert!(
+                f64::abs(t.value - x.signum()) < TOL,
+                "tanh({x}) should saturate to {}, got {}",
+                x.signum(),
+                t.value
+            );
+            assert!(
+                f64::abs(t.deriv) < TOL,
+                "tanh'({x}) should vanish, got {}",
+                t.deriv
+            );
+        }
+
+        // The saturating form must not cost accuracy where the old one worked,
+        // including at the origin, where tanh' = 1 and a signum-based rewrite
+        // would silently return 0.
+        for &x in &[0.0_f64, 1e-8, 0.5, -0.5, 3.0, -3.0] {
+            let t = Dual::variable(x).tanh();
+            assert!(f64::abs(t.value - x.tanh()) < TOL, "tanh({x}) value");
+            assert!(
+                f64::abs(t.deriv - (1.0 - x.tanh() * x.tanh())) < TOL,
+                "tanh'({x}) derivative"
+            );
+        }
+    }
+
+    /// #228: `powf` defaulted to `exp(n · ln self)`, which is NaN for every
+    /// negative base and gives a NaN *derivative* at zero while the value
+    /// happens to come out right — a silent failure. `x.powf(2.0)` has to agree
+    /// with `x * x` in both value and derivative.
+    #[test]
+    fn powf_handles_non_positive_bases() {
+        for &x in &[0.0_f64, -2.0, -0.5, 2.0] {
+            let squared = Dual::variable(x).powf(Dual::constant(2.0));
+            let by_multiplication = {
+                let d = Dual::variable(x);
+                d * d
+            };
+            assert!(
+                f64::abs(squared.value - by_multiplication.value) < TOL,
+                "({x})^2 value: powf gave {}, x*x gave {}",
+                squared.value,
+                by_multiplication.value
+            );
+            assert!(
+                f64::abs(squared.deriv - by_multiplication.deriv) < TOL,
+                "({x})^2 derivative: powf gave {}, x*x gave {}",
+                squared.deriv,
+                by_multiplication.deriv
+            );
+        }
+
+        // Odd integer exponent on a negative base keeps the sign.
+        let cubed = Dual::variable(-2.0_f64).powf(Dual::constant(3.0));
+        assert!(f64::abs(cubed.value + 8.0) < TOL);
+        assert!(f64::abs(cubed.deriv - 12.0) < TOL); // 3·(−2)² = 12
+
+        // n = 1 and n = 0 at the origin, where the exp/ln form divides by -inf.
+        let linear = Dual::variable(0.0_f64).powf(Dual::constant(1.0));
+        assert!(f64::abs(linear.value) < TOL);
+        assert!(f64::abs(linear.deriv - 1.0) < TOL);
+        let unity = Dual::variable(0.0_f64).powf(Dual::constant(0.0));
+        assert!(f64::abs(unity.value - 1.0) < TOL);
+
+        // A negative base with a genuinely fractional exponent has no real
+        // value and must stay NaN rather than inventing one.
+        let undefined = Dual::variable(-2.0_f64).powf(Dual::constant(0.5));
+        assert!(undefined.value.is_nan());
+    }
+
+    /// Guard rail for both fixes: the `f32`/`f64` impls override with `libm`
+    /// and must keep matching the standard library, so the rewritten defaults
+    /// cannot have been "fixed" by loosening what the primitives do.
+    #[test]
+    fn primitive_tanh_and_powf_still_match_std() {
+        for &x in &[0.0_f64, 0.5, -3.0, 90.0, 800.0] {
+            assert!(
+                f64::abs(Numeric::tanh(x) - x.tanh()) < TOL,
+                "f64::tanh({x})"
+            );
+        }
+        for &(b, n) in &[(2.0_f64, 3.5), (0.0, 2.0), (-2.0, 2.0), (-2.0, 3.0)] {
+            let got = Numeric::powf(b, n);
+            let want = b.powf(n);
+            assert!(
+                (got.is_nan() && want.is_nan()) || f64::abs(got - want) < TOL,
+                "f64::powf({b},{n}): got {got}, std {want}"
+            );
+        }
+    }
+
     #[test]
     fn floor_has_zero_derivative() {
         let floored = Dual::variable(2.7_f64).floor();


### PR DESCRIPTION
## What & why

Fixes #228. Both `Numeric` defaults broke on exactly the types the crate exists for — `f32`/`f64` override them with `libm` and were fine, `Dual`/`HyperDual`/`Jet` took the defaults and were not.

Reproduced on `5c45541` before changing anything:

```
tanh(800):    value=NaN  deriv=NaN
powf(0, 2):   value=0    deriv=NaN   x*x gives (0, 0)
powf(-2, 2):  value=NaN  deriv=NaN   x*x gives (4, -4)
```

Worth noting `powf(0, 2)` is the nastier of the two: the *value* comes out right and only the derivative is NaN, so it fails silently.

## tanh

`sinh/cosh` is `inf/inf` once `|x|` passes the `exp` overflow point (~88 in `f32`, ~709 in `f64`), where the true value has simply settled at ±1. Now evaluated from `exp` of a non-positive argument, which underflows to zero instead of overflowing.

```
before  tanh(800) = (NaN, NaN)
after   tanh(800) = (1, 0)
```

One detail that cost me a revision: I first wrote it as `signum(x) · f(|x|)`, which is tidier but wrong at the origin — `signum(0)` is zero, so it returned `tanh'(0) = 0` instead of `1`. The branch is on the sign for that reason, and there is a test pinning the origin.

## powf

`exp(n · ln self)` is NaN for every negative base and produces a NaN derivative at zero. Non-positive bases are now handled explicitly:

- `self == 0`: `0^0 = 1`, `0^1 = 0` with derivative 1, `0^n = 0` with derivative 0 for integral `n > 1`.
- `self < 0` with integral `n`: real-valued. Magnitude from `|self|`, sign from the parity of `n`, so the chain rule stays intact — `(-2)^3` gives `(-8, 12)`.
- `self < 0` with fractional `n`: no real value, stays NaN as `libm::pow` does.

I did not add a `to_i32` to the `Numeric` trait to route through `powi`; the parity is recovered with `n - 2·floor(n/2)`, which stays inside the existing trait surface.

## Tests

Three, in `tests/suite/scalar.rs`:

- `tanh_saturates_on_the_autodiff_scalars` — the issue's case, plus the ordinary range and the origin so the saturating form cannot cost accuracy where the old one worked.
- `powf_handles_non_positive_bases` — asserts `x.powf(2.0)` agrees with `x * x` in **both** value and derivative, which is the property the issue asks for.
- `primitive_tanh_and_powf_still_match_std` — **guard rail.** The `f32`/`f64` impls must keep matching std, so the defaults cannot have been "fixed" by loosening what the primitives do.

Verified they bite rather than assuming it. Reverting each default fails only its own test:

```
tanh reverted  -> tanh_saturates...              FAILED
powf reverted  -> powf_handles_non_positive...   FAILED
both reverted  -> primitive_tanh_and_powf...     ok      (guard rail)
```

## Checklist
- [x] `cargo test` (625 passed / 0 failed) + `cargo clippy --all-targets` clean locally
- [x] `cargo fmt --check` clean
- [x] CHANGELOG entry under `## [Unreleased]` → `### Fixed`
- [x] No `unwrap`/`expect`/`panic` on library paths

## One thing I deliberately left alone

`sinh` and `cosh` return `inf` for large `|x|`, which is correct, but their **derivatives** come back NaN. That is not these defaults — it is `Dual`'s product rule forming `inf * 0` against the `HALF` constant:

```
sinh(800): value=inf  deriv=NaN     (true value is inf)
```

Different cause, different fix, and it would widen this PR past the issue. Happy to open a separate issue for it if you want it tracked.
