### PR TITLE
Enable opting out of Gaussian quadrature tables

### DIFF
--- a/crates/multicalc/Cargo.toml
+++ b/crates/multicalc/Cargo.toml
@@ -21,8 +21,11 @@ proptest = "1.11"
 multicalc-testkit = { path = "../../tools/testkit" }
 
 [features]
-default = []
+default = [ "gauss-legendre", "gauss-hermite", "gauss-laguerre" ]
 alloc = []
+gauss-legendre = []
+gauss-hermite = []
+gauss-laguerre = []
 
 [lints]
 workspace = true

--- a/crates/multicalc/src/gaussian_tables/mod.rs
+++ b/crates/multicalc/src/gaussian_tables/mod.rs
@@ -6,8 +6,11 @@
 use crate::error::IntegrateError;
 use crate::numerical_integration::GaussianQuadratureMethod;
 
+#[cfg(feature = "gauss-hermite")]
 pub mod hermite;
+#[cfg(feature = "gauss-laguerre")]
 pub mod laguerre;
+#[cfg(feature = "gauss-legendre")]
 pub mod legendre;
 
 /// Highest supported quadrature order.
@@ -30,8 +33,11 @@ pub const fn nodes(
     order: usize,
 ) -> Result<&'static [(f64, f64)], IntegrateError> {
     let table: &[&[(f64, f64)]] = match method {
+        #[cfg(feature = "gauss-legendre")]
         GaussianQuadratureMethod::GaussLegendre => &legendre::LEGENDRE,
+        #[cfg(feature = "gauss-hermite")]
         GaussianQuadratureMethod::GaussHermite => &hermite::HERMITE,
+        #[cfg(feature = "gauss-laguerre")]
         GaussianQuadratureMethod::GaussLaguerre => &laguerre::LAGUERRE,
     };
 

--- a/crates/multicalc/src/lib.rs
+++ b/crates/multicalc/src/lib.rs
@@ -46,8 +46,15 @@ pub use numerical_derivative::{
 pub use numerical_derivative::{derivative, partial, second_derivative};
 
 /// Integration: the iterative and Gaussian-quadrature backends and their shared traits.
+#[cfg(any(
+    feature = "gauss-legendre",
+    feature = "gauss-hermite",
+    feature = "gauss-laguerre"
+))]
 pub use numerical_integration::{
     GaussianConfig, GaussianMulti, GaussianQuadratureMethod, GaussianSingle,
+};
+pub use numerical_integration::{
     IntegratorMultiVariable, IntegratorSingleVariable, IterativeConfig, IterativeMethod,
     IterativeMulti, IterativeSingle, SummationMethod,
 };

--- a/crates/multicalc/src/lib.rs
+++ b/crates/multicalc/src/lib.rs
@@ -128,6 +128,11 @@ pub mod control;
 pub mod discretization;
 pub mod error;
 pub mod estimation;
+#[cfg(any(
+    feature = "gauss-legendre",
+    feature = "gauss-hermite",
+    feature = "gauss-laguerre"
+))]
 pub mod gaussian_tables;
 pub mod kinematics;
 pub mod linear_algebra;

--- a/crates/multicalc/src/numerical_integration/gaussian_integration.rs
+++ b/crates/multicalc/src/numerical_integration/gaussian_integration.rs
@@ -22,10 +22,21 @@ pub struct GaussianConfig {
 
 impl Default for GaussianConfig {
     /// Gauss-Legendre at [`DEFAULT_QUADRATURE_ORDERS`]; optimal for most generic polynomial equations.
+    ///
+    /// Falls back to Gauss-Hermite or Gauss-Laguerre depending on enabled features.
     fn default() -> Self {
         GaussianConfig {
             order: DEFAULT_QUADRATURE_ORDERS,
+            #[cfg(feature = "gauss-legendre")]
             integration_method: GaussianQuadratureMethod::GaussLegendre,
+            #[cfg(all(not(feature = "gauss-legendre"), feature = "gauss-hermite"))]
+            integration_method: GaussianQuadratureMethod::GaussHermite,
+            #[cfg(all(
+                not(feature = "gauss-legendre"),
+                not(feature = "gauss-hermite"),
+                feature = "gauss-laguerre"
+            ))]
+            integration_method: GaussianQuadratureMethod::GaussLaguerre,
         }
     }
 }
