### PR TITLE
Add Default for spatial types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than `Vector<3, T>`. Each names the same type as the long spelling, so the two mix freely and
   nothing existing has to change. @kmolan
 - `Quaternion::from_two_vectors`, `Quaternion::rotation_angle_to`, and `Quaternion::inverse_transform_point`. (#214)
+- Add `Default` trait implementation for spatial types. @elias-taufer
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than `Vector<3, T>`. Each names the same type as the long spelling, so the two mix freely and
   nothing existing has to change. @kmolan
 - `Quaternion::from_two_vectors`, `Quaternion::rotation_angle_to`, and `Quaternion::inverse_transform_point`. (#214)
-- Add `Default` trait implementation for spatial types. @elias-taufer
+- Add `Default` trait implementation for spatial types `Quaternion`, `SO2`, `SO3`, `SE2`, `SE3`, `Twist`, `Wrench`. @elias-taufer (#244)
 
 ### Fixed
 

--- a/crates/multicalc/src/spatial/lie/se2.rs
+++ b/crates/multicalc/src/spatial/lie/se2.rs
@@ -248,3 +248,21 @@ impl<T: Numeric> Mul for SE2<T> {
         self.compose(rhs)
     }
 }
+
+impl<T: Numeric> Default for SE2<T> {
+    /// Returns the identity as default.
+    ///
+    /// ```
+    /// use multicalc::{SE2, SO2, Vector2D};
+    ///
+    /// let default_se2 = SE2::default();
+    /// let se2 = SE2::from_parts(
+    ///     SO2::from_angle(0.3), Vector2D::new([1.0, 2.0])
+    /// );
+    ///
+    /// assert_eq!(default_se2 * se2, se2);
+    /// ```
+    fn default() -> Self {
+        Self::identity()
+    }
+}

--- a/crates/multicalc/src/spatial/lie/se3.rs
+++ b/crates/multicalc/src/spatial/lie/se3.rs
@@ -212,3 +212,22 @@ impl<T: Numeric> Mul for SE3<T> {
         self.compose(rhs)
     }
 }
+
+impl<T: Numeric> Default for SE3<T> {
+    /// Returns the identity as default.
+    ///
+    /// ```
+    /// use multicalc::{SE3, SO3, Vector3D};
+    ///
+    /// let default_se3 = SE3::default();
+    /// let se3 = SE3::<f64>::from_parts(
+    ///     SO3::from_quaternion(multicalc::Quaternion::from_array([1.0, 2.0, 3.0, 4.0])),
+    ///     Vector3D::new([1.0, 2.0, 3.0])
+    /// );
+    ///
+    /// assert_eq!(se3 * default_se3, se3);
+    /// ```
+    fn default() -> Self {
+        Self::identity()
+    }
+}

--- a/crates/multicalc/src/spatial/lie/so2.rs
+++ b/crates/multicalc/src/spatial/lie/so2.rs
@@ -193,3 +193,18 @@ impl<T: Numeric> Mul for SO2<T> {
         self.compose(rhs)
     }
 }
+impl<T: Numeric> Default for SO2<T> {
+    /// Returns the identity as default.
+    ///
+    /// ```
+    /// use multicalc::SO2;
+    ///
+    /// let default_so2 = SO2::default();
+    /// let so2 = SO2::<f64>::from_angle(0.3);
+    ///
+    /// assert_eq!(so2 * default_so2, so2);
+    /// ```
+    fn default() -> Self {
+        Self::identity()
+    }
+}

--- a/crates/multicalc/src/spatial/lie/so3.rs
+++ b/crates/multicalc/src/spatial/lie/so3.rs
@@ -178,3 +178,19 @@ impl<T: Numeric> Mul for SO3<T> {
         self.compose(rhs)
     }
 }
+
+impl<T: Numeric> Default for SO3<T> {
+    /// Returns the identity as default.
+    ///
+    /// ```
+    /// use multicalc::SO3;
+    ///
+    /// let default_so3 = SO3::default();
+    /// let so3 = SO3::<f64>::from_quaternion(multicalc::Quaternion::from_array([1.0, 2.0, 3.0, 4.0]));
+    ///
+    /// assert_eq!(so3 * default_so3, so3);
+    /// ```
+    fn default() -> Self {
+        Self::identity()
+    }
+}

--- a/crates/multicalc/src/spatial/quaternion.rs
+++ b/crates/multicalc/src/spatial/quaternion.rs
@@ -665,3 +665,19 @@ impl<T: Numeric> Mul for Quaternion<T> {
         }
     }
 }
+
+impl<T: Numeric> Default for Quaternion<T> {
+    /// Returns the identity as default.
+    ///
+    /// ```
+    /// use multicalc::Quaternion;
+    ///
+    /// let default_quaternion = Quaternion::default();
+    /// let quaternion = Quaternion::<f64>::from_array([1.0, 2.0, 3.0, 4.0]);
+    ///
+    /// assert_eq!(quaternion * default_quaternion, quaternion);
+    /// ```
+    fn default() -> Self {
+        Self::identity()
+    }
+}

--- a/crates/multicalc/src/spatial/twist.rs
+++ b/crates/multicalc/src/spatial/twist.rs
@@ -197,3 +197,19 @@ impl<T: Numeric> From<Twist<T>> for Vector6D<T> {
         t.to_vector()
     }
 }
+
+impl<T: Numeric> Default for Twist<T> {
+    /// Returns the zero twist as default.
+    ///
+    /// ```
+    /// use multicalc::Twist;
+    ///
+    /// let default_twist = Twist::default();
+    /// let twist = Twist::<f64>::from_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    ///
+    /// assert_eq!(twist + default_twist, twist);
+    /// ```
+    fn default() -> Self {
+        Self::zeros()
+    }
+}

