### PR TITLE
Feat(Numeric): additional arithmetic methods

### DIFF
--- a/crates/multicalc/src/linear_algebra/test.rs
+++ b/crates/multicalc/src/linear_algebra/test.rs
@@ -354,6 +354,9 @@ impl Numeric for Counted {
     fn is_finite(self) -> bool {
         self.0.is_finite()
     }
+    fn is_infinite(self) -> bool {
+        self.0.is_infinite()
+    }
 }
 
 #[test]

--- a/crates/multicalc/src/linear_algebra/test.rs
+++ b/crates/multicalc/src/linear_algebra/test.rs
@@ -344,6 +344,9 @@ impl Numeric for Counted {
     fn round(self) -> Self {
         Counted(libm::round(self.0))
     }
+    fn trunc(self) -> Self {
+        Counted(libm::trunc(self.0))
+    }
 
     fn is_nan(self) -> bool {
         self.0.is_nan()

--- a/crates/multicalc/src/linear_algebra/test.rs
+++ b/crates/multicalc/src/linear_algebra/test.rs
@@ -284,6 +284,7 @@ impl Numeric for Counted {
     const HALF: Self = Counted(0.5);
     const TEN: Self = Counted(10.0);
     const HUNDRED: Self = Counted(f64::HUNDRED);
+    const ONE_HUNDRED_EIGHTY: Self = Counted(f64::ONE_HUNDRED_EIGHTY);
     const PI: Self = Counted(core::f64::consts::PI);
     const TWO_PI: Self = Counted(core::f64::consts::TAU);
     const EPSILON: Self = Counted(f64::EPSILON);

--- a/crates/multicalc/src/linear_algebra/test.rs
+++ b/crates/multicalc/src/linear_algebra/test.rs
@@ -338,6 +338,9 @@ impl Numeric for Counted {
     fn floor(self) -> Self {
         Counted(libm::floor(self.0))
     }
+    fn ceil(self) -> Self {
+        Counted(libm::ceil(self.0))
+    }
     fn round(self) -> Self {
         Counted(libm::round(self.0))
     }

--- a/crates/multicalc/src/linear_algebra/test.rs
+++ b/crates/multicalc/src/linear_algebra/test.rs
@@ -296,6 +296,8 @@ impl Numeric for Counted {
     const MAX: Self = Counted(f64::MAX);
     const MIN_POSITIVE: Self = Counted(f64::MIN_POSITIVE);
 
+    type Constant = Self;
+
     fn from_f64(value: f64) -> Self {
         Counted(value)
     }
@@ -347,6 +349,9 @@ impl Numeric for Counted {
     }
     fn trunc(self) -> Self {
         Counted(libm::trunc(self.0))
+    }
+    fn clamp(self, min: Self::Constant, max: Self::Constant) -> Self {
+        Counted(self.0.clamp(min.0, max.0))
     }
 
     fn is_nan(self) -> bool {

--- a/crates/multicalc/src/linear_algebra/test.rs
+++ b/crates/multicalc/src/linear_algebra/test.rs
@@ -281,6 +281,7 @@ impl Numeric for Counted {
     const ONE: Self = Counted(1.0);
     const TWO: Self = Counted(2.0);
     const HALF: Self = Counted(0.5);
+    const TEN: Self = Counted(10.0);
     const HUNDRED: Self = Counted(f64::HUNDRED);
     const PI: Self = Counted(core::f64::consts::PI);
     const TWO_PI: Self = Counted(core::f64::consts::TAU);

--- a/crates/multicalc/src/linear_algebra/test.rs
+++ b/crates/multicalc/src/linear_algebra/test.rs
@@ -280,6 +280,7 @@ impl Numeric for Counted {
     const ZERO: Self = Counted(0.0);
     const ONE: Self = Counted(1.0);
     const TWO: Self = Counted(2.0);
+    const THREE: Self = Counted(3.0);
     const HALF: Self = Counted(0.5);
     const TEN: Self = Counted(10.0);
     const HUNDRED: Self = Counted(f64::HUNDRED);
@@ -309,6 +310,9 @@ impl Numeric for Counted {
     }
     fn sqrt(self) -> Self {
         Counted(libm::sqrt(self.0))
+    }
+    fn cbrt(self) -> Self {
+        Counted(libm::cbrt(self.0))
     }
     fn sin(self) -> Self {
         Counted(libm::sin(self.0))

--- a/crates/multicalc/src/scalar/dual.rs
+++ b/crates/multicalc/src/scalar/dual.rs
@@ -292,6 +292,14 @@ impl<T: Numeric> Numeric for Dual<T> {
     }
 
     #[inline]
+    fn log2(self) -> Self {
+        Self {
+            value: self.value.log2(),
+            deriv: self.deriv / self.value / T::TWO.ln(),
+        }
+    }
+
+    #[inline]
     fn log10(self) -> Self {
         Self {
             value: self.value.log10(),

--- a/crates/multicalc/src/scalar/dual.rs
+++ b/crates/multicalc/src/scalar/dual.rs
@@ -168,6 +168,10 @@ impl<T: Numeric> Numeric for Dual<T> {
         value: T::HALF,
         deriv: T::ZERO,
     };
+    const TEN: Self = Dual {
+        value: T::TEN,
+        deriv: T::ZERO,
+    };
     const HUNDRED: Self = Dual {
         value: T::HUNDRED,
         deriv: T::ZERO,
@@ -284,6 +288,14 @@ impl<T: Numeric> Numeric for Dual<T> {
         Dual {
             value: self.value.ln(),
             deriv: self.deriv / self.value,
+        }
+    }
+
+    #[inline]
+    fn log10(self) -> Self {
+        Self {
+            value: self.value.log10(),
+            deriv: self.deriv / self.value / T::TEN.ln(),
         }
     }
 

--- a/crates/multicalc/src/scalar/dual.rs
+++ b/crates/multicalc/src/scalar/dual.rs
@@ -366,6 +366,15 @@ impl<T: Numeric> Numeric for Dual<T> {
         }
     }
 
+    /// Largest integer `>= self`. A step function, so the derivative is zero.
+    #[inline]
+    fn ceil(self) -> Self {
+        Dual {
+            value: self.value.ceil(),
+            deriv: T::ZERO,
+        }
+    }
+
     /// Nearest integer, ties away from zero. A step function, so the derivative is zero.
     #[inline]
     fn round(self) -> Self {

--- a/crates/multicalc/src/scalar/dual.rs
+++ b/crates/multicalc/src/scalar/dual.rs
@@ -405,4 +405,9 @@ impl<T: Numeric> Numeric for Dual<T> {
     fn is_finite(self) -> bool {
         self.value.is_finite()
     }
+    /// Reflects the value only; an infinite value can still carry a finite derivative.
+    #[inline]
+    fn is_infinite(self) -> bool {
+        self.value.is_infinite()
+    }
 }

--- a/crates/multicalc/src/scalar/dual.rs
+++ b/crates/multicalc/src/scalar/dual.rs
@@ -384,6 +384,16 @@ impl<T: Numeric> Numeric for Dual<T> {
         }
     }
 
+    /// Rounds towards zero, effectively removing the decimal part.
+    /// A step function, so the derivative is zero.
+    #[inline]
+    fn trunc(self) -> Self {
+        Dual {
+            value: self.value.trunc(),
+            deriv: T::ZERO,
+        }
+    }
+
     /// Reflects the value only; the derivative is not inspected.
     #[inline]
     fn is_nan(self) -> bool {

--- a/crates/multicalc/src/scalar/dual.rs
+++ b/crates/multicalc/src/scalar/dual.rs
@@ -301,6 +301,14 @@ impl<T: Numeric> Numeric for Dual<T> {
     }
 
     #[inline]
+    fn ln_1p(self) -> Self {
+        Dual {
+            value: self.value.ln_1p(),
+            deriv: self.deriv / (self.value + T::ONE),
+        }
+    }
+
+    #[inline]
     fn log2(self) -> Self {
         Self {
             value: self.value.log2(),

--- a/crates/multicalc/src/scalar/dual.rs
+++ b/crates/multicalc/src/scalar/dual.rs
@@ -164,6 +164,10 @@ impl<T: Numeric> Numeric for Dual<T> {
         value: T::TWO,
         deriv: T::ZERO,
     };
+    const THREE: Self = Dual {
+        value: T::THREE,
+        deriv: T::ZERO,
+    };
     const HALF: Self = Dual {
         value: T::HALF,
         deriv: T::ZERO,
@@ -250,6 +254,15 @@ impl<T: Numeric> Numeric for Dual<T> {
         Dual {
             value: root,
             deriv: self.deriv / (T::TWO * root),
+        }
+    }
+    /// At `value == 0` the derivative is unbounded (`1/(3·0)`) and becomes `inf`/`NaN`.
+    #[inline]
+    fn cbrt(self) -> Self {
+        let root = self.value.cbrt();
+        Dual {
+            value: root,
+            deriv: self.deriv / (T::THREE * root * root),
         }
     }
     #[inline]

--- a/crates/multicalc/src/scalar/dual.rs
+++ b/crates/multicalc/src/scalar/dual.rs
@@ -180,6 +180,10 @@ impl<T: Numeric> Numeric for Dual<T> {
         value: T::HUNDRED,
         deriv: T::ZERO,
     };
+    const ONE_HUNDRED_EIGHTY: Self = Dual {
+        value: T::ONE_HUNDRED_EIGHTY,
+        deriv: T::ZERO,
+    };
     const PI: Self = Dual {
         value: T::PI,
         deriv: T::ZERO,

--- a/crates/multicalc/src/scalar/dual.rs
+++ b/crates/multicalc/src/scalar/dual.rs
@@ -282,6 +282,15 @@ impl<T: Numeric> Numeric for Dual<T> {
             deriv: e * self.deriv,
         }
     }
+    #[inline]
+    fn expm1(self) -> Self {
+        let e = self.value.exp();
+        let em1 = self.value.expm1();
+        Dual {
+            value: em1,
+            deriv: e * self.deriv,
+        }
+    }
     /// Defined for `value > 0`; at `0` the value is `-inf` and the derivative unbounded.
     #[inline]
     fn ln(self) -> Self {

--- a/crates/multicalc/src/scalar/dual.rs
+++ b/crates/multicalc/src/scalar/dual.rs
@@ -225,6 +225,8 @@ impl<T: Numeric> Numeric for Dual<T> {
         deriv: T::ZERO,
     };
 
+    type Constant = T;
+
     #[inline]
     fn from_f64(value: f64) -> Self {
         Dual::constant(T::from_f64(value))
@@ -395,6 +397,27 @@ impl<T: Numeric> Numeric for Dual<T> {
         Dual {
             value: self.value.trunc(),
             deriv: T::ZERO,
+        }
+    }
+
+    /// Restrict a value to the interval `[min, max]`. Inside this range
+    /// it is the identity function, so nothing changes. Outside this range
+    /// it is a constant function (equal to either `min` or `max`), so the derivative
+    /// is equal to zero.
+    #[inline]
+    fn clamp(self, min: Self::Constant, max: Self::Constant) -> Self {
+        if self.value < min {
+            Self {
+                value: min,
+                deriv: T::ZERO,
+            }
+        } else if max < self.value {
+            Self {
+                value: max,
+                deriv: T::ZERO,
+            }
+        } else {
+            self
         }
     }
 

--- a/crates/multicalc/src/scalar/hyper_dual.rs
+++ b/crates/multicalc/src/scalar/hyper_dual.rs
@@ -223,6 +223,12 @@ impl<T: Numeric> Numeric for HyperDual<T> {
         eps2: T::ZERO,
         eps1eps2: T::ZERO,
     };
+    const TEN: Self = HyperDual {
+        real: T::TEN,
+        eps1: T::ZERO,
+        eps2: T::ZERO,
+        eps1eps2: T::ZERO,
+    };
     const HUNDRED: Self = HyperDual {
         real: T::HUNDRED,
         eps1: T::ZERO,
@@ -344,6 +350,16 @@ impl<T: Numeric> Numeric for HyperDual<T> {
             self.real.ln(),
             T::ONE / self.real,
             -(T::ONE / (self.real * self.real)),
+        )
+    }
+
+    #[inline]
+    fn log10(self) -> Self {
+        let ln10 = T::TEN.ln();
+        self.chain(
+            self.real.log10(),
+            T::ONE / self.real / ln10,
+            -(T::ONE / (self.real * self.real)) / ln10,
         )
     }
 

--- a/crates/multicalc/src/scalar/hyper_dual.rs
+++ b/crates/multicalc/src/scalar/hyper_dual.rs
@@ -217,6 +217,12 @@ impl<T: Numeric> Numeric for HyperDual<T> {
         eps2: T::ZERO,
         eps1eps2: T::ZERO,
     };
+    const THREE: Self = HyperDual {
+        real: T::THREE,
+        eps1: T::ZERO,
+        eps2: T::ZERO,
+        eps1eps2: T::ZERO,
+    };
     const HALF: Self = HyperDual {
         real: T::HALF,
         eps1: T::ZERO,
@@ -322,6 +328,14 @@ impl<T: Numeric> Numeric for HyperDual<T> {
         let root = self.real.sqrt();
         let d1 = T::ONE / (T::TWO * root);
         let d2 = -(d1 / (T::TWO * self.real));
+        self.chain(root, d1, d2)
+    }
+    /// At `real == 0` the derivatives are unbounded and become `inf`/`NaN`.
+    #[inline]
+    fn cbrt(self) -> Self {
+        let root = self.real.cbrt();
+        let d1 = T::ONE / (T::THREE * root * root);
+        let d2 = -(T::TWO * d1 * d1 / root);
         self.chain(root, d1, d2)
     }
     #[inline]

--- a/crates/multicalc/src/scalar/hyper_dual.rs
+++ b/crates/multicalc/src/scalar/hyper_dual.rs
@@ -360,6 +360,12 @@ impl<T: Numeric> Numeric for HyperDual<T> {
     }
 
     #[inline]
+    fn ln_1p(self) -> Self {
+        let xp1 = self.real + T::ONE;
+        self.chain(self.real.ln_1p(), T::ONE / xp1, -(T::ONE / (xp1 * xp1)))
+    }
+
+    #[inline]
     fn log2(self) -> Self {
         let ln2 = T::TWO.ln();
         self.chain(

--- a/crates/multicalc/src/scalar/hyper_dual.rs
+++ b/crates/multicalc/src/scalar/hyper_dual.rs
@@ -241,6 +241,12 @@ impl<T: Numeric> Numeric for HyperDual<T> {
         eps2: T::ZERO,
         eps1eps2: T::ZERO,
     };
+    const ONE_HUNDRED_EIGHTY: Self = HyperDual {
+        real: T::ONE_HUNDRED_EIGHTY,
+        eps1: T::ZERO,
+        eps2: T::ZERO,
+        eps1eps2: T::ZERO,
+    };
     const PI: Self = HyperDual {
         real: T::PI,
         eps1: T::ZERO,

--- a/crates/multicalc/src/scalar/hyper_dual.rs
+++ b/crates/multicalc/src/scalar/hyper_dual.rs
@@ -308,6 +308,8 @@ impl<T: Numeric> Numeric for HyperDual<T> {
         eps1eps2: T::ZERO,
     };
 
+    type Constant = T;
+
     #[inline]
     fn from_f64(value: f64) -> Self {
         HyperDual::constant(T::from_f64(value))
@@ -484,6 +486,31 @@ impl<T: Numeric> Numeric for HyperDual<T> {
             eps1: T::ZERO,
             eps2: T::ZERO,
             eps1eps2: T::ZERO,
+        }
+    }
+
+    /// Restrict a value to the interval `[min, max]`. Inside this range
+    /// it is the identity function, so nothing changes. Outside this range
+    /// it is a constant function (equal to either `min` or `max`), so the derivative
+    /// is equal to zero.
+    #[inline]
+    fn clamp(self, min: Self::Constant, max: Self::Constant) -> Self {
+        if self.real < min {
+            HyperDual {
+                real: min,
+                eps1: T::ZERO,
+                eps2: T::ZERO,
+                eps1eps2: T::ZERO,
+            }
+        } else if max < self.real {
+            HyperDual {
+                real: max,
+                eps1: T::ZERO,
+                eps2: T::ZERO,
+                eps1eps2: T::ZERO,
+            }
+        } else {
+            self
         }
     }
 

--- a/crates/multicalc/src/scalar/hyper_dual.rs
+++ b/crates/multicalc/src/scalar/hyper_dual.rs
@@ -354,6 +354,16 @@ impl<T: Numeric> Numeric for HyperDual<T> {
     }
 
     #[inline]
+    fn log2(self) -> Self {
+        let ln2 = T::TWO.ln();
+        self.chain(
+            self.real.log2(),
+            T::ONE / self.real / ln2,
+            -(T::ONE / (self.real * self.real)) / ln2,
+        )
+    }
+
+    #[inline]
     fn log10(self) -> Self {
         let ln10 = T::TEN.ln();
         self.chain(

--- a/crates/multicalc/src/scalar/hyper_dual.rs
+++ b/crates/multicalc/src/scalar/hyper_dual.rs
@@ -447,6 +447,16 @@ impl<T: Numeric> Numeric for HyperDual<T> {
             eps1eps2: T::ZERO,
         }
     }
+    /// Largest integer `>= self`; the derivatives of a step function are zero.
+    #[inline]
+    fn ceil(self) -> Self {
+        HyperDual {
+            real: self.real.ceil(),
+            eps1: T::ZERO,
+            eps2: T::ZERO,
+            eps1eps2: T::ZERO,
+        }
+    }
 
     /// Nearest integer, ties away from zero; the derivatives of a step function are zero.
     #[inline]

--- a/crates/multicalc/src/scalar/hyper_dual.rs
+++ b/crates/multicalc/src/scalar/hyper_dual.rs
@@ -492,4 +492,9 @@ impl<T: Numeric> Numeric for HyperDual<T> {
     fn is_finite(self) -> bool {
         self.real.is_finite()
     }
+    /// Reflects the real part only; an infinite value can still carry a finite derivative.
+    #[inline]
+    fn is_infinite(self) -> bool {
+        self.real.is_infinite()
+    }
 }

--- a/crates/multicalc/src/scalar/hyper_dual.rs
+++ b/crates/multicalc/src/scalar/hyper_dual.rs
@@ -469,6 +469,18 @@ impl<T: Numeric> Numeric for HyperDual<T> {
         }
     }
 
+    /// Rounds towards zero, effectively removing the decimal part.
+    /// A step function, so the derivative is zero.
+    #[inline]
+    fn trunc(self) -> Self {
+        HyperDual {
+            real: self.real.trunc(),
+            eps1: T::ZERO,
+            eps2: T::ZERO,
+            eps1eps2: T::ZERO,
+        }
+    }
+
     /// Reflects the real part only; the derivatives are not inspected.
     #[inline]
     fn is_nan(self) -> bool {

--- a/crates/multicalc/src/scalar/hyper_dual.rs
+++ b/crates/multicalc/src/scalar/hyper_dual.rs
@@ -343,6 +343,12 @@ impl<T: Numeric> Numeric for HyperDual<T> {
         let e = self.real.exp();
         self.chain(e, e, e)
     }
+    #[inline]
+    fn expm1(self) -> Self {
+        let e = self.real.exp();
+        let em1 = self.real.expm1();
+        self.chain(em1, e, e)
+    }
     /// Defined for `real > 0`; at `0` the value is `-inf` and the derivatives unbounded.
     #[inline]
     fn ln(self) -> Self {

--- a/crates/multicalc/src/scalar/jet.rs
+++ b/crates/multicalc/src/scalar/jet.rs
@@ -458,6 +458,13 @@ impl<T: Numeric, const N: usize> Numeric for Jet<T, N> {
         Jet::constant(self.coeffs[0].round())
     }
 
+    /// Rounds towards zero, effectively removing the decimal part.
+    /// A step function, so the derivative is zero.
+    #[inline]
+    fn trunc(self) -> Self {
+        Jet::constant(self.coeffs[0].trunc())
+    }
+
     /// Reflects the value only; the higher coefficients are not inspected.
     #[inline]
     fn is_nan(self) -> bool {

--- a/crates/multicalc/src/scalar/jet.rs
+++ b/crates/multicalc/src/scalar/jet.rs
@@ -226,6 +226,8 @@ impl<T: Numeric, const N: usize> Numeric for Jet<T, N> {
     const MAX: Self = Self::constant(T::MAX);
     const MIN_POSITIVE: Self = Self::constant(T::MIN_POSITIVE);
 
+    type Constant = T;
+
     #[inline]
     fn from_f64(value: f64) -> Self {
         Self::constant(T::from_f64(value))
@@ -464,6 +466,21 @@ impl<T: Numeric, const N: usize> Numeric for Jet<T, N> {
     #[inline]
     fn trunc(self) -> Self {
         Jet::constant(self.coeffs[0].trunc())
+    }
+
+    /// Restrict a value to the interval `[min, max]`. Inside this range
+    /// it is the identity function, so nothing changes. Outside this range
+    /// it is a constant function (equal to either `min` or `max`), so the derivative
+    /// is equal to zero.
+    #[inline]
+    fn clamp(self, min: Self::Constant, max: Self::Constant) -> Self {
+        if self.coeffs[0] < min {
+            Jet::constant(min)
+        } else if max < self.coeffs[0] {
+            Jet::constant(max)
+        } else {
+            self
+        }
     }
 
     /// Reflects the value only; the higher coefficients are not inspected.

--- a/crates/multicalc/src/scalar/jet.rs
+++ b/crates/multicalc/src/scalar/jet.rs
@@ -477,4 +477,10 @@ impl<T: Numeric, const N: usize> Numeric for Jet<T, N> {
     fn is_finite(self) -> bool {
         self.coeffs[0].is_finite()
     }
+
+    /// Reflects the value only; an infinite value can still carry finite coefficients.
+    #[inline]
+    fn is_infinite(self) -> bool {
+        self.coeffs[0].is_infinite()
+    }
 }

--- a/crates/multicalc/src/scalar/jet.rs
+++ b/crates/multicalc/src/scalar/jet.rs
@@ -211,6 +211,7 @@ impl<T: Numeric, const N: usize> Numeric for Jet<T, N> {
     const ONE: Self = Self::constant(T::ONE);
     const TWO: Self = Self::constant(T::TWO);
     const HALF: Self = Self::constant(T::HALF);
+    const TEN: Self = Self::constant(T::TEN);
     const HUNDRED: Self = Self::constant(T::HUNDRED);
     const PI: Self = Self::constant(T::PI);
     const TWO_PI: Self = Self::constant(T::TWO_PI);
@@ -312,6 +313,16 @@ impl<T: Numeric, const N: usize> Numeric for Jet<T, N> {
             u[k] = (v[k] - acc / T::from_usize(k)) / v[0];
         }
         Jet { coeffs: u }
+    }
+
+    #[inline]
+    fn log10(self) -> Self {
+        let ln10 = T::TEN.ln();
+        let Self { mut coeffs } = self.ln();
+        for x in coeffs.iter_mut() {
+            *x /= ln10;
+        }
+        Self { coeffs }
     }
 
     /// Four-quadrant arctangent. `u = atan2(y, x)` satisfies `(x²+y²)·u′ = x·y′ − y·x′`,

--- a/crates/multicalc/src/scalar/jet.rs
+++ b/crates/multicalc/src/scalar/jet.rs
@@ -299,6 +299,14 @@ impl<T: Numeric, const N: usize> Numeric for Jet<T, N> {
         Jet { coeffs: u }
     }
 
+    #[inline]
+    fn expm1(self) -> Self {
+        let em1 = self.coeffs[0].expm1();
+        let Self { mut coeffs } = self.exp();
+        coeffs[0] = em1;
+        Self { coeffs }
+    }
+
     /// `uₖ = (1/v₀)( vₖ − (1/k) Σ_{j=1..k-1} j·uⱼ·v₍ₖ₋ⱼ₎ )`. Defined for `value > 0`.
     #[inline]
     fn ln(self) -> Self {

--- a/crates/multicalc/src/scalar/jet.rs
+++ b/crates/multicalc/src/scalar/jet.rs
@@ -323,6 +323,23 @@ impl<T: Numeric, const N: usize> Numeric for Jet<T, N> {
         Jet { coeffs: u }
     }
 
+    /// `uₖ = (1/(1 + v₀))( vₖ − (1/k) Σ_{j=1..k-1} j·uⱼ·v₍ₖ₋ⱼ₎ )`. Defined for `value > 0`.
+    #[inline]
+    fn ln_1p(self) -> Self {
+        let v = &self.coeffs;
+        let v0 = v[0] + T::ONE;
+        let mut u = [T::ZERO; N];
+        u[0] = v[0].ln_1p();
+        for k in 1..N {
+            let mut acc = T::ZERO;
+            for j in 1..k {
+                acc += T::from_usize(j) * u[j] * v[k - j];
+            }
+            u[k] = (v[k] - acc / T::from_usize(k)) / v0;
+        }
+        Jet { coeffs: u }
+    }
+
     #[inline]
     fn log2(self) -> Self {
         let ln2 = T::TWO.ln();

--- a/crates/multicalc/src/scalar/jet.rs
+++ b/crates/multicalc/src/scalar/jet.rs
@@ -446,6 +446,12 @@ impl<T: Numeric, const N: usize> Numeric for Jet<T, N> {
         Jet::constant(self.coeffs[0].floor())
     }
 
+    /// Largest integer `>= self`; all higher coefficients (the derivatives) are zero.
+    #[inline]
+    fn ceil(self) -> Self {
+        Jet::constant(self.coeffs[0].ceil())
+    }
+
     /// Nearest integer, ties away from zero; all higher coefficients (the derivatives) are zero.
     #[inline]
     fn round(self) -> Self {

--- a/crates/multicalc/src/scalar/jet.rs
+++ b/crates/multicalc/src/scalar/jet.rs
@@ -214,6 +214,7 @@ impl<T: Numeric, const N: usize> Numeric for Jet<T, N> {
     const HALF: Self = Self::constant(T::HALF);
     const TEN: Self = Self::constant(T::TEN);
     const HUNDRED: Self = Self::constant(T::HUNDRED);
+    const ONE_HUNDRED_EIGHTY: Self = Self::constant(T::ONE_HUNDRED_EIGHTY);
     const PI: Self = Self::constant(T::PI);
     const TWO_PI: Self = Self::constant(T::TWO_PI);
     const EPSILON: Self = Self::constant(T::EPSILON);

--- a/crates/multicalc/src/scalar/jet.rs
+++ b/crates/multicalc/src/scalar/jet.rs
@@ -210,6 +210,7 @@ impl<T: Numeric, const N: usize> Numeric for Jet<T, N> {
     const ZERO: Self = Self::constant(T::ZERO);
     const ONE: Self = Self::constant(T::ONE);
     const TWO: Self = Self::constant(T::TWO);
+    const THREE: Self = Self::constant(T::THREE);
     const HALF: Self = Self::constant(T::HALF);
     const TEN: Self = Self::constant(T::TEN);
     const HUNDRED: Self = Self::constant(T::HUNDRED);
@@ -264,6 +265,46 @@ impl<T: Numeric, const N: usize> Numeric for Jet<T, N> {
             }
             u[k] = (v[k] - acc) / (T::TWO * u[0]);
         }
+        Jet { coeffs: u }
+    }
+
+    /// Cube root via Cauchy-product recurrence.
+    ///
+    /// We want `u = v^(1/3)`, i.e. `u·u·u = v` (Cauchy product). Writing `w = u·u`
+    /// (the Cauchy square, built up incrementally alongside `u`), the coefficient of
+    /// `u_k` in `(u·u·u)_k` is `3·u₀²` (it appears once from `i=k, j=l=0` and twice
+    /// more from `w`'s own `u₀·u_k` term), so:
+    ///
+    /// `uₖ = (vₖ − u₀·Σ_{m=1}^{k-1} uₘ·u₍ₖ₋ₘ₎ − Σ_{i=1}^{k-1} uᵢ·w₍ₖ₋ᵢ₎) / (3u₀²)`
+    ///
+    /// Unbounded at `value == 0`.
+    #[inline]
+    fn cbrt(self) -> Self {
+        let v = &self.coeffs;
+        let mut u = [T::ZERO; N];
+        let mut w = [T::ZERO; N]; // w[j] = (u·u)[j] = Σ_{m=0..=j} u[m]·u[j-m]
+
+        u[0] = v[0].cbrt();
+        w[0] = u[0] * u[0];
+        let three_u0_sq = w[0] + T::TWO * w[0];
+
+        for k in 1..N {
+            // p = Σ_{m=1}^{k-1} u[m]·u[k-m]  (the part of w[k] not involving u[0] or u[k])
+            let mut p = T::ZERO;
+            for m in 1..k {
+                p += u[m] * u[k - m];
+            }
+
+            // acc = everything in (u·u·u)[k] except the 3·u0²·u_k term
+            let mut acc = u[0] * p;
+            for i in 1..k {
+                acc += u[i] * w[k - i];
+            }
+
+            u[k] = (v[k] - acc) / three_u0_sq;
+            w[k] = p + T::TWO * u[0] * u[k]; // complete w[k] now that u[k] is known
+        }
+
         Jet { coeffs: u }
     }
 

--- a/crates/multicalc/src/scalar/jet.rs
+++ b/crates/multicalc/src/scalar/jet.rs
@@ -316,6 +316,16 @@ impl<T: Numeric, const N: usize> Numeric for Jet<T, N> {
     }
 
     #[inline]
+    fn log2(self) -> Self {
+        let ln2 = T::TWO.ln();
+        let Self { mut coeffs } = self.ln();
+        for x in coeffs.iter_mut() {
+            *x /= ln2;
+        }
+        Self { coeffs }
+    }
+
+    #[inline]
     fn log10(self) -> Self {
         let ln10 = T::TEN.ln();
         let Self { mut coeffs } = self.ln();

--- a/crates/multicalc/src/scalar/numeric.rs
+++ b/crates/multicalc/src/scalar/numeric.rs
@@ -89,6 +89,14 @@ pub trait Numeric:
     /// Natural logarithm of `self`.
     fn ln(self) -> Self;
 
+    /// Base 2 logarithm.
+    /// The default implementation uses two calls to `ln`.
+    /// More efficient overrides are used for `f32` and `f64`.
+    /// Other implementors of the trait will also likely want to override this method.
+    fn log2(self) -> Self {
+        self.ln() / Self::TWO.ln()
+    }
+
     /// Base 10 logarithm.
     /// The default implementation uses two calls to `ln`.
     /// More efficient overrides are used for `f32` and `f64`.
@@ -337,6 +345,10 @@ impl Numeric for f64 {
         libm::log(self)
     }
     #[inline]
+    fn log2(self) -> Self {
+        libm::log2(self)
+    }
+    #[inline]
     fn log10(self) -> Self {
         libm::log10(self)
     }
@@ -482,6 +494,10 @@ impl Numeric for f32 {
     #[inline]
     fn ln(self) -> Self {
         libm::logf(self)
+    }
+    #[inline]
+    fn log2(self) -> Self {
+        libm::log2f(self)
     }
     #[inline]
     fn log10(self) -> Self {

--- a/crates/multicalc/src/scalar/numeric.rs
+++ b/crates/multicalc/src/scalar/numeric.rs
@@ -32,6 +32,8 @@ pub trait Numeric:
     const TWO: Self;
     /// The value `0.5`.
     const HALF: Self;
+    /// The value `10`.
+    const TEN: Self;
     /// The value `100`.
     const HUNDRED: Self;
     /// Archimedes' constant, π.
@@ -86,6 +88,14 @@ pub trait Numeric:
     fn exp(self) -> Self;
     /// Natural logarithm of `self`.
     fn ln(self) -> Self;
+
+    /// Base 10 logarithm.
+    /// The default implementation uses two calls to `ln`.
+    /// More efficient overrides are used for `f32` and `f64`.
+    /// Other implementors of the trait will also likely want to override this method.
+    fn log10(self) -> Self {
+        self.ln() / Self::TEN.ln()
+    }
 
     /// Four-quadrant arctangent of `self / other`, in radians, taking `self` as the y
     /// coordinate and `other` as the x coordinate. Result in `(-π, π]`.
@@ -272,6 +282,7 @@ impl Numeric for f64 {
     const ONE: Self = 1.0;
     const TWO: Self = 2.0;
     const HALF: Self = 0.5;
+    const TEN: Self = 10.0;
     const HUNDRED: Self = 100.0;
     const PI: Self = core::f64::consts::PI;
     const TWO_PI: Self = core::f64::consts::PI * 2.0;
@@ -324,6 +335,10 @@ impl Numeric for f64 {
     #[inline]
     fn ln(self) -> Self {
         libm::log(self)
+    }
+    #[inline]
+    fn log10(self) -> Self {
+        libm::log10(self)
     }
 
     #[inline]
@@ -414,6 +429,7 @@ impl Numeric for f32 {
     const ONE: Self = 1.0;
     const TWO: Self = 2.0;
     const HALF: Self = 0.5;
+    const TEN: Self = 10.0;
     const HUNDRED: Self = 100.0;
     const PI: Self = core::f32::consts::PI;
     const TWO_PI: Self = core::f32::consts::PI * 2.0;
@@ -466,6 +482,10 @@ impl Numeric for f32 {
     #[inline]
     fn ln(self) -> Self {
         libm::logf(self)
+    }
+    #[inline]
+    fn log10(self) -> Self {
+        libm::log10f(self)
     }
 
     #[inline]

--- a/crates/multicalc/src/scalar/numeric.rs
+++ b/crates/multicalc/src/scalar/numeric.rs
@@ -30,6 +30,8 @@ pub trait Numeric:
     const ONE: Self;
     /// The value `2`.
     const TWO: Self;
+    /// The value `3`.
+    const THREE: Self;
     /// The value `0.5`.
     const HALF: Self;
     /// The value `10`.
@@ -78,6 +80,8 @@ pub trait Numeric:
     fn abs(self) -> Self;
     /// Square root.
     fn sqrt(self) -> Self;
+    /// Cube root.
+    fn cbrt(self) -> Self;
     /// Sine, with `self` in radians.
     fn sin(self) -> Self;
     /// Cosine, with `self` in radians.
@@ -305,6 +309,7 @@ impl Numeric for f64 {
     const ZERO: Self = 0.0;
     const ONE: Self = 1.0;
     const TWO: Self = 2.0;
+    const THREE: Self = 3.0;
     const HALF: Self = 0.5;
     const TEN: Self = 10.0;
     const HUNDRED: Self = 100.0;
@@ -339,6 +344,10 @@ impl Numeric for f64 {
     #[inline]
     fn sqrt(self) -> Self {
         libm::sqrt(self)
+    }
+    #[inline]
+    fn cbrt(self) -> Self {
+        libm::cbrt(self)
     }
     #[inline]
     fn sin(self) -> Self {
@@ -464,6 +473,7 @@ impl Numeric for f32 {
     const ZERO: Self = 0.0;
     const ONE: Self = 1.0;
     const TWO: Self = 2.0;
+    const THREE: Self = 3.0;
     const HALF: Self = 0.5;
     const TEN: Self = 10.0;
     const HUNDRED: Self = 100.0;
@@ -498,6 +508,10 @@ impl Numeric for f32 {
     #[inline]
     fn sqrt(self) -> Self {
         libm::sqrtf(self)
+    }
+    #[inline]
+    fn cbrt(self) -> Self {
+        libm::cbrtf(self)
     }
     #[inline]
     fn sin(self) -> Self {

--- a/crates/multicalc/src/scalar/numeric.rs
+++ b/crates/multicalc/src/scalar/numeric.rs
@@ -88,6 +88,13 @@ pub trait Numeric:
     /// Square root.
     fn sqrt(self) -> Self;
     /// Cube root.
+    ///
+    /// ```
+    /// use multicalc::Numeric;
+    ///
+    /// let x: f64 = 8.0;
+    /// assert_eq!(x.cbrt(), 2.0);
+    /// ```
     fn cbrt(self) -> Self;
     /// Sine, with `self` in radians.
     fn sin(self) -> Self;
@@ -104,6 +111,13 @@ pub trait Numeric:
     /// The default implementation computes the result using `exp` and normal subtraction,
     /// however overrides for `f32` and `f64` use a more accurate primitive.
     /// Other implementors of the trait will also likely want to override this method.
+    ///
+    /// ```
+    /// use multicalc::Numeric;
+    ///
+    /// let x: f64 = 0.0;
+    /// assert_eq!(x.expm1(), 0.0);
+    /// ```
     fn expm1(self) -> Self {
         self.exp() - Self::ONE
     }
@@ -112,6 +126,13 @@ pub trait Numeric:
     /// The default implementation computes the result using `ln` and normal addition,
     /// however overrides for `f32` and `f64` use a more accurate primitive.
     /// Other implementors of the trait will also likely want to override this method.
+    ///
+    /// ```
+    /// use multicalc::Numeric;
+    ///
+    /// let x: f64 = 0.0;
+    /// assert_eq!(x.ln_1p(), 0.0);
+    /// ```
     fn ln_1p(self) -> Self {
         (self + Self::ONE).ln()
     }
@@ -120,6 +141,13 @@ pub trait Numeric:
     /// The default implementation uses two calls to `ln`.
     /// More efficient overrides are used for `f32` and `f64`.
     /// Other implementors of the trait will also likely want to override this method.
+    ///
+    /// ```
+    /// use multicalc::Numeric;
+    ///
+    /// let x: f64 = 2.0;
+    /// assert_eq!(x.log2(), 1.0);
+    /// ```
     fn log2(self) -> Self {
         self.ln() / Self::TWO.ln()
     }
@@ -128,6 +156,13 @@ pub trait Numeric:
     /// The default implementation uses two calls to `ln`.
     /// More efficient overrides are used for `f32` and `f64`.
     /// Other implementors of the trait will also likely want to override this method.
+    ///
+    /// ```
+    /// use multicalc::Numeric;
+    ///
+    /// let x: f64 = 10.0;
+    /// assert_eq!(x.log10(), 1.0);
+    /// ```
     fn log10(self) -> Self {
         self.ln() / Self::TEN.ln()
     }
@@ -149,6 +184,13 @@ pub trait Numeric:
     ///
     /// A step function, so its derivative is zero everywhere it is differentiable; the dual
     /// implementations therefore carry a zero derivative.
+    ///
+    /// ```
+    /// use multicalc::Numeric;
+    ///
+    /// let x: f64 = 2.1;
+    /// assert_eq!(x.ceil(), 3.0);
+    /// ```
     fn ceil(self) -> Self;
 
     /// The nearest integer to `self`, rounding half away from zero.
@@ -161,6 +203,13 @@ pub trait Numeric:
     ///
     /// A step function, so its derivative is zero everywhere it is differentiable; the dual
     /// implementations therefore carry a zero derivative.
+    ///
+    /// ```
+    /// use multicalc::Numeric;
+    ///
+    /// let x: f64 = 2.8;
+    /// assert_eq!(x.trunc(), 2.0);
+    /// ```
     fn trunc(self) -> Self;
 
     /// Restrict a value to the interval `[min, max]` unless it is NaN.

--- a/crates/multicalc/src/scalar/numeric.rs
+++ b/crates/multicalc/src/scalar/numeric.rs
@@ -71,6 +71,11 @@ pub trait Numeric:
     /// ```
     const MIN_POSITIVE: Self;
 
+    /// The type used to represent constant values.
+    /// For normal numbers (such as `f32` and `f64`) this is simply `Self`.
+    /// For auto differentiation types this is the underlying scalar value.
+    type Constant: Numeric;
+
     /// Converts from `f64`, narrowing if necessary. Used for table values and literals.
     fn from_f64(value: f64) -> Self;
     /// Converts from `u64`, e.g. an iteration count.
@@ -157,6 +162,21 @@ pub trait Numeric:
     /// A step function, so its derivative is zero everywhere it is differentiable; the dual
     /// implementations therefore carry a zero derivative.
     fn trunc(self) -> Self;
+
+    /// Restrict a value to the interval `[min, max]` unless it is NaN.
+    ///
+    /// ```
+    /// use multicalc::Numeric;
+    ///
+    /// let min: f64 = -1.0;
+    /// let max: f64 = 2.0;
+    ///
+    /// assert_eq!(Numeric::clamp(17.0, min, max), max);
+    /// assert_eq!(Numeric::clamp(1.0, min, max), 1.0);
+    /// assert_eq!(Numeric::clamp(-1.3, min, max), min);
+    /// assert!(Numeric::clamp(f64::NAN, min, max).is_nan());
+    /// ```
+    fn clamp(self, min: Self::Constant, max: Self::Constant) -> Self;
 
     /// Sign of `self`: `1` for positive, `-1` for negative, `0` at zero.
     ///
@@ -390,6 +410,8 @@ impl Numeric for f64 {
     const MAX: Self = f64::MAX;
     const MIN_POSITIVE: Self = f64::MIN_POSITIVE;
 
+    type Constant = f64;
+
     #[inline]
     fn from_f64(value: f64) -> Self {
         value
@@ -475,6 +497,10 @@ impl Numeric for f64 {
     #[inline]
     fn trunc(self) -> Self {
         libm::trunc(self)
+    }
+    #[inline]
+    fn clamp(self, min: Self::Constant, max: Self::Constant) -> Self {
+        self.clamp(min, max)
     }
     #[inline]
     fn max(self, other: Self) -> Self {
@@ -567,6 +593,8 @@ impl Numeric for f32 {
     const MAX: Self = f32::MAX;
     const MIN_POSITIVE: Self = f32::MIN_POSITIVE;
 
+    type Constant = f32;
+
     #[inline]
     fn from_f64(value: f64) -> Self {
         value as f32
@@ -652,6 +680,10 @@ impl Numeric for f32 {
     #[inline]
     fn trunc(self) -> Self {
         libm::truncf(self)
+    }
+    #[inline]
+    fn clamp(self, min: Self::Constant, max: Self::Constant) -> Self {
+        self.clamp(min, max)
     }
     #[inline]
     fn max(self, other: Self) -> Self {

--- a/crates/multicalc/src/scalar/numeric.rs
+++ b/crates/multicalc/src/scalar/numeric.rs
@@ -97,6 +97,14 @@ pub trait Numeric:
         self.exp() - Self::ONE
     }
 
+    /// Calculates `ln(1 + x)`.
+    /// The default implementation computes the result using `ln` and normal addition,
+    /// however overrides for `f32` and `f64` use a more accurate primitive.
+    /// Other implementors of the trait will also likely want to override this method.
+    fn ln_1p(self) -> Self {
+        (self + Self::ONE).ln()
+    }
+
     /// Base 2 logarithm.
     /// The default implementation uses two calls to `ln`.
     /// More efficient overrides are used for `f32` and `f64`.
@@ -357,6 +365,10 @@ impl Numeric for f64 {
         libm::log(self)
     }
     #[inline]
+    fn ln_1p(self) -> Self {
+        libm::log1p(self)
+    }
+    #[inline]
     fn log2(self) -> Self {
         libm::log2(self)
     }
@@ -510,6 +522,10 @@ impl Numeric for f32 {
     #[inline]
     fn ln(self) -> Self {
         libm::logf(self)
+    }
+    #[inline]
+    fn ln_1p(self) -> Self {
+        libm::log1pf(self)
     }
     #[inline]
     fn log2(self) -> Self {

--- a/crates/multicalc/src/scalar/numeric.rs
+++ b/crates/multicalc/src/scalar/numeric.rs
@@ -138,6 +138,12 @@ pub trait Numeric:
     /// implementations therefore carry a zero derivative.
     fn floor(self) -> Self;
 
+    /// The largest integer greater than or equal to `self`.
+    ///
+    /// A step function, so its derivative is zero everywhere it is differentiable; the dual
+    /// implementations therefore carry a zero derivative.
+    fn ceil(self) -> Self;
+
     /// The nearest integer to `self`, rounding half away from zero.
     ///
     /// A step function, so its derivative is zero everywhere it is differentiable; the dual
@@ -399,6 +405,10 @@ impl Numeric for f64 {
         libm::floor(self)
     }
     #[inline]
+    fn ceil(self) -> Self {
+        libm::ceil(self)
+    }
+    #[inline]
     fn round(self) -> Self {
         libm::round(self)
     }
@@ -561,6 +571,10 @@ impl Numeric for f32 {
     #[inline]
     fn floor(self) -> Self {
         libm::floorf(self)
+    }
+    #[inline]
+    fn ceil(self) -> Self {
+        libm::ceilf(self)
     }
     #[inline]
     fn round(self) -> Self {

--- a/crates/multicalc/src/scalar/numeric.rs
+++ b/crates/multicalc/src/scalar/numeric.rs
@@ -89,6 +89,14 @@ pub trait Numeric:
     /// Natural logarithm of `self`.
     fn ln(self) -> Self;
 
+    /// Calculates `(e^self) - 1`.
+    /// The default implementation computes the result using `exp` and normal subtraction,
+    /// however overrides for `f32` and `f64` use a more accurate primitive.
+    /// Other implementors of the trait will also likely want to override this method.
+    fn expm1(self) -> Self {
+        self.exp() - Self::ONE
+    }
+
     /// Base 2 logarithm.
     /// The default implementation uses two calls to `ln`.
     /// More efficient overrides are used for `f32` and `f64`.
@@ -341,6 +349,10 @@ impl Numeric for f64 {
         libm::exp(self)
     }
     #[inline]
+    fn expm1(self) -> Self {
+        libm::expm1(self)
+    }
+    #[inline]
     fn ln(self) -> Self {
         libm::log(self)
     }
@@ -490,6 +502,10 @@ impl Numeric for f32 {
     #[inline]
     fn exp(self) -> Self {
         libm::expf(self)
+    }
+    #[inline]
+    fn expm1(self) -> Self {
+        libm::expm1f(self)
     }
     #[inline]
     fn ln(self) -> Self {

--- a/crates/multicalc/src/scalar/numeric.rs
+++ b/crates/multicalc/src/scalar/numeric.rs
@@ -192,6 +192,27 @@ pub trait Numeric:
         if self < other { self } else { other }
     }
 
+    /// Folds an angle into a ±π band by subtracting whole turns.
+    ///
+    /// Note: This function can fail to produce a result in the range [-π, π] due to
+    /// loss of precision in floating point numbers.
+    ///
+    /// ```
+    /// use multicalc::Numeric;
+    ///
+    /// // Small-ish number of whole turns removed
+    /// let x: f64 = 0.132 + 10.0 * f64::TWO_PI;
+    /// assert!((x.wrap_to_pi() - 0.132).abs() < 1e-8);
+    ///
+    /// // A very large number fails to be in range due to precision loss.
+    /// let x: f64 = 3.6663732791101215e224;
+    /// assert!(x.wrap_to_pi() < -4e200);
+    /// ```
+    #[inline]
+    fn wrap_to_pi(self) -> Self {
+        self - Self::TWO_PI * (self / Self::TWO_PI).round()
+    }
+
     /// Arctangent, in radians.
     #[inline]
     fn atan(self) -> Self {

--- a/crates/multicalc/src/scalar/numeric.rs
+++ b/crates/multicalc/src/scalar/numeric.rs
@@ -38,6 +38,8 @@ pub trait Numeric:
     const TEN: Self;
     /// The value `100`.
     const HUNDRED: Self;
+    // The value `180`.
+    const ONE_HUNDRED_EIGHTY: Self;
     /// Archimedes' constant, π.
     const PI: Self;
     /// Two times π (the circle constant τ) — one full turn in radians.
@@ -213,6 +215,34 @@ pub trait Numeric:
         self - Self::TWO_PI * (self / Self::TWO_PI).round()
     }
 
+    /// Convert an angle measured in degrees to on measured in radians.
+    ///
+    /// ```
+    /// use multicalc::Numeric;
+    ///
+    /// let deg: f64 = 90.0;
+    /// let rad = deg.to_radians();
+    /// assert!((rad - f64::PI / 2.0).abs() < 1e-12);
+    /// ```
+    #[inline]
+    fn to_radians(self) -> Self {
+        self / Self::ONE_HUNDRED_EIGHTY * Self::PI
+    }
+
+    /// Convert an angle measured in radians to on measured in degrees.
+    ///
+    /// ```
+    /// use multicalc::Numeric;
+    ///
+    /// let rad: f64 = f64::PI / 4.0;
+    /// let deg = rad.to_degrees();
+    /// assert!((deg - 45.0).abs() < 1e-12);
+    /// ```
+    #[inline]
+    fn to_degrees(self) -> Self {
+        self / Self::PI * Self::ONE_HUNDRED_EIGHTY
+    }
+
     /// Arctangent, in radians.
     #[inline]
     fn atan(self) -> Self {
@@ -348,6 +378,7 @@ impl Numeric for f64 {
     const HALF: Self = 0.5;
     const TEN: Self = 10.0;
     const HUNDRED: Self = 100.0;
+    const ONE_HUNDRED_EIGHTY: Self = 180.0;
     const PI: Self = core::f64::consts::PI;
     const TWO_PI: Self = core::f64::consts::PI * 2.0;
     const EPSILON: Self = f64::EPSILON;
@@ -524,6 +555,7 @@ impl Numeric for f32 {
     const HALF: Self = 0.5;
     const TEN: Self = 10.0;
     const HUNDRED: Self = 100.0;
+    const ONE_HUNDRED_EIGHTY: Self = 180.0;
     const PI: Self = core::f32::consts::PI;
     const TWO_PI: Self = core::f32::consts::PI * 2.0;
     const EPSILON: Self = f32::EPSILON;

--- a/crates/multicalc/src/scalar/numeric.rs
+++ b/crates/multicalc/src/scalar/numeric.rs
@@ -150,6 +150,12 @@ pub trait Numeric:
     /// implementations therefore carry a zero derivative.
     fn round(self) -> Self;
 
+    /// The rounds a number toward zero, effectively removing the decimal part.
+    ///
+    /// A step function, so its derivative is zero everywhere it is differentiable; the dual
+    /// implementations therefore carry a zero derivative.
+    fn trunc(self) -> Self;
+
     /// Sign of `self`: `1` for positive, `-1` for negative, `0` at zero.
     ///
     /// The derivative is zero wherever it is defined. This default maps NaN and both zeros to
@@ -413,6 +419,10 @@ impl Numeric for f64 {
         libm::round(self)
     }
     #[inline]
+    fn trunc(self) -> Self {
+        libm::trunc(self)
+    }
+    #[inline]
     fn max(self, other: Self) -> Self {
         libm::fmax(self, other)
     }
@@ -579,6 +589,10 @@ impl Numeric for f32 {
     #[inline]
     fn round(self) -> Self {
         libm::roundf(self)
+    }
+    #[inline]
+    fn trunc(self) -> Self {
+        libm::truncf(self)
     }
     #[inline]
     fn max(self, other: Self) -> Self {

--- a/crates/multicalc/src/scalar/numeric.rs
+++ b/crates/multicalc/src/scalar/numeric.rs
@@ -315,6 +315,8 @@ pub trait Numeric:
     fn is_nan(self) -> bool;
     /// Returns `true` if `self` is neither infinite nor NaN.
     fn is_finite(self) -> bool;
+    /// Returns `true` if `self` is positive or negative infinity and false otherwise.
+    fn is_infinite(self) -> bool;
 }
 
 impl Numeric for f64 {
@@ -487,6 +489,10 @@ impl Numeric for f64 {
     fn is_finite(self) -> bool {
         f64::is_finite(self)
     }
+    #[inline]
+    fn is_infinite(self) -> bool {
+        f64::is_infinite(self)
+    }
 }
 
 impl Numeric for f32 {
@@ -658,5 +664,9 @@ impl Numeric for f32 {
     #[inline]
     fn is_finite(self) -> bool {
         f32::is_finite(self)
+    }
+    #[inline]
+    fn is_infinite(self) -> bool {
+        f32::is_infinite(self)
     }
 }

--- a/crates/multicalc/tests/suite/scalar.rs
+++ b/crates/multicalc/tests/suite/scalar.rs
@@ -29,6 +29,8 @@ mod numeric_methods {
         assert!((Numeric::tanh(1.1_f64) - 1.1_f64.tanh()).abs() < TOL);
         assert!((Numeric::hypot(3.0_f64, 4.0) - 5.0).abs() < TOL);
         assert!((Numeric::powf(2.0_f64, 3.5) - 2.0_f64.powf(3.5)).abs() < TOL);
+        assert!((Numeric::ln(7.0_f64) - 7.0_f64.ln()).abs() < TOL);
+        assert!((Numeric::log10(7.0_f64) - 7.0_f64.log10()).abs() < TOL);
         assert_eq!(Numeric::mul_add(2.0_f64, 3.0, 1.0), 7.0);
         assert_eq!(Numeric::recip(4.0_f64), 0.25);
         assert_eq!(Numeric::signum(-3.0_f64), -1.0);
@@ -178,6 +180,11 @@ mod dual {
         let logarithm = Dual::variable(2.0_f64).ln();
         assert!(f64::abs(logarithm.value - f64::ln(2.0)) < TOL);
         assert!(f64::abs(logarithm.deriv - 0.5) < TOL);
+
+        // f(x) = log10(x), f'(x) = 1/(ln(10) * x); at x = 7 -> log10 7 and 1/(7 * ln(10))
+        let log10 = Dual::variable(7.0).log10();
+        assert!(f64::abs(log10.value - f64::log10(7.0)) < TOL);
+        assert!(f64::abs(log10.deriv - (7.0 * 10.0.ln()).recip()) < TOL);
     }
 
     #[test]
@@ -435,6 +442,23 @@ mod hyper_dual {
     }
 
     #[test]
+    fn log_second_derivative() {
+        // f(x) = ln(x) -> f' = 1/x, f'' = -1/x^2
+        let x = 7.0;
+        let ln = HyperDual::variable(x).ln();
+        assert!(f64::abs(ln.real - f64::ln(x)) < TOL);
+        assert!(f64::abs(ln.eps1 - x.recip()) < TOL);
+        assert!(f64::abs(ln.eps1eps2 - (-1.0 / (x * x))) < TOL);
+
+        // f(x) = log10(x) -> f' = 1/(ln10 * x), f'' = -1/(ln10 * x^2)
+        let ln10 = 10.0.ln();
+        let ln = HyperDual::variable(x).log10();
+        assert!(f64::abs(ln.real - f64::log10(x)) < TOL);
+        assert!(f64::abs(ln.eps1 - x.recip() / ln10) < TOL);
+        assert!(f64::abs(ln.eps1eps2 - (-1.0 / (ln10 * x * x))) < TOL);
+    }
+
+    #[test]
     fn exp_is_its_own_second_derivative() {
         // f(x) = exp(x) is its own derivative to all orders
         let x = 1.3_f64;
@@ -654,6 +678,14 @@ mod jet {
         assert!(f64::abs(logarithm.derivative(1) - 1.0 / x) < TOL);
         assert!(f64::abs(logarithm.derivative(2) - (-1.0 / (x * x))) < TOL);
         assert!(f64::abs(logarithm.derivative(3) - 2.0 / (x * x * x)) < TOL);
+
+        // f(x) = log10(x): f'=1/(ln10 * x), f''=-1/(ln10 * x^2), f'''=2/(ln10 * x^3)
+        let ln10 = 10.0.ln();
+        let logarithm = Jet::<f64, 4>::variable(x).log10();
+        assert!(f64::abs(logarithm.derivative(0) - f64::log10(x)) < TOL);
+        assert!(f64::abs(logarithm.derivative(1) - x.recip() / ln10) < TOL);
+        assert!(f64::abs(logarithm.derivative(2) - (-1.0 / (ln10 * x * x))) < TOL);
+        assert!(f64::abs(logarithm.derivative(3) - 2.0 / (ln10 * x * x * x)) < TOL);
     }
 
     #[test]

--- a/crates/multicalc/tests/suite/scalar.rs
+++ b/crates/multicalc/tests/suite/scalar.rs
@@ -2,6 +2,7 @@
 
 mod numeric_methods {
     use multicalc::scalar::Numeric;
+    use proptest::prelude::*;
 
     const TOL: f64 = 1e-12;
 
@@ -103,6 +104,27 @@ mod numeric_methods {
         // trunc on an exact integer and a negative.
         assert_eq!(Numeric::trunc(-3.0_f64), -3.0);
         assert_eq!(Numeric::trunc(-2.1_f64), -2.0);
+        // -pi wraps to pi
+        assert_eq!((-f64::PI).wrap_to_pi(), f64::PI);
+        // pi wraps to -pi
+        assert_eq!(f64::PI.wrap_to_pi(), -f64::PI);
+        // 2π wraps to 0
+        assert_eq!(f64::TWO_PI.wrap_to_pi(), 0.0);
+    }
+
+    fn check_wrap_to_pi(x: f64) {
+        let y = x.wrap_to_pi();
+        assert!((-f64::PI..=f64::PI).contains(&y));
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        #[test]
+        fn wrap_to_pi(x in (-5_000_f64)..5_000_f64) {
+            check_wrap_to_pi(x);
+        }
+
     }
 }
 

--- a/crates/multicalc/tests/suite/scalar.rs
+++ b/crates/multicalc/tests/suite/scalar.rs
@@ -30,6 +30,7 @@ mod numeric_methods {
         assert!((Numeric::hypot(3.0_f64, 4.0) - 5.0).abs() < TOL);
         assert!((Numeric::powf(2.0_f64, 3.5) - 2.0_f64.powf(3.5)).abs() < TOL);
         assert!((Numeric::ln(7.0_f64) - 7.0_f64.ln()).abs() < TOL);
+        assert!((Numeric::log2(7.0_f64) - 7.0_f64.log2()).abs() < TOL);
         assert!((Numeric::log10(7.0_f64) - 7.0_f64.log10()).abs() < TOL);
         assert_eq!(Numeric::mul_add(2.0_f64, 3.0, 1.0), 7.0);
         assert_eq!(Numeric::recip(4.0_f64), 0.25);
@@ -185,6 +186,11 @@ mod dual {
         let log10 = Dual::variable(7.0).log10();
         assert!(f64::abs(log10.value - f64::log10(7.0)) < TOL);
         assert!(f64::abs(log10.deriv - (7.0 * 10.0.ln()).recip()) < TOL);
+
+        // f(x) = log2(x), f'(x) = 1/(ln(2) * x); at x = 7 -> log2 7 and 1/(7 * ln(2))
+        let log2 = Dual::variable(7.0).log2();
+        assert!(f64::abs(log2.value - f64::log2(7.0)) < TOL);
+        assert!(f64::abs(log2.deriv - (7.0 * 2.0.ln()).recip()) < TOL);
     }
 
     #[test]
@@ -450,12 +456,19 @@ mod hyper_dual {
         assert!(f64::abs(ln.eps1 - x.recip()) < TOL);
         assert!(f64::abs(ln.eps1eps2 - (-1.0 / (x * x))) < TOL);
 
+        // f(x) = log2(x) -> f' = 1/(ln2 * x), f'' = -1/(ln2 * x^2)
+        let ln2 = 2.0.ln();
+        let log2 = HyperDual::variable(x).log2();
+        assert!(f64::abs(log2.real - f64::log2(x)) < TOL);
+        assert!(f64::abs(log2.eps1 - x.recip() / ln2) < TOL);
+        assert!(f64::abs(log2.eps1eps2 - (-1.0 / (ln2 * x * x))) < TOL);
+
         // f(x) = log10(x) -> f' = 1/(ln10 * x), f'' = -1/(ln10 * x^2)
         let ln10 = 10.0.ln();
-        let ln = HyperDual::variable(x).log10();
-        assert!(f64::abs(ln.real - f64::log10(x)) < TOL);
-        assert!(f64::abs(ln.eps1 - x.recip() / ln10) < TOL);
-        assert!(f64::abs(ln.eps1eps2 - (-1.0 / (ln10 * x * x))) < TOL);
+        let log10 = HyperDual::variable(x).log10();
+        assert!(f64::abs(log10.real - f64::log10(x)) < TOL);
+        assert!(f64::abs(log10.eps1 - x.recip() / ln10) < TOL);
+        assert!(f64::abs(log10.eps1eps2 - (-1.0 / (ln10 * x * x))) < TOL);
     }
 
     #[test]
@@ -678,6 +691,14 @@ mod jet {
         assert!(f64::abs(logarithm.derivative(1) - 1.0 / x) < TOL);
         assert!(f64::abs(logarithm.derivative(2) - (-1.0 / (x * x))) < TOL);
         assert!(f64::abs(logarithm.derivative(3) - 2.0 / (x * x * x)) < TOL);
+
+        // f(x) = log2(x): f'=1/(ln2 * x), f''=-1/(ln2 * x^2), f'''=2/(ln2 * x^3)
+        let ln2 = 2.0.ln();
+        let logarithm = Jet::<f64, 4>::variable(x).log2();
+        assert!(f64::abs(logarithm.derivative(0) - f64::log2(x)) < TOL);
+        assert!(f64::abs(logarithm.derivative(1) - x.recip() / ln2) < TOL);
+        assert!(f64::abs(logarithm.derivative(2) - (-1.0 / (ln2 * x * x))) < TOL);
+        assert!(f64::abs(logarithm.derivative(3) - 2.0 / (ln2 * x * x * x)) < TOL);
 
         // f(x) = log10(x): f'=1/(ln10 * x), f''=-1/(ln10 * x^2), f'''=2/(ln10 * x^3)
         let ln10 = 10.0.ln();

--- a/crates/multicalc/tests/suite/scalar.rs
+++ b/crates/multicalc/tests/suite/scalar.rs
@@ -36,6 +36,8 @@ mod numeric_methods {
         assert!((Numeric::log2(7.0_f64) - 7.0_f64.log2()).abs() < TOL);
         assert!((Numeric::log10(7.0_f64) - 7.0_f64.log10()).abs() < TOL);
         assert_eq!(Numeric::mul_add(2.0_f64, 3.0, 1.0), 7.0);
+        assert_eq!(Numeric::sqrt(4.0_f64), 2.0);
+        assert_eq!(Numeric::cbrt(8.0_f64), 2.0);
         assert_eq!(Numeric::recip(4.0_f64), 0.25);
         assert_eq!(Numeric::signum(-3.0_f64), -1.0);
         assert!(Numeric::signum(f64::NAN).is_nan());
@@ -155,6 +157,14 @@ mod dual {
         let root = Dual::variable(4.0_f64).sqrt();
         assert!(f64::abs(root.value - 2.0) < TOL);
         assert!(f64::abs(root.deriv - 0.25) < TOL);
+    }
+
+    #[test]
+    fn cbrt_value_and_derivative() {
+        // f(x) = cbrt(x), f'(x) = 1/(3 x^(2/3)); at x = 27 -> 3 and 1/27
+        let root = Dual::variable(27.0_f64).cbrt();
+        assert!(f64::abs(root.value - 3.0) < TOL);
+        assert!(f64::abs(root.deriv - 1.0 / 27.0) < TOL);
     }
 
     #[test]
@@ -451,6 +461,28 @@ mod hyper_dual {
     }
 
     #[test]
+    fn sqrt_second_derivative() {
+        // f(x) = sqrt(x) -> f' = 1/(2 * sqrt(x)), f'' = -1/(4 * x^3/2)
+        let x = 3.7_f64;
+        let root_x = f64::sqrt(x);
+        let sqrt = HyperDual::variable(x).sqrt();
+        assert!(f64::abs(sqrt.real - root_x) < TOL);
+        assert!(f64::abs(sqrt.eps1 - 0.5 / root_x) < TOL);
+        assert!(f64::abs(sqrt.eps1eps2 - (-0.25 / (x * root_x))) < TOL);
+    }
+
+    #[test]
+    fn cbrt_second_derivative() {
+        // f(x) = cbrt(x) -> f' = 1/(3 * x^2/3), f'' = -2/(9 * x^5/3)
+        let x = 3.7_f64;
+        let root_x = f64::cbrt(x);
+        let cbrt = HyperDual::variable(x).cbrt();
+        assert!(f64::abs(cbrt.real - root_x) < TOL);
+        assert!(f64::abs(cbrt.eps1 - 1.0 / (3.0 * root_x * root_x)) < TOL);
+        assert!(f64::abs(cbrt.eps1eps2 - (-2.0 * root_x / (9.0 * x * x))) < TOL);
+    }
+
+    #[test]
     fn sin_second_derivative() {
         // f(x) = sin(x) -> f' = cos(x), f'' = -sin(x)
         let x = 0.7_f64;
@@ -715,6 +747,18 @@ mod jet {
         assert!(f64::abs(root.derivative(1) - 1.0 / (2.0 * f64::sqrt(x))) < TOL);
         assert!(f64::abs(root.derivative(2) - (-1.0 / (4.0 * x * f64::sqrt(x)))) < TOL);
         assert!(f64::abs(root.derivative(3) - 3.0 / (8.0 * x * x * f64::sqrt(x))) < TOL);
+    }
+
+    #[test]
+    fn cbrt_derivatives_to_third_order() {
+        // f(x) = cbrt(x): f'=1/(3 * x^{2/3}), f''=-2/(9 x^{5/3}), f'''=10/(27 x^{8/3})
+        let x = 1.7_f64;
+        let root_x = f64::cbrt(x);
+        let cbrt = Jet::<f64, 4>::variable(x).cbrt();
+        assert!(f64::abs(cbrt.derivative(0) - root_x) < TOL);
+        assert!(f64::abs(cbrt.derivative(1) - 1.0 / (3.0 * root_x * root_x)) < TOL);
+        assert!(f64::abs(cbrt.derivative(2) - (-2.0 * root_x / (9.0 * x * x))) < TOL);
+        assert!(f64::abs(cbrt.derivative(3) - 10.0 * root_x / (27.0 * x * x * x)) < TOL);
     }
 
     #[test]

--- a/crates/multicalc/tests/suite/scalar.rs
+++ b/crates/multicalc/tests/suite/scalar.rs
@@ -29,6 +29,8 @@ mod numeric_methods {
         assert!((Numeric::tanh(1.1_f64) - 1.1_f64.tanh()).abs() < TOL);
         assert!((Numeric::hypot(3.0_f64, 4.0) - 5.0).abs() < TOL);
         assert!((Numeric::powf(2.0_f64, 3.5) - 2.0_f64.powf(3.5)).abs() < TOL);
+        assert!((Numeric::exp(3.0_f64) - 3.0_f64.exp()).abs() < TOL);
+        assert!((Numeric::expm1(0.03_f64) - 0.03_f64.expm1()).abs() < TOL);
         assert!((Numeric::ln(7.0_f64) - 7.0_f64.ln()).abs() < TOL);
         assert!((Numeric::log2(7.0_f64) - 7.0_f64.log2()).abs() < TOL);
         assert!((Numeric::log10(7.0_f64) - 7.0_f64.log10()).abs() < TOL);
@@ -176,6 +178,11 @@ mod dual {
         let exponential = Dual::variable(x).exp();
         assert!(f64::abs(exponential.value - f64::exp(x)) < TOL);
         assert!(f64::abs(exponential.deriv - f64::exp(x)) < TOL);
+
+        let x = 0.03_f64;
+        let em1 = Dual::variable(x).expm1();
+        assert!(f64::abs(em1.value - f64::expm1(x)) < TOL);
+        assert!(f64::abs(em1.deriv - f64::exp(x)) < TOL);
 
         // f(x) = ln(x), f'(x) = 1/x; at x = 2 -> ln 2 and 0.5
         let logarithm = Dual::variable(2.0_f64).ln();
@@ -479,6 +486,13 @@ mod hyper_dual {
         assert!(f64::abs(exponential.real - f64::exp(x)) < TOL);
         assert!(f64::abs(exponential.eps1 - f64::exp(x)) < TOL);
         assert!(f64::abs(exponential.eps1eps2 - f64::exp(x)) < TOL);
+
+        // f(x) = exp(x) - 1 derivatives match those of exp(x)
+        let x = 0.03_f64;
+        let exponential = HyperDual::variable(x).expm1();
+        assert!(f64::abs(exponential.real - f64::expm1(x)) < TOL);
+        assert!(f64::abs(exponential.eps1 - f64::exp(x)) < TOL);
+        assert!(f64::abs(exponential.eps1eps2 - f64::exp(x)) < TOL);
     }
 
     #[test]
@@ -624,6 +638,13 @@ mod jet {
         let x = 0.4_f64;
         let exponential = Jet::<f64, 6>::variable(x).exp();
         for order in 0..6 {
+            assert!(f64::abs(exponential.derivative(order) - f64::exp(x)) < TOL);
+        }
+
+        // every non-trivial derivative of exp(x) - 1 is exp(x)
+        let exponential = Jet::<f64, 6>::variable(x).expm1();
+        assert!(f64::abs(exponential.derivative(0) - f64::expm1(x)) < TOL);
+        for order in 1..6 {
             assert!(f64::abs(exponential.derivative(order) - f64::exp(x)) < TOL);
         }
     }

--- a/crates/multicalc/tests/suite/scalar.rs
+++ b/crates/multicalc/tests/suite/scalar.rs
@@ -2,6 +2,7 @@
 
 mod numeric_methods {
     use multicalc::scalar::Numeric;
+    use multicalc_testkit::tol::{Tol, assert_scalar_close};
     use proptest::prelude::*;
 
     const TOL: f64 = 1e-12;
@@ -117,6 +118,17 @@ mod numeric_methods {
         assert!((-f64::PI..=f64::PI).contains(&y));
     }
 
+    fn check_deg_rad_roundtrip(x: f64) {
+        // to_degrees and to_radians are inverse functions of each other.
+
+        let tol = Tol {
+            abs: 1e-12,
+            rel: 1e-8,
+        };
+        assert_scalar_close(x.to_degrees().to_radians(), x, tol);
+        assert_scalar_close(x.to_radians().to_degrees(), x, tol);
+    }
+
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(256))]
 
@@ -125,6 +137,10 @@ mod numeric_methods {
             check_wrap_to_pi(x);
         }
 
+        #[test]
+        fn deg_rad_roundtrip(x in prop::num::f64::NORMAL) {
+            check_deg_rad_roundtrip(x);
+        }
     }
 }
 

--- a/crates/multicalc/tests/suite/scalar.rs
+++ b/crates/multicalc/tests/suite/scalar.rs
@@ -30,8 +30,9 @@ mod numeric_methods {
         assert!((Numeric::hypot(3.0_f64, 4.0) - 5.0).abs() < TOL);
         assert!((Numeric::powf(2.0_f64, 3.5) - 2.0_f64.powf(3.5)).abs() < TOL);
         assert!((Numeric::exp(3.0_f64) - 3.0_f64.exp()).abs() < TOL);
-        assert!((Numeric::expm1(0.03_f64) - 0.03_f64.expm1()).abs() < TOL);
+        assert!((Numeric::expm1(0.03_f64) - f64::exp_m1(0.03)).abs() < TOL);
         assert!((Numeric::ln(7.0_f64) - 7.0_f64.ln()).abs() < TOL);
+        assert!((Numeric::ln_1p(0.05_f64) - 0.05_f64.ln_1p()).abs() < TOL);
         assert!((Numeric::log2(7.0_f64) - 7.0_f64.log2()).abs() < TOL);
         assert!((Numeric::log10(7.0_f64) - 7.0_f64.log10()).abs() < TOL);
         assert_eq!(Numeric::mul_add(2.0_f64, 3.0, 1.0), 7.0);
@@ -181,13 +182,18 @@ mod dual {
 
         let x = 0.03_f64;
         let em1 = Dual::variable(x).expm1();
-        assert!(f64::abs(em1.value - f64::expm1(x)) < TOL);
+        assert!(f64::abs(em1.value - f64::exp_m1(x)) < TOL);
         assert!(f64::abs(em1.deriv - f64::exp(x)) < TOL);
 
         // f(x) = ln(x), f'(x) = 1/x; at x = 2 -> ln 2 and 0.5
         let logarithm = Dual::variable(2.0_f64).ln();
         assert!(f64::abs(logarithm.value - f64::ln(2.0)) < TOL);
         assert!(f64::abs(logarithm.deriv - 0.5) < TOL);
+
+        // f(x) = ln(1 + x), f'(x) = 1/(1 + x); at x = -0.2 -> ln 0.8 and 1.25
+        let logarithm = Dual::variable(-0.2_f64).ln_1p();
+        assert!(f64::abs(logarithm.value - f64::ln(0.8)) < TOL);
+        assert!(f64::abs(logarithm.deriv - 1.25) < TOL);
 
         // f(x) = log10(x), f'(x) = 1/(ln(10) * x); at x = 7 -> log10 7 and 1/(7 * ln(10))
         let log10 = Dual::variable(7.0).log10();
@@ -476,6 +482,14 @@ mod hyper_dual {
         assert!(f64::abs(log10.real - f64::log10(x)) < TOL);
         assert!(f64::abs(log10.eps1 - x.recip() / ln10) < TOL);
         assert!(f64::abs(log10.eps1eps2 - (-1.0 / (ln10 * x * x))) < TOL);
+
+        // f(x) = ln(1 + x) -> f' = 1/(1 + x), f'' = -1/(1 + x)^2
+        let x = 0.03;
+        let xp1 = x + 1.0;
+        let ln = HyperDual::variable(x).ln_1p();
+        assert!(f64::abs(ln.real - f64::ln_1p(x)) < TOL);
+        assert!(f64::abs(ln.eps1 - xp1.recip()) < TOL);
+        assert!(f64::abs(ln.eps1eps2 - (-1.0 / (xp1 * xp1))) < TOL);
     }
 
     #[test]
@@ -490,7 +504,7 @@ mod hyper_dual {
         // f(x) = exp(x) - 1 derivatives match those of exp(x)
         let x = 0.03_f64;
         let exponential = HyperDual::variable(x).expm1();
-        assert!(f64::abs(exponential.real - f64::expm1(x)) < TOL);
+        assert!(f64::abs(exponential.real - f64::exp_m1(x)) < TOL);
         assert!(f64::abs(exponential.eps1 - f64::exp(x)) < TOL);
         assert!(f64::abs(exponential.eps1eps2 - f64::exp(x)) < TOL);
     }
@@ -643,7 +657,7 @@ mod jet {
 
         // every non-trivial derivative of exp(x) - 1 is exp(x)
         let exponential = Jet::<f64, 6>::variable(x).expm1();
-        assert!(f64::abs(exponential.derivative(0) - f64::expm1(x)) < TOL);
+        assert!(f64::abs(exponential.derivative(0) - f64::exp_m1(x)) < TOL);
         for order in 1..6 {
             assert!(f64::abs(exponential.derivative(order) - f64::exp(x)) < TOL);
         }
@@ -728,6 +742,15 @@ mod jet {
         assert!(f64::abs(logarithm.derivative(1) - x.recip() / ln10) < TOL);
         assert!(f64::abs(logarithm.derivative(2) - (-1.0 / (ln10 * x * x))) < TOL);
         assert!(f64::abs(logarithm.derivative(3) - 2.0 / (ln10 * x * x * x)) < TOL);
+
+        // f(x) = ln(1 + x): f'=1/(1 + x), f''=-1/(1 + x)^2, f'''=2/(1 + x)^3
+        let x = 0.123_f64;
+        let xp1 = x + 1.0;
+        let logarithm = Jet::<f64, 4>::variable(x).ln_1p();
+        assert!(f64::abs(logarithm.derivative(0) - f64::ln_1p(x)) < TOL);
+        assert!(f64::abs(logarithm.derivative(1) - 1.0 / xp1) < TOL);
+        assert!(f64::abs(logarithm.derivative(2) - (-1.0 / (xp1 * xp1))) < TOL);
+        assert!(f64::abs(logarithm.derivative(3) - 2.0 / (xp1 * xp1 * xp1)) < TOL);
     }
 
     #[test]

--- a/crates/multicalc/tests/suite/scalar.rs
+++ b/crates/multicalc/tests/suite/scalar.rs
@@ -23,6 +23,8 @@ mod numeric_methods {
         assert_eq!(Numeric::floor(-2.1_f64), -3.0);
         assert_eq!(Numeric::ceil(2.7_f64), 3.0);
         assert_eq!(Numeric::ceil(-2.1_f64), -2.0);
+        assert_eq!(Numeric::trunc(2.7_f64), 2.0);
+        assert_eq!(Numeric::trunc(-2.1_f64), -2.0);
         assert!((Numeric::asin(0.5_f64) - 0.5_f64.asin()).abs() < TOL);
         assert!((Numeric::acos(0.5_f64) - 0.5_f64.acos()).abs() < TOL);
         assert!((Numeric::atan(0.7_f64) - 0.7_f64.atan()).abs() < TOL);
@@ -98,6 +100,9 @@ mod numeric_methods {
         // ceil on an exact integer and a negative.
         assert_eq!(Numeric::ceil(-3.0_f64), -3.0);
         assert_eq!(Numeric::ceil(-2.1_f64), -2.0);
+        // trunc on an exact integer and a negative.
+        assert_eq!(Numeric::trunc(-3.0_f64), -3.0);
+        assert_eq!(Numeric::trunc(-2.1_f64), -2.0);
     }
 }
 
@@ -412,6 +417,13 @@ mod dual {
     }
 
     #[test]
+    fn trunc_has_zero_derivative() {
+        let truncated = Dual::variable(2.7_f64).trunc();
+        assert!(f64::abs(truncated.value - 2.0) < TOL);
+        assert!(f64::abs(truncated.deriv) < TOL);
+    }
+
+    #[test]
     fn copysign_carries_the_sign_into_the_derivative() {
         let same = Dual::variable(3.0_f64).copysign(Dual::constant(1.0));
         assert!(f64::abs(same.value - 3.0) < TOL && f64::abs(same.deriv - 1.0) < TOL);
@@ -576,6 +588,14 @@ mod hyper_dual {
         assert!(f64::abs(ceiled.real - 3.0) < TOL);
         assert!(f64::abs(ceiled.eps1) < TOL);
         assert!(f64::abs(ceiled.eps1eps2) < TOL);
+    }
+
+    #[test]
+    fn trunc_has_zero_derivative() {
+        let truncated = HyperDual::variable(2.7_f64).trunc();
+        assert!(f64::abs(truncated.real - 2.0) < TOL);
+        assert!(f64::abs(truncated.eps1) < TOL);
+        assert!(f64::abs(truncated.eps1eps2) < TOL);
     }
 
     #[test]
@@ -906,6 +926,15 @@ mod jet {
         assert!(f64::abs(ceiled.derivative(1)) < TOL);
         assert!(f64::abs(ceiled.derivative(2)) < TOL);
         assert!(f64::abs(ceiled.derivative(3)) < TOL);
+    }
+
+    #[test]
+    fn trunc_has_zero_derivative() {
+        let truncated = Jet::<f64, 4>::variable(2.7_f64).trunc();
+        assert!(f64::abs(truncated.derivative(0) - 2.0) < TOL);
+        assert!(f64::abs(truncated.derivative(1)) < TOL);
+        assert!(f64::abs(truncated.derivative(2)) < TOL);
+        assert!(f64::abs(truncated.derivative(3)) < TOL);
     }
 
     #[test]

--- a/crates/multicalc/tests/suite/scalar.rs
+++ b/crates/multicalc/tests/suite/scalar.rs
@@ -471,6 +471,27 @@ mod dual {
     }
 
     #[test]
+    fn clamp_derivative() {
+        let min: f64 = 0.0;
+        let max: f64 = 1.0;
+
+        // Values above max are replaced with max and zero derivative
+        let clamped = Dual::variable(2.7_f64).clamp(min, max);
+        assert_eq!(clamped.value, max);
+        assert_eq!(clamped.deriv, 0.0);
+
+        // Values below min are replaced with min and zero derivative
+        let clamped = Dual::variable(-2.7_f64).clamp(min, max);
+        assert_eq!(clamped.value, min);
+        assert_eq!(clamped.deriv, 0.0);
+
+        // Values in range are unchanged.
+        let x = Dual::variable(0.5_f64);
+        let clamped = x.clamp(min, max);
+        assert_eq!(x, clamped);
+    }
+
+    #[test]
     fn copysign_carries_the_sign_into_the_derivative() {
         let same = Dual::variable(3.0_f64).copysign(Dual::constant(1.0));
         assert!(f64::abs(same.value - 3.0) < TOL && f64::abs(same.deriv - 1.0) < TOL);
@@ -653,6 +674,29 @@ mod hyper_dual {
         assert!(f64::abs(truncated.real - 2.0) < TOL);
         assert!(f64::abs(truncated.eps1) < TOL);
         assert!(f64::abs(truncated.eps1eps2) < TOL);
+    }
+
+    #[test]
+    fn clamp_derivative() {
+        let min: f64 = 0.0;
+        let max: f64 = 1.0;
+
+        // Values above max are replaced with max and zero derivative
+        let clamped = HyperDual::variable(2.7_f64).clamp(min, max);
+        assert_eq!(clamped.real, max);
+        assert_eq!(clamped.eps1, 0.0);
+        assert_eq!(clamped.eps1eps2, 0.0);
+
+        // Values below min are replaced with min and zero derivative
+        let clamped = HyperDual::variable(-2.7_f64).clamp(min, max);
+        assert_eq!(clamped.real, min);
+        assert_eq!(clamped.eps1, 0.0);
+        assert_eq!(clamped.eps1eps2, 0.0);
+
+        // Values in range are unchanged.
+        let x = HyperDual::variable(0.5_f64);
+        let clamped = x.clamp(min, max);
+        assert_eq!(x, clamped);
     }
 
     #[test]
@@ -1003,6 +1047,31 @@ mod jet {
         assert!(f64::abs(truncated.derivative(1)) < TOL);
         assert!(f64::abs(truncated.derivative(2)) < TOL);
         assert!(f64::abs(truncated.derivative(3)) < TOL);
+    }
+
+    #[test]
+    fn clamp_derivative() {
+        let min: f64 = 0.0;
+        let max: f64 = 1.0;
+
+        // Values above max are replaced with max and zero derivative
+        let clamped = Jet::<f64, 4>::variable(2.7_f64).clamp(min, max);
+        assert_eq!(clamped.derivative(0), max);
+        for i in 1..4 {
+            assert_eq!(clamped.derivative(i), 0.0);
+        }
+
+        // Values below min are replaced with min and zero derivative
+        let clamped = Jet::<f64, 4>::variable(-2.7_f64).clamp(min, max);
+        assert_eq!(clamped.derivative(0), min);
+        for i in 1..4 {
+            assert_eq!(clamped.derivative(i), 0.0);
+        }
+
+        // Values in range are unchanged.
+        let x = Jet::<f64, 4>::variable(0.5_f64);
+        let clamped = x.clamp(min, max);
+        assert_eq!(x, clamped);
     }
 
     #[test]

--- a/crates/multicalc/tests/suite/scalar.rs
+++ b/crates/multicalc/tests/suite/scalar.rs
@@ -227,6 +227,15 @@ mod dual {
     }
 
     #[test]
+    fn test_infinite_value_finite_derivative() {
+        // In the limit x -> INFINITY, ln(x) -> INFINITY while d/dx (ln x) -> 0.
+        let x = f64::INFINITY;
+        let y = Dual::variable(x).ln();
+        assert!(y.is_infinite());
+        assert!(y.deriv.is_finite());
+    }
+
+    #[test]
     fn the_chain_rule_holds_through_exp_of_sin() {
         // f(x) = exp(sin(x)), f'(x) = cos(x) exp(sin(x))
         let x = 0.6_f64;
@@ -549,6 +558,16 @@ mod hyper_dual {
     }
 
     #[test]
+    fn test_infinite_value_finite_derivative() {
+        // In the limit x -> INFINITY, ln(x) -> INFINITY while d/dx (ln x) -> 0.
+        let x = f64::INFINITY;
+        let y = HyperDual::variable(x).ln();
+        assert!(y.is_infinite());
+        assert!(y.eps1.is_finite());
+        assert!(y.eps1eps2.is_finite());
+    }
+
+    #[test]
     fn exp_is_its_own_second_derivative() {
         // f(x) = exp(x) is its own derivative to all orders
         let x = 1.3_f64;
@@ -843,6 +862,17 @@ mod jet {
         assert!(f64::abs(logarithm.derivative(1) - 1.0 / xp1) < TOL);
         assert!(f64::abs(logarithm.derivative(2) - (-1.0 / (xp1 * xp1))) < TOL);
         assert!(f64::abs(logarithm.derivative(3) - 2.0 / (xp1 * xp1 * xp1)) < TOL);
+    }
+
+    #[test]
+    fn test_infinite_value_finite_derivative() {
+        // In the limit x -> INFINITY, ln(x) -> INFINITY while d/dx (ln x) -> 0.
+        let x = f64::INFINITY;
+        let y = Jet::<f64, 4>::variable(x).ln();
+        assert!(y.is_infinite());
+        assert!(y.derivative(1).is_finite());
+        assert!(y.derivative(2).is_finite());
+        assert!(y.derivative(3).is_finite());
     }
 
     #[test]

--- a/crates/multicalc/tests/suite/scalar.rs
+++ b/crates/multicalc/tests/suite/scalar.rs
@@ -21,6 +21,8 @@ mod numeric_methods {
         assert_eq!(Numeric::copysign(-3.0_f64, 1.0), 3.0);
         assert_eq!(Numeric::floor(2.7_f64), 2.0);
         assert_eq!(Numeric::floor(-2.1_f64), -3.0);
+        assert_eq!(Numeric::ceil(2.7_f64), 3.0);
+        assert_eq!(Numeric::ceil(-2.1_f64), -2.0);
         assert!((Numeric::asin(0.5_f64) - 0.5_f64.asin()).abs() < TOL);
         assert!((Numeric::acos(0.5_f64) - 0.5_f64.acos()).abs() < TOL);
         assert!((Numeric::atan(0.7_f64) - 0.7_f64.atan()).abs() < TOL);
@@ -93,6 +95,9 @@ mod numeric_methods {
         // floor on an exact integer and a negative.
         assert_eq!(Numeric::floor(-3.0_f64), -3.0);
         assert_eq!(Numeric::floor(-2.1_f64), -3.0);
+        // ceil on an exact integer and a negative.
+        assert_eq!(Numeric::ceil(-3.0_f64), -3.0);
+        assert_eq!(Numeric::ceil(-2.1_f64), -2.0);
     }
 }
 
@@ -400,6 +405,13 @@ mod dual {
     }
 
     #[test]
+    fn ceil_has_zero_derivative() {
+        let ceiled = Dual::variable(2.7_f64).ceil();
+        assert!(f64::abs(ceiled.value - 3.0) < TOL);
+        assert!(f64::abs(ceiled.deriv) < TOL);
+    }
+
+    #[test]
     fn copysign_carries_the_sign_into_the_derivative() {
         let same = Dual::variable(3.0_f64).copysign(Dual::constant(1.0));
         assert!(f64::abs(same.value - 3.0) < TOL && f64::abs(same.deriv - 1.0) < TOL);
@@ -548,6 +560,22 @@ mod hyper_dual {
         assert!(f64::abs(reciprocal.real - 0.5) < TOL);
         assert!(f64::abs(reciprocal.eps1 - (-0.25)) < TOL);
         assert!(f64::abs(reciprocal.eps1eps2 - 0.25) < TOL);
+    }
+
+    #[test]
+    fn floor_has_zero_derivative() {
+        let floored = HyperDual::variable(2.7_f64).floor();
+        assert!(f64::abs(floored.real - 2.0) < TOL);
+        assert!(f64::abs(floored.eps1) < TOL);
+        assert!(f64::abs(floored.eps1eps2) < TOL);
+    }
+
+    #[test]
+    fn ceil_has_zero_derivative() {
+        let ceiled = HyperDual::variable(2.7_f64).ceil();
+        assert!(f64::abs(ceiled.real - 3.0) < TOL);
+        assert!(f64::abs(ceiled.eps1) < TOL);
+        assert!(f64::abs(ceiled.eps1eps2) < TOL);
     }
 
     #[test]
@@ -860,6 +888,24 @@ mod jet {
         for order in 1..4 {
             assert!(f64::abs(constant.coeffs[order]) < TOL);
         }
+    }
+
+    #[test]
+    fn floor_has_zero_derivative() {
+        let floored = Jet::<f64, 4>::variable(2.7_f64).floor();
+        assert!(f64::abs(floored.derivative(0) - 2.0) < TOL);
+        assert!(f64::abs(floored.derivative(1)) < TOL);
+        assert!(f64::abs(floored.derivative(2)) < TOL);
+        assert!(f64::abs(floored.derivative(3)) < TOL);
+    }
+
+    #[test]
+    fn ceil_has_zero_derivative() {
+        let ceiled = Jet::<f64, 4>::variable(2.7_f64).ceil();
+        assert!(f64::abs(ceiled.derivative(0) - 3.0) < TOL);
+        assert!(f64::abs(ceiled.derivative(1)) < TOL);
+        assert!(f64::abs(ceiled.derivative(2)) < TOL);
+        assert!(f64::abs(ceiled.derivative(3)) < TOL);
     }
 
     #[test]

--- a/demos/examples/basics/estimation.rs
+++ b/demos/examples/basics/estimation.rs
@@ -84,11 +84,6 @@ impl VectorFn<1, 1> for Compass {
     }
 }
 
-/// Folds an angle into a ±π band by subtracting whole turns.
-fn wrap_to_pi<T: Numeric>(angle: T) -> T {
-    angle - T::TWO_PI * (angle / T::TWO_PI).round()
-}
-
 /// The beacons a robot ranges against to find itself, at the corners of a 10 m square room.
 /// Example taken from https://github.com/destenson/kalman-filter-rs/blob/master/examples/particle_filter_robot.rs
 #[cfg(feature = "alloc")]
@@ -456,7 +451,7 @@ fn main() -> Result<(), CalcError> {
         compass_noise,
     );
     let predicted = Compass.eval(wrapped.state().as_array())[0];
-    let residual = wrap_to_pi(measurement - predicted);
+    let residual = (measurement - predicted).wrap_to_pi();
     wrapped.update_with_residual(&Compass, Vector::new([residual]))?;
 
     println!("\nAngle wrapping near ±π (true heading error ≈ 0.08 rad)");

--- a/demos/src/sim/kalman_filter_models.rs
+++ b/demos/src/sim/kalman_filter_models.rs
@@ -33,7 +33,7 @@ impl VectorFn<5, 5> for CoordinatedTurnModel {
             )
         };
         // Fold the output heading back into range by subtracting whole turns.
-        let wrapped = next_heading - S::TWO_PI * (next_heading / S::TWO_PI).round();
+        let wrapped = next_heading.wrap_to_pi();
         [next_x, next_y, wrapped, speed, turn_rate]
     }
 }

--- a/demos/src/sim/particle_filter_localizer.rs
+++ b/demos/src/sim/particle_filter_localizer.rs
@@ -173,7 +173,7 @@ impl VectorFn<3, 3> for LocalizationMotion {
         let heading = state[2];
         let next = heading + S::from_f64(self.delta_heading);
         let step = S::from_f64(self.delta_arc_length);
-        let wrapped = next - S::TWO_PI * (next / S::TWO_PI).round();
+        let wrapped = next.wrap_to_pi();
         [
             state[0] + step * heading.cos(),
             state[1] + step * heading.sin(),

--- a/tools/embedded-smoke/src/checks.rs
+++ b/tools/embedded-smoke/src/checks.rs
@@ -296,7 +296,7 @@ impl VectorFn<5, 5> for CoordinatedTurn {
                 y + speed * heading.sin() * dt,
             )
         };
-        let wrapped = next_heading - S::TWO_PI * (next_heading / S::TWO_PI).round();
+        let wrapped = next_heading.wrap_to_pi();
         [next_x, next_y, wrapped, speed, turn_rate]
     }
 }

--- a/tools/testkit/src/problems.rs
+++ b/tools/testkit/src/problems.rs
@@ -311,7 +311,7 @@ impl VectorFn<5, 5> for CoordinatedTurn {
                 y + speed * heading.sin() * dt,
             )
         };
-        let wrapped = next_heading - S::TWO_PI * (next_heading / S::TWO_PI).round();
+        let wrapped = next_heading.wrap_to_pi();
         [next_x, next_y, wrapped, speed, turn_rate]
     }
 }


### PR DESCRIPTION
## What & why

Closes #215 

Adds the following new functions to `Numeric` along with implementations on the auto differentiation types and tests:

- Cube root (cbrt)
- ceil
- trunc
- clamp
- expm1 (e^x - 1)
- ln_1p (ln(x + 1)
- logarithm base 2 (log2)
- logarithm base 10 (log10)
- wrap_to_pi (restrict to [-pi, pi])
- to_radians / to_degrees (angle conversion functions)
- is_infinite

These functions will make it more convenient to implement certain algorithms (some examples now use `wrap_to_pi` for instance).

Note: `clamp` introduced a new associated type to the trait as well because I thought the type signature `fn clamp(self, min: Self::Constant, max: Self::Constant) -> Self` made more sense than `fn clamp(self, min: Self, max: Self) -> Self` would on the auto diff types.

No change to CHANGELOG.md here pending a decision on #237 

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
