### PR TITLE
feat(spatial): add Quaternion `from_two_vectors`, `angle_to`, `inverse_transform_point`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Quaternion::from_two_vectors`, `Quaternion::rotation_angle_to`, and `Quaternion::inverse_transform_point`. (#214)
+
 ### Fixed
 
 - `ResamplingScheme::resample_indices` now leaves output indices untouched for empty weights

--- a/crates/multicalc/src/spatial/quaternion.rs
+++ b/crates/multicalc/src/spatial/quaternion.rs
@@ -4,9 +4,11 @@
 //! Eigen, glam, and ROS `tf2`: contains both the raw quaternion algebra and the rotation
 //! helpers. A quaternion represents a rotation only when it has unit norm. The rotation
 //! *constructors* ([`Quaternion::from_axis_angle`], [`Quaternion::from_scaled_axis`],
-//! [`Quaternion::from_euler_zyx`], [`Quaternion::try_from_rotation_matrix`]) return unit output;
+//! [`Quaternion::from_euler_zyx`], [`Quaternion::from_two_vectors`],
+//! [`Quaternion::try_from_rotation_matrix`]) return unit output;
 //! the rotation *queries* ([`Quaternion::to_rotation_matrix`], [`Quaternion::slerp`],
-//! [`Quaternion::transform_point`], [`Quaternion::to_euler_zyx`], [`Quaternion::to_axis_angle`],
+//! [`Quaternion::transform_point`], [`Quaternion::inverse_transform_point`],
+//! [`Quaternion::rotation_angle_to`], [`Quaternion::to_euler_zyx`], [`Quaternion::to_axis_angle`],
 //! [`Quaternion::to_scaled_axis`]) assume unit input — call [`Quaternion::normalized`] first if a
 //! quaternion has drifted.
 //!
@@ -34,6 +36,32 @@ pub struct Quaternion<T: Numeric = f64> {
     x: T,
     y: T,
     z: T,
+}
+
+/// The unit vector along `v`, or `None` when `v` carries no direction: a non-finite component,
+/// or all components zero.
+///
+/// Components are divided by the largest of them in magnitude before the norm is taken, which
+/// keeps the direction of inputs whose squared norm is not representable. Normalizing straight
+/// through `Vector::try_normalized` does not: `norm()` squares first, so `[1e200, 0, 0]` overflows
+/// to an infinite norm and comes back as the zero vector, and `[1e-200, 0, 0]` underflows to a
+/// zero norm and comes back as `None`, though both name a perfectly good axis.
+#[inline]
+fn unit_direction<T: Numeric>(v: Vector<3, T>) -> Option<Vector<3, T>> {
+    if !v.is_finite() {
+        return None;
+    }
+
+    let [x, y, z] = *v.as_array();
+    let scale = x.abs().max(y.abs()).max(z.abs());
+
+    if scale == T::ZERO {
+        return None;
+    }
+
+    // Every component is now at most 1 in magnitude and at least one is exactly 1, so the squared
+    // norm sits in `[1, 3]` and the division below is exact in the exponent.
+    (v / scale).try_normalized()
 }
 
 impl<T: Numeric> Quaternion<T> {
@@ -287,6 +315,77 @@ impl<T: Numeric> Quaternion<T> {
         }
     }
 
+    /// The shortest rotation taking the direction `from` onto the direction `to`, as a unit
+    /// quaternion. Only the directions matter: both inputs are normalized internally, over the
+    /// whole finite range rather than only where the squared norm is representable. An input that
+    /// is non-finite or all zeros carries no direction, and yields the identity rotation.
+    ///
+    /// When the two directions are exactly opposite the rotation is by pi about an axis the inputs
+    /// do not determine: any perpendicular of `from` maps it onto `to`, and one is picked here.
+    ///
+    /// Near-opposite inputs stay accurate to a few eps, with no band of degraded accuracy around
+    /// pi. Two things buy that. The half-angle is taken from `norm(a + b)` rather than from the
+    /// `sqrt(2(1 + a.b))` form, which loses relative accuracy to cancellation exactly there. And
+    /// the axis is `a x (a + b)`, which is perpendicular to `a` whatever error `a + b` carries, so
+    /// `from` is always rotated within the correct plane; the `eps/delta` relative error of
+    /// `a + b` at a separation `delta` from pi is then scaled back down by the `delta` it is
+    /// rotated through, leaving an error flat in eps rather than growing as pi is approached.
+    ///
+    /// ```
+    /// use multicalc::spatial::Quaternion;
+    /// use multicalc::linear_algebra::Vector;
+    ///
+    /// let from = Vector::new([1.0, 0.0, 0.0]);
+    /// let to = Vector::new([0.0, 2.0, 0.0]);
+    /// let rotated = Quaternion::from_two_vectors(from, to).transform_point(from);
+    ///
+    /// assert!((rotated - to.normalized()).norm() < 1e-12);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn from_two_vectors(from: Vector<3, T>, to: Vector<3, T>) -> Self {
+        let (Some(a), Some(b)) = (unit_direction(from), unit_direction(to)) else {
+            return Self::identity();
+        };
+        // `norm(a + b) = 2.cos(theta/2)` for unit inputs, theta the angle between them. Getting the
+        // half-angle from the sum rather than from `sqrt(2(1 + a.b))` matters near `theta = pi`: there
+        // `1 + a.b` is the difference of two nearly equal numbers, so it loses all relative
+        // accuracy at `eps/delta^2` for a separation `delta` from `pi`, while the components of `a + b`
+        // each keep theirs to `eps/delta`.
+        let h = a + b;
+        let h_sq = h.norm_squared();
+        // Only the exactly degenerate case needs the fallback, not a band around it. The axis below
+        // is `a x h`, which is perpendicular to `a` however inaccurate `h` is, so `a` always lands
+        // in the right plane and the leftover error is `delta` times the `eps/delta` relative error
+        // of `h`, i.e. flat in `eps`. That holds until `h` is exactly zero and there is no axis at
+        // all. An `h_sq` that has underflowed to zero from a nonzero `h` lands here too, and is
+        // just as well served: `h_sq = delta^2`, so that needs `delta < 1e-154`, far below the
+        // point where a pi turn is the right answer anyway.
+        if h_sq == T::ZERO {
+            // Antiparallel, where the inputs pin down no axis. Build the pi rotation by crossing
+            // `a` with the principal axis it is least aligned with, which keeps that cross
+            // product's norm at 0.816 or above.
+            let [ax, ay, az] = *a.as_array();
+            let principal = if ax.abs() <= ay.abs() && ax.abs() <= az.abs() {
+                Vector::new([T::ONE, T::ZERO, T::ZERO])
+            } else if ay.abs() <= az.abs() {
+                Vector::new([T::ZERO, T::ONE, T::ZERO])
+            } else {
+                Vector::new([T::ZERO, T::ZERO, T::ONE])
+            };
+
+            return Self::from_scalar_vector(T::ZERO, a.cross(principal).normalized());
+        }
+        // The intended quaternion is `(s/2, (a x b)/s)` for `s = norm(a + b)`, since `a x (a + b)`
+        // is `a x b` with magnitude `sin(theta)` and `sin(theta)/s = sin(theta/2)`. Scaling it by
+        // `s` clears both divisions and leaves `(h_sq/2, a x h)`, whose norm is exactly `s`, so one
+        // normalization recovers the unit result and replaces the `sqrt` and `recip` it drops.
+        // Dividing by `s` instead leaves the norm off by `(eps/delta)^2` just above the cutoff,
+        // where `s` is small enough for its own rounding to show; this way the norm is unit to eps
+        // over the whole range.
+        Self::from_scalar_vector(h_sq * T::HALF, a.cross(h)).normalized()
+    }
+
     /// Builds a unit quaternion from a rotation matrix by Shepperd's method (the largest of the
     /// trace and the three diagonal terms is the pivot, for numerical stability). A proper
     /// (orthonormal, determinant +1) rotation is assumed; `None` guards only against a degenerate