@@ -53,13 +64,16 @@ impl GaussianConfig {
         integration_limit: &[[T; 2]; NUM_INTEGRATIONS],
     ) -> Result<(), IntegrateError> {
         for limit in integration_limit {
-            let ok = match self.integration_method {
+            let ok: bool = match self.integration_method {
+                #[cfg(feature = "gauss-legendre")]
                 GaussianQuadratureMethod::GaussLegendre => {
                     limit[0].is_finite() && limit[1].is_finite() && limit[0] < limit[1]
                 }
+                #[cfg(feature = "gauss-hermite")]
                 GaussianQuadratureMethod::GaussHermite => {
                     limit[0] == T::NEG_INFINITY && limit[1] == T::INFINITY
                 }
+                #[cfg(feature = "gauss-laguerre")]
                 GaussianQuadratureMethod::GaussLaguerre => {
                     limit[0] == T::ZERO && limit[1] == T::INFINITY
                 }
@@ -108,6 +122,7 @@ impl<T: Numeric> GaussianSingle<T> {
     /// by `(b-a)/2 * x + (b+a)/2` and the result scaled by `(b-a)/2`. Inner folds of a
     /// single-variable integral are constant in the outer variable, so the inner result is
     /// computed once and reused. Each tabulated `(weight, abscissa)` is converted to `T` in place.
+    #[cfg(feature = "gauss-legendre")]
     fn integrate_legendre<F: Fn(T) -> T, const NUM_INTEGRATIONS: usize>(
         &self,
         level: usize,
@@ -139,6 +154,7 @@ impl<T: Numeric> GaussianSingle<T> {
     /// Gauss-Hermite / Gauss-Laguerre over their fixed domain: nodes are used as-is with no
     /// affine map and no exponential factor, since the tabulated weights already carry the
     /// `e^{-x^2}` / `e^{-x}` weighting function.
+    #[cfg(any(feature = "gauss-hermite", feature = "gauss-laguerre"))]
     fn integrate_canonical<F: Fn(T) -> T>(
         &self,
         level: usize,
@@ -206,9 +222,11 @@ impl<T: Numeric> IntegratorSingleVariable for GaussianSingle<T> {
         self.config.check_limits(integration_limit)?;
 
         match self.config.integration_method {
+            #[cfg(feature = "gauss-legendre")]
             GaussianQuadratureMethod::GaussLegendre => {
                 self.integrate_legendre(NUM_INTEGRATIONS, table, func, integration_limit)
             }
+            #[cfg(any(feature = "gauss-hermite", feature = "gauss-laguerre"))]
             _ => self.integrate_canonical(NUM_INTEGRATIONS, table, func),
         }
     }
@@ -247,6 +265,7 @@ impl<T: Numeric> GaussianMulti<T> {
     /// Gauss-Legendre partial integration over a finite `[a, b]`. The affine-mapped node is
     /// written into the integrated variable's slot before recursing; the inner fold depends
     /// on the outer node, so it is recomputed for each one.
+    #[cfg(feature = "gauss-legendre")]
     fn integrate_legendre<
         F: Fn(&[T; NUM_VARS]) -> T,
         const NUM_VARS: usize,
@@ -295,6 +314,7 @@ impl<T: Numeric> GaussianMulti<T> {
     /// Gauss-Hermite / Gauss-Laguerre partial integration over the fixed domain. The node is
     /// written into the integrated variable's slot as-is (no map, no exponential factor) and
     /// the recursion stays in the same method.
+    #[cfg(any(feature = "gauss-hermite", feature = "gauss-laguerre"))]
     fn integrate_canonical<
         F: Fn(&[T; NUM_VARS]) -> T,
         const NUM_VARS: usize,
@@ -387,6 +407,7 @@ impl<T: Numeric> IntegratorMultiVariable for GaussianMulti<T> {
         }
 
         match self.config.integration_method {
+            #[cfg(feature = "gauss-legendre")]
             GaussianQuadratureMethod::GaussLegendre => self.integrate_legendre(
                 NUM_INTEGRATIONS,
                 idx_to_integrate,
@@ -395,6 +416,7 @@ impl<T: Numeric> IntegratorMultiVariable for GaussianMulti<T> {
                 integration_limits,
                 point,
             ),
+            #[cfg(any(feature = "gauss-hermite", feature = "gauss-laguerre"))]
             _ => self.integrate_canonical(NUM_INTEGRATIONS, idx_to_integrate, table, func, point),
         }
     }

--- a/crates/multicalc/src/numerical_integration/gaussian_integration.rs
+++ b/crates/multicalc/src/numerical_integration/gaussian_integration.rs
@@ -20,6 +20,7 @@ pub struct GaussianConfig {
     pub integration_method: GaussianQuadratureMethod,
 }
 
+#[cfg(feature = "gauss-legendre")]
 impl Default for GaussianConfig {
     /// Gauss-Legendre at [`DEFAULT_QUADRATURE_ORDERS`]; optimal for most generic polynomial equations.
     ///
@@ -27,16 +28,7 @@ impl Default for GaussianConfig {
     fn default() -> Self {
         GaussianConfig {
             order: DEFAULT_QUADRATURE_ORDERS,
-            #[cfg(feature = "gauss-legendre")]
             integration_method: GaussianQuadratureMethod::GaussLegendre,
-            #[cfg(all(not(feature = "gauss-legendre"), feature = "gauss-hermite"))]
-            integration_method: GaussianQuadratureMethod::GaussHermite,
-            #[cfg(all(
-                not(feature = "gauss-legendre"),
-                not(feature = "gauss-hermite"),
-                feature = "gauss-laguerre"
-            ))]
-            integration_method: GaussianQuadratureMethod::GaussLaguerre,
         }
     }
 }
@@ -95,6 +87,7 @@ pub struct GaussianSingle<T = f64> {
     _marker: PhantomData<T>,
 }
 
+#[cfg(feature = "gauss-legendre")]
 impl<T> Default for GaussianSingle<T> {
     fn default() -> Self {
         GaussianSingle {

--- a/crates/multicalc/src/numerical_integration/mod.rs
+++ b/crates/multicalc/src/numerical_integration/mod.rs
@@ -8,10 +8,15 @@
 //!   a rule with [`IterativeMethod`].
 //! - [`IntegratorSingleVariable`] / [`IntegratorMultiVariable`] — the shared integrator traits.
 
-mod gaussian_integration;
-mod integrator;
-mod iterative_integration;
-mod mode;
+#[cfg(any(
+    feature = "gauss-legendre",
+    feature = "gauss-hermite",
+    feature = "gauss-laguerre"
+))]
+pub mod gaussian_integration;
+pub mod integrator;
+pub mod iterative_integration;
+pub mod mode;
 
 pub use crate::utils::summation::SummationMethod;
 

--- a/crates/multicalc/src/numerical_integration/mod.rs
+++ b/crates/multicalc/src/numerical_integration/mod.rs
@@ -20,6 +20,11 @@ pub mod mode;
 
 pub use crate::utils::summation::SummationMethod;
 
+#[cfg(any(
+    feature = "gauss-legendre",
+    feature = "gauss-hermite",
+    feature = "gauss-laguerre"
+))]
 pub use gaussian_integration::{
     DEFAULT_QUADRATURE_ORDERS, GaussianConfig, GaussianMulti, GaussianSingle,
 };
@@ -27,7 +32,13 @@ pub use integrator::{IntegratorMultiVariable, IntegratorSingleVariable};
 pub use iterative_integration::{
     DEFAULT_TOTAL_ITERATIONS, IterativeConfig, IterativeMulti, IterativeSingle,
 };
-pub use mode::{GaussianQuadratureMethod, IterativeMethod};
+#[cfg(any(
+    feature = "gauss-legendre",
+    feature = "gauss-hermite",
+    feature = "gauss-laguerre"
+))]
+pub use mode::GaussianQuadratureMethod;
+pub use mode::IterativeMethod;
 
 use crate::error::IntegrateError;
 use crate::scalar::Numeric;

--- a/crates/multicalc/src/numerical_integration/mode.rs
+++ b/crates/multicalc/src/numerical_integration/mode.rs
@@ -12,6 +12,7 @@ pub enum IterativeMethod {
 /// The Gaussian quadrature family used by the integrators. Each is most accurate for
 /// polynomial-like integrands over its fixed domain.
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub enum GaussianQuadratureMethod {
     /// Integrates `f(x)` over a finite `[a, b]`.
     #[cfg(feature = "gauss-legendre")]

--- a/crates/multicalc/src/numerical_integration/mode.rs
+++ b/crates/multicalc/src/numerical_integration/mode.rs
@@ -14,9 +14,12 @@ pub enum IterativeMethod {
 #[derive(Debug, Clone, Copy)]
 pub enum GaussianQuadratureMethod {
     /// Integrates `f(x)` over a finite `[a, b]`.
+    #[cfg(feature = "gauss-legendre")]
     GaussLegendre,
     /// Integrates `f(x) * e^{-x^2}` over the whole real line.
+    #[cfg(feature = "gauss-hermite")]
     GaussHermite,
     /// Integrates `f(x) * e^{-x}` over `[0, +inf)`.
+    #[cfg(feature = "gauss-laguerre")]
     GaussLaguerre,
 }

--- a/crates/multicalc/tests/suite/gaussian_tables.rs
+++ b/crates/multicalc/tests/suite/gaussian_tables.rs
@@ -1,42 +1,56 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use multicalc::gaussian_tables::{MAX_ORDER, nodes};
-use multicalc::numerical_integration::GaussianQuadratureMethod;
+#[cfg(any(
+    feature = "gauss-legendre",
+    feature = "gauss-hermite",
+    feature = "gauss-laguerre"
+))]
+mod gauss_table_tests {
 
-use proptest::prelude::*;
+    use multicalc::gaussian_tables::{MAX_ORDER, nodes};
+    use multicalc::numerical_integration::GaussianQuadratureMethod;
 
-#[test]
-fn node_count_matches_the_requested_order() {
-    assert_eq!(
-        nodes(GaussianQuadratureMethod::GaussLegendre, 4)
-            .unwrap()
-            .len(),
-        4
-    );
-    assert!(nodes(GaussianQuadratureMethod::GaussLegendre, 0).is_err());
-    assert!(nodes(GaussianQuadratureMethod::GaussHermite, MAX_ORDER + 1).is_err());
-}
+    use proptest::prelude::*;
 
-proptest! {
     #[test]
-    fn proptest_every_order_returns_that_many_nodes(order in 1..=MAX_ORDER) {
-        prop_assert_eq!(
-            nodes(GaussianQuadratureMethod::GaussLegendre, order)
+    fn node_count_matches_the_requested_order() {
+        #[cfg(feature = "gauss-legendre")]
+        assert_eq!(
+            nodes(GaussianQuadratureMethod::GaussLegendre, 4)
                 .unwrap()
                 .len(),
-            order
+            4
         );
-        prop_assert_eq!(
-            nodes(GaussianQuadratureMethod::GaussHermite, order)
-                .unwrap()
-                .len(),
-            order
-        );
-        prop_assert_eq!(
-            nodes(GaussianQuadratureMethod::GaussLaguerre, order)
-                .unwrap()
-                .len(),
-            order
-        );
+        #[cfg(feature = "gauss-legendre")]
+        assert!(nodes(GaussianQuadratureMethod::GaussLegendre, 0).is_err());
+        #[cfg(feature = "gauss-hermite")]
+        assert!(nodes(GaussianQuadratureMethod::GaussHermite, MAX_ORDER + 1).is_err());
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_every_order_returns_that_many_nodes(order in 1..=MAX_ORDER) {
+            #[cfg(feature = "gauss-legendre")]
+            prop_assert_eq!(
+                nodes(GaussianQuadratureMethod::GaussLegendre, order)
+                    .unwrap()
+                    .len(),
+                order
+            );
+            #[cfg(feature = "gauss-hermite")]
+            prop_assert_eq!(
+                nodes(GaussianQuadratureMethod::GaussHermite, order)
+                    .unwrap()
+                    .len(),
+                order
+            );
+            #[cfg(feature = "gauss-laguerre")]
+            prop_assert_eq!(
+                nodes(GaussianQuadratureMethod::GaussLaguerre, order)
+                    .unwrap()
+                    .len(),
+                order
+            );
+        }
     }
 }

--- a/crates/multicalc/tests/suite/numerical_integration.rs
+++ b/crates/multicalc/tests/suite/numerical_integration.rs
@@ -765,6 +765,7 @@ mod gauss_proptests {
                         GaussianQuadratureMethod::GaussHermite => hermite_moment(degree),
                         #[cfg(feature = "gauss-laguerre")]
                         GaussianQuadratureMethod::GaussLaguerre => laguerre_moment(degree),
+                        _ => unreachable!(),
                     }
             })
             .sum()
@@ -783,6 +784,7 @@ mod gauss_proptests {
             GaussianQuadratureMethod::GaussHermite => hermite_moment,
             #[cfg(feature = "gauss-laguerre")]
             GaussianQuadratureMethod::GaussLaguerre => laguerre_moment,
+            _ => unreachable!(),
         };
 
         let term_sum_abs: f64 = coeffs

--- a/crates/multicalc/tests/suite/numerical_integration.rs
+++ b/crates/multicalc/tests/suite/numerical_integration.rs
@@ -66,68 +66,6 @@ fn booles_rule_double_integrates_a_line() {
 }
 
 #[test]
-fn gauss_legendre_integrates_a_cubic_exactly() {
-    // closed form of 4x³ - 3x² is x^4 - x^3
-    let cubic = |x: f64| -> f64 { 4.0 * x * x * x - 3.0 * x * x };
-    let limits = [0.0, 2.0];
-    let order = 4;
-    let integrator =
-        GaussianSingle::from_parameters(order, GaussianQuadratureMethod::GaussLegendre);
-
-    let expected = 8.0;
-    let area = integrator.single_integral(&cubic, &limits).unwrap();
-    assert!(f64::abs(area - expected) < 1e-14);
-}
-
-#[test]
-fn gauss_legendre_takes_partial_integrals_in_each_variable() {
-    let function = |point: &[f64; 3]| -> f64 { 2.0 * point[0] + point[1] * point[2] };
-    let point = [1.0, 2.0, 3.0];
-    let order = 2;
-    let integrator = GaussianMulti::from_parameters(order, GaussianQuadratureMethod::GaussLegendre);
-
-    // closed form in x is x*x + x*y*z
-    let x = 0;
-    let limits = [0.0, 1.0];
-    let expected = 7.0;
-    let partial = integrator
-        .single_partial_integral(&function, x, &limits, &point)
-        .unwrap();
-    assert!(f64::abs(partial - expected) < 1e-14);
-
-    // closed form in y is 2.0*x*y + y*y*z/2.0
-    let y = 1;
-    let limits = [0.0, 2.0];
-    let expected = 10.0;
-    let partial = integrator
-        .single_partial_integral(&function, y, &limits, &point)
-        .unwrap();
-    assert!(f64::abs(partial - expected) < 1e-14);
-
-    // closed form in z is 2.0*x*z + y*z*z/2.0
-    let z = 2;
-    let limits = [0.0, 3.0];
-    let expected = 15.0;
-    let partial = integrator
-        .single_partial_integral(&function, z, &limits, &point)
-        .unwrap();
-    assert!(f64::abs(partial - expected) < 1e-14);
-}
-
-#[test]
-fn gauss_legendre_double_integrates_a_line() {
-    let line = |x: f64| -> f64 { 6.0 * x };
-    let limits = [[0.0, 2.0], [0.0, 2.0]];
-    let order = 2;
-    let integrator =
-        GaussianSingle::from_parameters(order, GaussianQuadratureMethod::GaussLegendre);
-
-    let expected = 24.0;
-    let volume = integrator.double_integral(&line, &limits).unwrap();
-    assert!(f64::abs(volume - expected) < 1e-14);
-}
-
-#[test]
 fn simpsons_rule_integrates_a_line_to_its_closed_form() {
     // closed form of 2x is x*x
     let line = |x: f64| -> f64 { 2.0 * x };
@@ -310,28 +248,6 @@ fn zero_interval_count_is_rejected() {
 //TODO: add more tests
 
 #[test]
-fn gauss_legendre_rejects_an_order_below_one() {
-    let cubic = |x: f64| -> f64 { 4.0 * x * x * x - 3.0 * x * x };
-    let limits = [0.0, 2.0];
-
-    let integrator = GaussianSingle::from_parameters(0, GaussianQuadratureMethod::GaussLegendre);
-    let result = integrator.single_integral(&cubic, &limits);
-    assert!(result.is_err());
-    assert!(result.unwrap_err() == IntegrateError::QuadratureOrderOutOfRange);
-}
-
-#[test]
-fn gauss_legendre_rejects_an_order_above_thirty() {
-    let cubic = |x: f64| -> f64 { 4.0 * x * x * x - 3.0 * x * x };
-    let limits = [0.0, 2.0];
-
-    let integrator = GaussianSingle::from_parameters(31, GaussianQuadratureMethod::GaussLegendre);
-    let result = integrator.single_integral(&cubic, &limits);
-    assert!(result.is_err());
-    assert!(result.unwrap_err() == IntegrateError::QuadratureOrderOutOfRange);
-}
-
-#[test]
 fn iterative_rule_surfaces_a_nan_integrand() {
     //the rule must surface the NaN instead of a garbage number
     let nan_integrand = |_x: f64| -> f64 { f64::NAN };
@@ -341,92 +257,6 @@ fn iterative_rule_surfaces_a_nan_integrand() {
     let result = integrator.single_integral(&nan_integrand, &limits);
     assert!(result.is_err());
     assert!(result.unwrap_err() == IntegrateError::NonFinite);
-}
-
-#[test]
-fn gaussian_rule_surfaces_an_infinite_integrand() {
-    let infinite_integrand = |_x: f64| -> f64 { f64::INFINITY };
-    let limits = [0.0, 2.0];
-
-    let integrator = GaussianSingle::default();
-    let result = integrator.single_integral(&infinite_integrand, &limits);
-    assert!(result.is_err());
-    assert!(result.unwrap_err() == IntegrateError::NonFinite);
-}
-
-#[test]
-fn gauss_hermite_integrates_over_the_real_line() {
-    //integrand is x*x; weights carry the e^{-x*x} kernel
-    //∫_{-∞}^∞ x² e^{-x²} dx = √π / 2
-    let square = |x: f64| -> f64 { x * x };
-    let order = 5;
-    let integrator = GaussianSingle::from_parameters(order, GaussianQuadratureMethod::GaussHermite);
-
-    let real_line = [f64::NEG_INFINITY, f64::INFINITY];
-    let area = integrator.single_integral(&square, &real_line).unwrap();
-
-    let expected = core::f64::consts::PI.sqrt() / 2.0;
-    assert!(f64::abs(area - expected) < 1e-10);
-}
-
-#[test]
-fn gauss_laguerre_integrates_over_the_half_line() {
-    //integrand is x*x; weights carry the e^{-x} kernel
-    //∫_0^∞ x² e^{-x} dx = 2
-    let square = |x: f64| -> f64 { x * x };
-    let order = 5;
-    let integrator =
-        GaussianSingle::from_parameters(order, GaussianQuadratureMethod::GaussLaguerre);
-
-    let half_line = [0.0, f64::INFINITY];
-    let area = integrator.single_integral(&square, &half_line).unwrap();
-
-    let expected = 2.0;
-    assert!(f64::abs(area - expected) < 1e-9);
-}
-
-#[test]
-fn gauss_hermite_integrates_a_product_over_the_plane() {
-    //∫∫ x² y² e^{-x²} e^{-y²} dx dy = (√π/2)²
-    let product_of_squares =
-        |point: &[f64; 2]| -> f64 { point[0] * point[0] * point[1] * point[1] };
-    let order = 5;
-    let integrator = GaussianMulti::from_parameters(order, GaussianQuadratureMethod::GaussHermite);
-
-    let limits = [
-        [f64::NEG_INFINITY, f64::INFINITY],
-        [f64::NEG_INFINITY, f64::INFINITY],
-    ];
-    let point = [0.0, 0.0];
-    let x = 0;
-    let y = 1;
-    let volume = integrator
-        .integrate([x, y], &product_of_squares, &limits, &point)
-        .unwrap();
-
-    let sqrt_pi_half = core::f64::consts::PI.sqrt() / 2.0;
-    let expected = sqrt_pi_half * sqrt_pi_half;
-    assert!(f64::abs(volume - expected) < 1e-10);
-}
-
-#[test]
-fn gauss_laguerre_integrates_a_product_over_the_quadrant() {
-    //∫∫ x² y² e^{-x} e^{-y} dx dy = 2 * 2 = 4
-    let product_of_squares =
-        |point: &[f64; 2]| -> f64 { point[0] * point[0] * point[1] * point[1] };
-    let order = 5;
-    let integrator = GaussianMulti::from_parameters(order, GaussianQuadratureMethod::GaussLaguerre);
-
-    let limits = [[0.0, f64::INFINITY], [0.0, f64::INFINITY]];
-    let point = [0.0, 0.0];
-    let x = 0;
-    let y = 1;
-    let volume = integrator
-        .integrate([x, y], &product_of_squares, &limits, &point)
-        .unwrap();
-
-    let expected = 4.0;
-    assert!(f64::abs(volume - expected) < 1e-8);
 }
 
 #[test]
@@ -563,17 +393,219 @@ fn booles_rule_integrates_a_line_at_f32() {
     assert!(f32::abs(area - expected) < 1e-3, "got {area}");
 }
 
-#[test]
-fn gauss_legendre_integrates_a_cubic_at_f32() {
-    //4x^3 - 3x^2 integrated over [0, 2] is 8
-    let cubic = |x: f32| -> f32 { 4.0 * x * x * x - 3.0 * x * x };
-    let order = 4;
-    let integrator =
-        GaussianSingle::<f32>::from_parameters(order, GaussianQuadratureMethod::GaussLegendre);
+#[cfg(feature = "gauss-legendre")]
+mod gauss_legendre {
+    use super::*;
 
-    let expected = 8.0;
-    let area = integrator.single_integral(&cubic, &[0.0, 2.0]).unwrap();
-    assert!(f32::abs(area - expected) < 1e-2, "got {area}");
+    #[test]
+    fn gaussian_rule_surfaces_an_infinite_integrand() {
+        let infinite_integrand = |_x: f64| -> f64 { f64::INFINITY };
+        let limits = [0.0, 2.0];
+
+        let integrator = GaussianSingle::default();
+        let result = integrator.single_integral(&infinite_integrand, &limits);
+        assert!(result.is_err());
+        assert!(result.unwrap_err() == IntegrateError::NonFinite);
+    }
+
+    #[test]
+    fn gaussian_multi_rejects_out_of_range_index() {
+        let function = |point: &[f64; 2]| point[0] + point[1];
+        let point = [1.0, 2.0];
+        let integrator = GaussianMulti::default();
+        let error = integrator
+            .integrate([2; 1], &function, &[[0.0, 1.0]; 1], &point)
+            .unwrap_err();
+        assert_eq!(error, IntegrateError::IndexOutOfRange);
+    }
+
+    #[test]
+    fn gauss_legendre_integrates_a_cubic_exactly() {
+        // closed form of 4x³ - 3x² is x^4 - x^3
+        let cubic = |x: f64| -> f64 { 4.0 * x * x * x - 3.0 * x * x };
+        let limits = [0.0, 2.0];
+        let order = 4;
+        let integrator =
+            GaussianSingle::from_parameters(order, GaussianQuadratureMethod::GaussLegendre);
+
+        let expected = 8.0;
+        let area = integrator.single_integral(&cubic, &limits).unwrap();
+        assert!(f64::abs(area - expected) < 1e-14);
+    }
+
+    #[test]
+    fn gauss_legendre_takes_partial_integrals_in_each_variable() {
+        let function = |point: &[f64; 3]| -> f64 { 2.0 * point[0] + point[1] * point[2] };
+        let point = [1.0, 2.0, 3.0];
+        let order = 2;
+        let integrator =
+            GaussianMulti::from_parameters(order, GaussianQuadratureMethod::GaussLegendre);
+
+        // closed form in x is x*x + x*y*z
+        let x = 0;
+        let limits = [0.0, 1.0];
+        let expected = 7.0;
+        let partial = integrator
+            .single_partial_integral(&function, x, &limits, &point)
+            .unwrap();
+        assert!(f64::abs(partial - expected) < 1e-14);
+
+        // closed form in y is 2.0*x*y + y*y*z/2.0
+        let y = 1;
+        let limits = [0.0, 2.0];
+        let expected = 10.0;
+        let partial = integrator
+            .single_partial_integral(&function, y, &limits, &point)
+            .unwrap();
+        assert!(f64::abs(partial - expected) < 1e-14);
+
+        // closed form in z is 2.0*x*z + y*z*z/2.0
+        let z = 2;
+        let limits = [0.0, 3.0];
+        let expected = 15.0;
+        let partial = integrator
+            .single_partial_integral(&function, z, &limits, &point)
+            .unwrap();
+        assert!(f64::abs(partial - expected) < 1e-14);
+    }
+
+    #[test]
+    fn gauss_legendre_double_integrates_a_line() {
+        let line = |x: f64| -> f64 { 6.0 * x };
+        let limits = [[0.0, 2.0], [0.0, 2.0]];
+        let order = 2;
+        let integrator =
+            GaussianSingle::from_parameters(order, GaussianQuadratureMethod::GaussLegendre);
+
+        let expected = 24.0;
+        let volume = integrator.double_integral(&line, &limits).unwrap();
+        assert!(f64::abs(volume - expected) < 1e-14);
+    }
+
+    #[test]
+    fn gauss_legendre_rejects_an_order_below_one() {
+        let cubic = |x: f64| -> f64 { 4.0 * x * x * x - 3.0 * x * x };
+        let limits = [0.0, 2.0];
+
+        let integrator =
+            GaussianSingle::from_parameters(0, GaussianQuadratureMethod::GaussLegendre);
+        let result = integrator.single_integral(&cubic, &limits);
+        assert!(result.is_err());
+        assert!(result.unwrap_err() == IntegrateError::QuadratureOrderOutOfRange);
+    }
+
+    #[test]
+    fn gauss_legendre_rejects_an_order_above_thirty() {
+        let cubic = |x: f64| -> f64 { 4.0 * x * x * x - 3.0 * x * x };
+        let limits = [0.0, 2.0];
+
+        let integrator =
+            GaussianSingle::from_parameters(31, GaussianQuadratureMethod::GaussLegendre);
+        let result = integrator.single_integral(&cubic, &limits);
+        assert!(result.is_err());
+        assert!(result.unwrap_err() == IntegrateError::QuadratureOrderOutOfRange);
+    }
+
+    #[test]
+    fn gauss_legendre_integrates_a_cubic_at_f32() {
+        //4x^3 - 3x^2 integrated over [0, 2] is 8
+        let cubic = |x: f32| -> f32 { 4.0 * x * x * x - 3.0 * x * x };
+        let order = 4;
+        let integrator =
+            GaussianSingle::<f32>::from_parameters(order, GaussianQuadratureMethod::GaussLegendre);
+
+        let expected = 8.0;
+        let area = integrator.single_integral(&cubic, &[0.0, 2.0]).unwrap();
+        assert!(f32::abs(area - expected) < 1e-2, "got {area}");
+    }
+}
+
+#[cfg(feature = "gauss-hermite")]
+mod gauss_hermite {
+    use super::*;
+
+    #[test]
+    fn gauss_hermite_integrates_over_the_real_line() {
+        //integrand is x*x; weights carry the e^{-x*x} kernel
+        //∫_{-∞}^∞ x² e^{-x²} dx = √π / 2
+        let square = |x: f64| -> f64 { x * x };
+        let order = 5;
+        let integrator =
+            GaussianSingle::from_parameters(order, GaussianQuadratureMethod::GaussHermite);
+
+        let real_line = [f64::NEG_INFINITY, f64::INFINITY];
+        let area = integrator.single_integral(&square, &real_line).unwrap();
+
+        let expected = core::f64::consts::PI.sqrt() / 2.0;
+        assert!(f64::abs(area - expected) < 1e-10);
+    }
+
+    #[test]
+    fn gauss_hermite_integrates_a_product_over_the_plane() {
+        //∫∫ x² y² e^{-x²} e^{-y²} dx dy = (√π/2)²
+        let product_of_squares =
+            |point: &[f64; 2]| -> f64 { point[0] * point[0] * point[1] * point[1] };
+        let order = 5;
+        let integrator =
+            GaussianMulti::from_parameters(order, GaussianQuadratureMethod::GaussHermite);
+
+        let limits = [
+            [f64::NEG_INFINITY, f64::INFINITY],
+            [f64::NEG_INFINITY, f64::INFINITY],
+        ];
+        let point = [0.0, 0.0];
+        let x = 0;
+        let y = 1;
+        let volume = integrator
+            .integrate([x, y], &product_of_squares, &limits, &point)
+            .unwrap();
+
+        let sqrt_pi_half = core::f64::consts::PI.sqrt() / 2.0;
+        let expected = sqrt_pi_half * sqrt_pi_half;
+        assert!(f64::abs(volume - expected) < 1e-10);
+    }
+}
+
+#[cfg(feature = "gauss-laguerre")]
+mod gauss_laguerre {
+    use super::*;
+
+    #[test]
+    fn gauss_laguerre_integrates_over_the_half_line() {
+        //integrand is x*x; weights carry the e^{-x} kernel
+        //∫_0^∞ x² e^{-x} dx = 2
+        let square = |x: f64| -> f64 { x * x };
+        let order = 5;
+        let integrator =
+            GaussianSingle::from_parameters(order, GaussianQuadratureMethod::GaussLaguerre);
+
+        let half_line = [0.0, f64::INFINITY];
+        let area = integrator.single_integral(&square, &half_line).unwrap();
+
+        let expected = 2.0;
+        assert!(f64::abs(area - expected) < 1e-9);
+    }
+
+    #[test]
+    fn gauss_laguerre_integrates_a_product_over_the_quadrant() {
+        //∫∫ x² y² e^{-x} e^{-y} dx dy = 2 * 2 = 4
+        let product_of_squares =
+            |point: &[f64; 2]| -> f64 { point[0] * point[0] * point[1] * point[1] };
+        let order = 5;
+        let integrator =
+            GaussianMulti::from_parameters(order, GaussianQuadratureMethod::GaussLaguerre);
+
+        let limits = [[0.0, f64::INFINITY], [0.0, f64::INFINITY]];
+        let point = [0.0, 0.0];
+        let x = 0;
+        let y = 1;
+        let volume = integrator
+            .integrate([x, y], &product_of_squares, &limits, &point)
+            .unwrap();
+
+        let expected = 4.0;
+        assert!(f64::abs(volume - expected) < 1e-8);
+    }
 }
 
 fn polynomial_coeffs(degree: usize) -> impl Strategy<Value = Vec<f64>> {
@@ -663,119 +695,151 @@ fn proptest_booles_integration_f64() {
     iterative_integration_proptest(5, integrator);
 }
 
-fn gauss_coeffs() -> impl Strategy<Value = (usize, Vec<f64>)> {
-    (1..10usize).prop_flat_map(|order| (Just(order), polynomial_coeffs(2 * order - 1)))
-}
+#[cfg(any(
+    feature = "gauss-legendre",
+    feature = "gauss-hermite",
+    feature = "gauss-laguerre"
+))]
+mod gauss_proptests {
+    use super::*;
 
-fn double_factorial(value: u64) -> f64 {
-    let mut product = 1.0;
-    let mut term = value;
-    while term > 1 {
-        product *= term as f64;
-        term -= 2;
+    fn gauss_coeffs() -> impl Strategy<Value = (usize, Vec<f64>)> {
+        (1..10usize).prop_flat_map(|order| (Just(order), polynomial_coeffs(2 * order - 1)))
     }
-    product
-}
 
-fn legendre_moment(degree: usize, [lower_limit, upper_limit]: [f64; 2]) -> f64 {
-    (upper_limit.powi(degree as i32 + 1) - lower_limit.powi(degree as i32 + 1))
-        / (degree as f64 + 1.0)
-}
+    #[cfg(feature = "gauss-legendre")]
+    fn legendre_moment(degree: usize, [lower_limit, upper_limit]: [f64; 2]) -> f64 {
+        (upper_limit.powi(degree as i32 + 1) - lower_limit.powi(degree as i32 + 1))
+            / (degree as f64 + 1.0)
+    }
 
-fn hermite_moment(degree: usize) -> f64 {
-    if degree % 2 == 1 {
-        0.0
-    } else {
-        let half_degree = degree / 2;
-        let double_factorial_term = if half_degree == 0 {
-            1.0
+    #[cfg(feature = "gauss-hermite")]
+    fn double_factorial(value: u64) -> f64 {
+        let mut product = 1.0;
+        let mut term = value;
+        while term > 1 {
+            product *= term as f64;
+            term -= 2;
+        }
+        product
+    }
+
+    #[cfg(feature = "gauss-hermite")]
+    fn hermite_moment(degree: usize) -> f64 {
+        if degree % 2 == 1 {
+            0.0
         } else {
-            double_factorial(2 * half_degree as u64 - 1)
-        };
-        double_factorial_term * std::f64::consts::PI.sqrt() / 2f64.powi(half_degree as i32)
+            let half_degree = degree / 2;
+            let double_factorial_term = if half_degree == 0 {
+                1.0
+            } else {
+                double_factorial(2 * half_degree as u64 - 1)
+            };
+            double_factorial_term * std::f64::consts::PI.sqrt() / 2f64.powi(half_degree as i32)
+        }
     }
-}
 
-fn laguerre_moment(degree: usize) -> f64 {
-    (1..=degree as u64)
-        .map(|factor| factor as f64)
-        .product::<f64>()
-        .max(1.0)
-}
+    #[cfg(feature = "gauss-laguerre")]
+    fn laguerre_moment(degree: usize) -> f64 {
+        (1..=degree as u64)
+            .map(|factor| factor as f64)
+            .product::<f64>()
+            .max(1.0)
+    }
 
-fn gauss_closed_form(quadrature: GaussianQuadratureMethod, coeffs: &[f64], limit: [f64; 2]) -> f64 {
-    coeffs
-        .iter()
-        .enumerate()
-        .map(|(degree, coefficient)| {
-            coefficient
-                * match quadrature {
-                    GaussianQuadratureMethod::GaussLegendre => legendre_moment(degree, limit),
-                    GaussianQuadratureMethod::GaussHermite => hermite_moment(degree),
-                    GaussianQuadratureMethod::GaussLaguerre => laguerre_moment(degree),
-                }
-        })
-        .sum()
-}
+    #[allow(unused)]
+    fn gauss_closed_form(
+        quadrature: GaussianQuadratureMethod,
+        coeffs: &[f64],
+        limit: [f64; 2],
+    ) -> f64 {
+        coeffs
+            .iter()
+            .enumerate()
+            .map(|(degree, coefficient)| {
+                coefficient
+                    * match quadrature {
+                        #[cfg(feature = "gauss-legendre")]
+                        GaussianQuadratureMethod::GaussLegendre => legendre_moment(degree, limit),
+                        #[cfg(feature = "gauss-hermite")]
+                        GaussianQuadratureMethod::GaussHermite => hermite_moment(degree),
+                        #[cfg(feature = "gauss-laguerre")]
+                        GaussianQuadratureMethod::GaussLaguerre => laguerre_moment(degree),
+                    }
+            })
+            .sum()
+    }
 
-fn gauss_tolerance(quadrature: GaussianQuadratureMethod, coeffs: &[f64], limit: [f64; 2]) -> f64 {
-    let moment_fn = match quadrature {
-        GaussianQuadratureMethod::GaussLegendre => return tolerance_from_coeffs(coeffs, limit),
-        GaussianQuadratureMethod::GaussHermite => hermite_moment,
-        GaussianQuadratureMethod::GaussLaguerre => laguerre_moment,
-    };
+    #[allow(unused, dead_code)]
+    fn gauss_tolerance(
+        quadrature: GaussianQuadratureMethod,
+        coeffs: &[f64],
+        limit: [f64; 2],
+    ) -> f64 {
+        let moment_fn: fn(usize) -> f64 = match quadrature {
+            #[cfg(feature = "gauss-legendre")]
+            GaussianQuadratureMethod::GaussLegendre => return tolerance_from_coeffs(coeffs, limit),
+            #[cfg(feature = "gauss-hermite")]
+            GaussianQuadratureMethod::GaussHermite => hermite_moment,
+            #[cfg(feature = "gauss-laguerre")]
+            GaussianQuadratureMethod::GaussLaguerre => laguerre_moment,
+        };
 
-    let term_sum_abs: f64 = coeffs
-        .iter()
-        .enumerate()
-        .map(|(degree, &coefficient)| (coefficient * moment_fn(degree)).abs())
-        .sum();
+        let term_sum_abs: f64 = coeffs
+            .iter()
+            .enumerate()
+            .map(|(degree, &coefficient)| (coefficient * moment_fn(degree)).abs())
+            .sum();
 
-    (term_sum_abs).max(1.0) * 1e-9
-}
+        (term_sum_abs).max(1.0) * 1e-9
+    }
 
-fn gauss_integration_proptest(
-    quadrature: GaussianQuadratureMethod,
-    limit_strat: impl Strategy<Value = [f64; 2]>,
-) {
-    proptest!(|(
-        limit in limit_strat,
-        (n, coeffs) in gauss_coeffs(),
-        )| {
+    fn gauss_integration_proptest(
+        quadrature: GaussianQuadratureMethod,
+        limit_strat: impl Strategy<Value = [f64; 2]>,
+    ) {
+        proptest!(|(
+            limit in limit_strat,
+            (n, coeffs) in gauss_coeffs(),
+            )| {
 
-        let function = func_from_coeffs(&coeffs);
-        let closed_form = gauss_closed_form(quadrature, &coeffs, limit);
-        let tolerance = gauss_tolerance(quadrature, &coeffs, limit);
+            let function = func_from_coeffs(&coeffs);
+            let closed_form = gauss_closed_form(quadrature, &coeffs, limit);
+            let tolerance = gauss_tolerance(quadrature, &coeffs, limit);
 
-        let integrator = GaussianSingle::<f64>::from_parameters(
-        n,
-        quadrature,
+            let integrator = GaussianSingle::<f64>::from_parameters(
+            n,
+            quadrature,
+            );
+
+            let area = integrator.single_integral(&function, &limit).unwrap();
+            prop_assert!(f64::abs(area - closed_form) < tolerance);
+        });
+    }
+
+    #[test]
+    #[cfg(feature = "gauss-legendre")]
+    fn proptest_gauss_legendre_integration_f64() {
+        gauss_integration_proptest(GaussianQuadratureMethod::GaussLegendre, integration_limit());
+    }
+
+    #[test]
+    #[cfg(feature = "gauss-hermite")]
+    fn proptest_gauss_hermite_integration_f64() {
+        gauss_integration_proptest(
+            GaussianQuadratureMethod::GaussHermite,
+            Just([-f64::INFINITY, f64::INFINITY]),
         );
+    }
 
-        let area = integrator.single_integral(&function, &limit).unwrap();
-        prop_assert!(f64::abs(area - closed_form) < tolerance);
-    });
-}
-
-#[test]
-fn proptest_gauss_legendre_integration_f64() {
-    gauss_integration_proptest(GaussianQuadratureMethod::GaussLegendre, integration_limit());
-}
-
-#[test]
-fn proptest_gauss_hermite_integration_f64() {
-    gauss_integration_proptest(
-        GaussianQuadratureMethod::GaussHermite,
-        Just([-f64::INFINITY, f64::INFINITY]),
-    );
-}
-
-#[test]
-fn proptest_gauss_laguerre_integration_f64() {
-    gauss_integration_proptest(
-        GaussianQuadratureMethod::GaussLaguerre,
-        Just([0.0, f64::INFINITY]),
-    );
+    #[test]
+    #[cfg(feature = "gauss-laguerre")]
+    fn proptest_gauss_laguerre_integration_f64() {
+        gauss_integration_proptest(
+            GaussianQuadratureMethod::GaussLaguerre,
+            Just([0.0, f64::INFINITY]),
+        );
+    }
 }
 
 #[test]
@@ -804,17 +868,6 @@ fn iterative_multi_rejects_out_of_range_index() {
     let function = |point: &[f64; 2]| point[0] + point[1];
     let point = [1.0, 2.0];
     let integrator = IterativeMulti::default();
-    let error = integrator
-        .integrate([2; 1], &function, &[[0.0, 1.0]; 1], &point)
-        .unwrap_err();
-    assert_eq!(error, IntegrateError::IndexOutOfRange);
-}
-
-#[test]
-fn gaussian_multi_rejects_out_of_range_index() {
-    let function = |point: &[f64; 2]| point[0] + point[1];
-    let point = [1.0, 2.0];
-    let integrator = GaussianMulti::default();
     let error = integrator
         .integrate([2; 1], &function, &[[0.0, 1.0]; 1], &point)
         .unwrap_err();

--- a/tools/embedded-smoke/Cargo.toml
+++ b/tools/embedded-smoke/Cargo.toml
@@ -12,7 +12,7 @@ default = ["full-smoke"]
 full-smoke = []
 
 [dependencies]
-multicalc = { path = "../../crates/multicalc", default-features = false }
+multicalc = { path = "../../crates/multicalc", default-features = false, features = [ "gauss-legendre" ]}
 multicalc-testkit = { path = "../testkit" }
 
 [target.'cfg(target_arch = "arm")'.dependencies]


### PR DESCRIPTION
## What & why

Resolves #226 

Put gaussian tables behind features `gauss-legendre`, `gauss-hermite` and `gauss-laguerre`. The new features are opt-out.

When I run `cargo size` on the lib itself with and without the features, .text remains the same size, but .rmeta is smaller. I wonder if we need an actual program for a proper test.

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