--- a/crates/multicalc/src/spatial/wrench.rs
+++ b/crates/multicalc/src/spatial/wrench.rs
@@ -195,3 +195,19 @@ impl<T: Numeric> From<Wrench<T>> for Vector6D<T> {
         w.to_vector()
     }
 }
+
+impl<T: Numeric> Default for Wrench<T> {
+    /// Returns the zero wrench as default.
+    ///
+    /// ```
+    /// use multicalc::Wrench;
+    ///
+    /// let default_wrench = Wrench::default();
+    /// let wrench = Wrench::<f64>::from_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    ///
+    /// assert_eq!(wrench + default_wrench, wrench);
+    /// ```
+    fn default() -> Self {
+        Self::zeros()
+    }
+}

--- a/crates/multicalc/tests/suite/spatial/lie.rs
+++ b/crates/multicalc/tests/suite/spatial/lie.rs
@@ -4,7 +4,7 @@
 
 use std::f64::consts::PI;
 
-use multicalc::linear_algebra::{Matrix, Vector, Vector3D, Vector6D};
+use multicalc::linear_algebra::{Matrix, Vector, Vector2D, Vector3D, Vector6D};
 use multicalc::scalar::{Dual, Numeric};
 use multicalc::spatial::{SE2, SE3, SO2, SO3};
 use rand::rngs::StdRng;
@@ -791,4 +791,47 @@ fn near_zero_exp_log_and_jacobians_f32() {
     for i in 0..3 {
         assert!((back_se2_tiny[i] - tiny_se2[i]).abs() < 1e-5);
     }
+}
+
+#[test]
+fn so2_default_is_identity() {
+    let default_so2 = SO2::default();
+    let so2 = SO2::<f64>::from_angle(0.3);
+
+    assert_eq!(default_so2, SO2::identity());
+    assert_eq!(so2 * default_so2, so2);
+    assert_eq!(default_so2 * so2, so2);
+}
+
+#[test]
+fn so3_default_is_identity() {
+    let default_so3 = SO3::default();
+    let so3 = SO3::<f64>::from_quaternion(multicalc::Quaternion::from_array([1.0, 2.0, 3.0, 4.0]));
+
+    assert_eq!(default_so3, SO3::identity());
+    assert_eq!(so3 * default_so3, so3);
+    assert_eq!(default_so3 * so3, so3);
+}
+
+#[test]
+fn se2_default_is_identity() {
+    let default_se2 = SE2::default();
+    let se2 = SE2::from_parts(SO2::from_angle(0.3), Vector2D::new([1.0, 2.0]));
+
+    assert_eq!(default_se2, SE2::identity());
+    assert_eq!(default_se2 * se2, se2);
+    assert_eq!(se2 * default_se2, se2);
+}
+
+#[test]
+fn se3_default_is_identity() {
+    let default_se3 = SE3::default();
+    let se3 = SE3::<f64>::from_parts(
+        SO3::from_quaternion(multicalc::Quaternion::from_array([1.0, 2.0, 3.0, 4.0])),
+        Vector3D::new([1.0, 2.0, 3.0]),
+    );
+
+    assert_eq!(default_se3, SE3::identity());
+    assert_eq!(se3 * default_se3, se3);
+    assert_eq!(default_se3 * se3, se3);
 }

--- a/crates/multicalc/tests/suite/spatial/quaternion.rs
+++ b/crates/multicalc/tests/suite/spatial/quaternion.rs
@@ -767,3 +767,13 @@ fn near_zero_identities_f64() {
 fn near_zero_identities_f32() {
     near_zero_scaled_axis_roundtrip::<f32>();
 }
+
+#[test]
+fn quaternion_default_is_identity() {
+    let default_quaternion = Quaternion::default();
+    let quaternion = Quaternion::<f64>::from_array([1.0, 2.0, 3.0, 4.0]);
+
+    assert_eq!(default_quaternion, Quaternion::identity());
+    assert_eq!(quaternion * default_quaternion, quaternion);
+    assert_eq!(default_quaternion * quaternion, quaternion);
+}

--- a/crates/multicalc/tests/suite/spatial/twist_wrench.rs
+++ b/crates/multicalc/tests/suite/spatial/twist_wrench.rs
@@ -124,3 +124,23 @@ fn ad_transparent_under_dual() {
         assert!(output.deriv.abs() < 1e-12);
     }
 }
+
+#[test]
+fn wrench_default_is_zero() {
+    let wrench = Wrench::<f64>::from_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let zero = Wrench::<f64>::default();
+
+    assert_eq!(zero, Wrench::zeros());
+    assert_eq!(wrench + zero, wrench);
+    assert_eq!(zero + wrench, wrench);
+}
+
+#[test]
+fn twist_default_is_zero() {
+    let twist = Twist::<f64>::from_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let zero = Twist::<f64>::default();
+
+    assert_eq!(zero, Twist::zeros());
+    assert_eq!(twist + zero, twist);
+    assert_eq!(zero + twist, twist);
+}


### PR DESCRIPTION
## What & why

Implemented the `Default` trait for `Quaternion`, `SO2`, `SO3`, `SE2`, `SE3`, `Twist`, and `Wrench` by mapping them to their identities/zeros. This allows these types to be used in generic code requiring `Default`.

Issue #162 didn't mention `FreeJointState` so `Default` was intentionally not implemented for this type.

Closes #162 

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