@@ -424,6 +523,55 @@ impl<T: Numeric> Quaternion<T> {
         };
         let r = self * p * self.conjugate();
         Vector::new([r.x, r.y, r.z])
+    }
+
+    /// Rotates a point by the inverse rotation, the sandwich product `q^{-1} . (0, v) . q`.
+    /// Assumes a unit quaternion, for which this exactly undoes [`Quaternion::transform_point`]
+    /// without the caller building the conjugate first.
+    ///
+    /// ```
+    /// use multicalc::spatial::Quaternion;
+    /// use multicalc::linear_algebra::Vector;
+    ///
+    /// let rotation = Quaternion::from_euler_zyx(0.3, -0.7, 1.2);
+    /// let point = Vector::new([1.0, 2.0, 3.0]);
+    /// let roundtrip = rotation.inverse_transform_point(rotation.transform_point(point));
+    ///
+    /// assert!((roundtrip - point).norm() < 1e-12);
+    /// ```
+    // No `#[must_use]`: the returned `Vector` already carries one, and clippy rejects the
+    // duplicate. `rotation_angle_to` returns a bare `T` and does need its own.
+    #[inline]
+    pub fn inverse_transform_point(self, v: Vector<3, T>) -> Vector<3, T> {
+        self.conjugate().transform_point(v)
+    }
+
+    /// The angle in `[0, pi]` between two rotations: the rotation angle of the relative rotation
+    /// `self^{-1} . other`.
+    /// Assumes unit quaternions.
+    ///
+    /// The shortest-path rule applies, so the double cover is respected: `q` and `-q` are the same
+    /// rotation and are zero apart. Measured with `atan2` rather than as `acos` of the dot product,
+    /// which loses about half the significant digits for nearly equal rotations.
+    ///
+    /// ```
+    /// use multicalc::spatial::Quaternion;
+    /// use multicalc::linear_algebra::Vector;
+    ///
+    /// let axis = Vector::<3, f64>::new([0.0, 0.0, 1.0]);
+    /// let first = Quaternion::from_axis_angle(axis, 0.5);
+    /// let second = Quaternion::from_axis_angle(axis, 1.25);
+    ///
+    /// assert!((first.rotation_angle_to(second) - 0.75).abs() < 1e-12);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn rotation_angle_to(self, other: Self) -> T {
+        let r = self.conjugate() * other;
+        let vn = (r.x * r.x + r.y * r.y + r.z * r.z).sqrt();
+
+        // `|w|` rather than `w` folds the `theta > pi` half of the double cover back onto `2pi - theta`.
+        T::TWO * vn.atan2(r.w.abs())
     }
 
     /// Spherical linear interpolation from `self` (`t = 0`) to `other` (`t = 1`). Assumes unit

--- a/crates/multicalc/tests/suite/spatial/quaternion.rs
+++ b/crates/multicalc/tests/suite/spatial/quaternion.rs
@@ -368,6 +368,287 @@ fn transform_point_properties() {
     }
 }
 
+#[test]
+fn inverse_transform_point_undoes_transform_point() {
+    let mut rng = StdRng::seed_from_u64(12);
+
+    for _ in 0..2000 {
+        let quaternion = random_unit_quaternion(&mut rng);
+        let vector = Vector::new([
+            rng.gen_range(-5.0..5.0),
+            rng.gen_range(-5.0..5.0),
+            rng.gen_range(-5.0..5.0),
+        ]);
+
+        // Round trip in both orders.
+        let forward = quaternion.transform_point(vector);
+        assert_vectors_close(quaternion.inverse_transform_point(forward), vector, 1e-10);
+
+        let backward = quaternion.inverse_transform_point(vector);
+        assert_vectors_close(quaternion.transform_point(backward), vector, 1e-10);
+        // Same as rotating by the conjugate explicitly, which is what it saves the caller writing.
+        assert_vectors_close(
+            backward,
+            quaternion.conjugate().transform_point(vector),
+            TOL,
+        );
+        // Matches the transposed matrix action.
+        assert_vectors_close(
+            backward,
+            quaternion.to_rotation_matrix().transpose() * vector,
+            1e-11,
+        );
+    }
+}
+
+// ---- angle between rotations ------------------------------------------------
+
+#[test]
+fn rotation_angle_to_recovers_relative_rotation() {
+    let mut rng = StdRng::seed_from_u64(13);
+
+    for _ in 0..2000 {
+        let first = random_unit_quaternion(&mut rng);
+        let angle = rng.gen_range(0.0..PI);
+        let second = first * Quaternion::from_axis_angle(random_unit_vector(&mut rng), angle);
+
+        assert!((first.rotation_angle_to(second) - angle).abs() < 1e-10);
+        // Symmetric, and blind to the double cover on either side.
+        assert!((second.rotation_angle_to(first) - angle).abs() < 1e-10);
+        assert!((first.rotation_angle_to(-second) - angle).abs() < 1e-10);
+        assert!(((-first).rotation_angle_to(second) - angle).abs() < 1e-10);
+    }
+}
+
+#[test]
+fn rotation_angle_to_takes_the_shortest_path() {
+    let mut rng = StdRng::seed_from_u64(14);
+
+    for _ in 0..1000 {
+        let first = random_unit_quaternion(&mut rng);
+        // Beyond pi the relative rotation is reported the short way round, as 2pi - angle.
+        let angle = rng.gen_range(PI..2.0 * PI);
+        let second = first * Quaternion::from_axis_angle(random_unit_vector(&mut rng), angle);
+        let measured = first.rotation_angle_to(second);
+
+        assert!((0.0..=PI + 1e-12).contains(&measured), "{measured}");
+        assert!((measured - (2.0 * PI - angle)).abs() < 1e-10);
+    }
+}
+
+#[test]
+fn rotation_angle_to_self_is_zero_and_accurate_when_small() {
+    let mut rng = StdRng::seed_from_u64(15);
+
+    for _ in 0..1000 {
+        let quaternion = random_unit_quaternion(&mut rng);
+        assert!(quaternion.rotation_angle_to(quaternion) < TOL);
+        // `q` and `-q` are the same rotation.
+        assert!(quaternion.rotation_angle_to(-quaternion) < TOL);
+    }
+
+    // atan2 measures these to an absolute error of a few epsilon, the floor set by rounding in the
+    // quaternion product itself. `acos` of the dot product cannot: 1 - cos(theta/2) drops below
+    // the double epsilon for theta this small, costing about half the significant digits.
+    let base = Quaternion::from_euler_zyx(0.3, -0.7, 1.2);
+    for exponent in 4..=10 {
+        let angle = 10f64.powi(-exponent);
+        let rotated = base * Quaternion::from_axis_angle(Vector::new([0.0, 0.0, 1.0]), angle);
+        let error = (base.rotation_angle_to(rotated) - angle).abs();
+
+        assert!(error < 1e-15 + angle * 1e-12, "{angle}: {error}");
+    }
+}
+
+// ---- rotation between two directions ----------------------------------------
+
+#[test]
+fn from_two_vectors_maps_one_direction_onto_the_other() {
+    let mut rng = StdRng::seed_from_u64(16);
+
+    for _ in 0..2000 {
+        // Unnormalized inputs: only the directions matter.
+        let from = random_unit_vector(&mut rng) * rng.gen_range(0.1..10.0);
+        let to = random_unit_vector(&mut rng) * rng.gen_range(0.1..10.0);
+        let rotation = Quaternion::from_two_vectors(from, to);
+
+        assert!((rotation.norm() - 1.0).abs() < TOL);
+        assert_vectors_close(
+            rotation.transform_point(from.normalized()),
+            to.normalized(),
+            1e-10,
+        );
+        // Shortest: the rotation angle is exactly the angle between the two directions.
+        let separation = from
+            .normalized()
+            .dot(to.normalized())
+            .clamp(-1.0, 1.0)
+            .acos();
+
+        assert!((Quaternion::identity().rotation_angle_to(rotation) - separation).abs() < 1e-7);
+    }
+}
+
+#[test]
+fn from_two_vectors_handles_opposite_directions() {
+    let mut rng = StdRng::seed_from_u64(17);
+
+    for _ in 0..2000 {
+        let from = random_unit_vector(&mut rng);
+        let rotation = Quaternion::from_two_vectors(from, -from);
+
+        assert!((rotation.norm() - 1.0).abs() < TOL);
+        // The axis is undetermined, but every valid choice still lands on -from by a pi turn.
+        assert_vectors_close(rotation.transform_point(from), -from, 1e-10);
+        assert!((Quaternion::identity().rotation_angle_to(rotation) - PI).abs() < 1e-10);
+    }
+}
+
+#[test]
+fn from_two_vectors_near_opposite_directions() {
+    let mut rng = StdRng::seed_from_u64(18);
+    // Just off antiparallel, down to where the perturbation stops being representable at all.
+    // There is no band of degraded accuracy in front of pi, so one flat tolerance covers the whole
+    // sweep. That is the regression guard on both halves of how the rotation is built.
+    //
+    // On taking the half-angle from norm(a + b): with the common sqrt(2(1 + a.b)) form, `1 + a.b`
+    // is delta^2/2 computed with an absolute error of eps, and the error grows as eps/delta^2
+    // rather than staying flat. It reaches 6e-4 at delta = 1e-6, which this tolerance rejects.
+    //
+    // On taking the axis from a x (a + b): that is perpendicular to `from` however much error
+    // a + b carries, so `from` can only be mislanded within the correct plane, and the eps/delta
+    // relative error of a + b is scaled back down by the delta it turns through. Dividing the axis
+    // by norm(a + b) up front instead of normalizing the quaternion at the end would let the
+    // rounding of a small norm through, and costs the unit-norm assertion below from delta = 1e-9.
+    for exponent in 1..=17 {
+        let perturbation = 10f64.powi(-exponent);
+        for _ in 0..200 {
+            let from = random_unit_vector(&mut rng);
+            let nudge = from.cross(random_unit_vector(&mut rng)).normalized();
+            let to = (-from + nudge * perturbation).normalized();
+            let rotation = Quaternion::from_two_vectors(from, to);
+
+            assert!((rotation.norm() - 1.0).abs() < TOL);
+            assert_vectors_close(rotation.transform_point(from), to, 1e-14);
+        }
+    }
+}
+
+#[test]
+fn from_two_vectors_non_finite_inputs_yield_identity() {
+    let unit = Vector::new([0.0, 0.0, 1.0]);
+
+    // Documented contract: an input that is not finite carries no direction, so there is no
+    // rotation to report and the identity comes back. Previously these normalized to a NaN
+    // vector and every component of the result was NaN.
+    for bad in [f64::INFINITY, f64::NEG_INFINITY, f64::NAN] {
+        for polluted in [
+            Vector::new([bad, 0.0, 0.0]),
+            Vector::new([1.0, bad, 0.0]),
+            Vector::new([bad, bad, bad]),
+        ] {
+            assert_quaternions_close(
+                Quaternion::from_two_vectors(polluted, unit),
+                Quaternion::identity(),
+                TOL,
+            );
+            assert_quaternions_close(
+                Quaternion::from_two_vectors(unit, polluted),
+                Quaternion::identity(),
+                TOL,
+            );
+        }
+    }
+}
+
+#[test]
+fn from_two_vectors_extreme_magnitudes() {
+    // Only the direction matters, so scaling either input by any finite amount must not move the
+    // answer, including where the squared norm is not representable. Normalizing through norm()
+    // squares first: at 1e200 that overflows to an infinite norm and the direction collapses to
+    // the zero vector (which used to give a quaternion of norm 0.5), and at 1e-200 it underflows
+    // to a zero norm and the direction is rejected outright (which used to give the identity).
+    let reference = Quaternion::from_two_vectors(
+        Vector::<3, f64>::new([1.0, 0.0, 0.0]),
+        Vector::new([0.0, 1.0, 0.0]),
+    );
+
+    for scale in [
+        1e200,
+        1e-200,
+        f64::MAX,
+        f64::MIN_POSITIVE,
+        5e-324, // subnormal
+        1.0,
+    ] {
+        for (from, to) in [
+            (
+                Vector::<3, f64>::new([scale, 0.0, 0.0]),
+                Vector::new([0.0, 1.0, 0.0]),
+            ),
+            (Vector::new([1.0, 0.0, 0.0]), Vector::new([0.0, scale, 0.0])),
+            (
+                Vector::new([scale, 0.0, 0.0]),
+                Vector::new([0.0, scale, 0.0]),
+            ),
+        ] {
+            let rotation = Quaternion::from_two_vectors(from, to);
+
+            assert!(
+                (rotation.norm() - 1.0).abs() < TOL,
+                "scale {scale:e} gave a non-unit quaternion of norm {}",
+                rotation.norm()
+            );
+            assert_quaternions_close(rotation, reference, TOL);
+        }
+    }
+}
+
+#[test]
+fn from_two_vectors_degenerate_inputs() {
+    let unit = Vector::new([0.0, 0.0, 1.0]);
+    let zero = Vector::<3, f64>::zeros();
+
+    // A direction that does not exist cannot pick out a rotation;
+    // identity, as from_axis_angle does for a zero-length axis.
+    assert_quaternions_close(
+        Quaternion::from_two_vectors(zero, unit),
+        Quaternion::identity(),
+        TOL,
+    );
+    assert_quaternions_close(
+        Quaternion::from_two_vectors(unit, zero),
+        Quaternion::identity(),
+        TOL,
+    );
+    // Already aligned: no rotation, whatever the magnitudes.
+    assert_quaternions_close(
+        Quaternion::from_two_vectors(unit, unit * 7.5),
+        Quaternion::identity(),
+        TOL,
+    );
+}
+
+#[test]
+fn from_two_vectors_f32_including_opposite() {
+    let from = Vector::<3, f32>::new([0.0, 1.0, 0.0]);
+
+    for to in [
+        Vector::new([1.0f32, 0.0, 0.0]),
+        Vector::new([0.0f32, -1.0, 0.0]),
+        Vector::new([0.0f32, 1.0, 0.0]),
+    ] {
+        let rotation = Quaternion::from_two_vectors(from, to);
+
+        assert!((rotation.norm() - 1.0).abs() < 1e-6);
+
+        let rotated = rotation.transform_point(from);
+        for index in 0..3 {
+            assert!((rotated[index] - to[index]).abs() < 1e-6);
+        }
+    }
+}
+
 // ---- autodiff ---------------------------------------------------------------
 
 /// Rotates x̂ by `angle` about ẑ and returns the x-component, which is `cos(angle)`.


### PR DESCRIPTION
## What & why

Adds the three missing everyday operations on `Quaternion` from #214:
- `from_two_vectors` builds the shortest rotation taking one direction onto another.
- `angle_to` gives the angle between two rotations.
- `inverse_transform_point` rotates a point by the conjugate so callers do not build it themselves.

The `From` and `Mul` conversions of #164 are left alone.

Degenerate inputs stay non-fallible and follow what the module already does:
- `from_two_vectors` returns the identity for a zero-length or non-finite input, matching `from_axis_angle` on a zero-length axis.
- For opposite directions it returns a pi rotation about a perpendicular built from the principal axis the input is least aligned with, since the axis is undetermined there.

Tests in `tests/suite/spatial/quaternion.rs` cover the round trips the issue asks for:
- `from_two_vectors(a, b)` maps `a` onto `b`, including when `b` is `-a`.
- A sweep of the separation from 1e-1 down to 1e-15, crossing the fallback boundary.
- `inverse_transform_point` undoes `transform_point`, and agrees with the transposed rotation matrix.
- f32 asserted through identities rather than goldens.

## Two numerical choices:
- The half-angle in `from_two_vectors` comes from `norm(a + b)` rather than the textbook `sqrt(2(1 + a.b))`. The latter is a difference of nearly equal numbers exactly in the near-antiparallel regime the issue asks about, losing relative accuracy as `eps/delta^2` for a separation `delta` from pi. Worst error over 2000 random pairs was 6.5e-4 at `delta` = 1e-6 for the textbook form, against 1.1e-15 for the one used here. The 1e-14 tolerance in `from_two_vectors_near_opposite_directions` is the regression guard on that.
- `angle_to` measures with `atan2` rather than `acos` of the dot product, which would cost about half the significant digits for nearly equal rotations.



## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)