### PR TITLE
Remove `residual` field from SolveError::DidNotConverge

### DIFF
--- a/crates/multicalc/src/error.rs
+++ b/crates/multicalc/src/error.rs
@@ -64,8 +64,6 @@ pub enum SolveError {
     DidNotConverge {
         /// Iterations (or evaluations) spent before giving up.
         iters: usize,
-        /// Residual norm at the final iterate.
-        residual: f64,
     },
     /// A residual or Jacobian value was infinite or NaN.
     NonFinite,
@@ -294,10 +292,10 @@ impl core::fmt::Display for IntegrateError {
 impl core::fmt::Display for SolveError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            SolveError::DidNotConverge { iters, residual } => {
+            SolveError::DidNotConverge { iters } => {
                 write!(
                     f,
-                    "solver did not converge after {iters} iterations (residual {residual})"
+                    "solver did not converge after {iters} iterations"
                 )
             }
             SolveError::NonFinite => {

--- a/crates/multicalc/src/error.rs
+++ b/crates/multicalc/src/error.rs
@@ -293,10 +293,7 @@ impl core::fmt::Display for SolveError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             SolveError::DidNotConverge { iters } => {
-                write!(
-                    f,
-                    "solver did not converge after {iters} iterations"
-                )
+                write!(f, "solver did not converge after {iters} iterations")
             }
             SolveError::NonFinite => {
                 f.write_str("residual or Jacobian contained a non-finite value")

--- a/crates/multicalc/src/optimization/gauss_newton.rs
+++ b/crates/multicalc/src/optimization/gauss_newton.rs
@@ -224,8 +224,6 @@ impl<D: DerivatorMultiVariable> GaussNewton<D> {
             }
         }
 
-        Err(SolveError::DidNotConverge {
-            iters: evaluations,
-        })
+        Err(SolveError::DidNotConverge { iters: evaluations })
     }
 }

--- a/crates/multicalc/src/optimization/gauss_newton.rs
+++ b/crates/multicalc/src/optimization/gauss_newton.rs
@@ -7,7 +7,7 @@ use crate::numerical_derivative::AutoDiffMulti;
 use crate::numerical_derivative::DerivatorMultiVariable;
 use crate::numerical_derivative::Jacobian;
 use crate::optimization::{MinimizationReport, TerminationReason, is_finite, report};
-use crate::scalar::{Numeric, Primal, VectorFn};
+use crate::scalar::{Numeric, VectorFn};
 
 /// Maximum step halvings per iteration when backtracking is enabled.
 const MAX_BACKTRACK: usize = 20;
@@ -133,7 +133,6 @@ impl<D: DerivatorMultiVariable> GaussNewton<D> {
     ) -> Result<MinimizationReport<N, D::Scalar>, SolveError>
     where
         D: Clone,
-        D::Scalar: Primal,
         F: VectorFn<N, M>,
     {
         let zero = D::Scalar::ZERO;
@@ -227,7 +226,6 @@ impl<D: DerivatorMultiVariable> GaussNewton<D> {
 
         Err(SolveError::DidNotConverge {
             iters: evaluations,
-            residual: fnorm.to_f64(),
         })
     }
 }

--- a/crates/multicalc/src/optimization/levenberg_marquardt.rs
+++ b/crates/multicalc/src/optimization/levenberg_marquardt.rs
@@ -8,7 +8,7 @@ use crate::numerical_derivative::DerivatorMultiVariable;
 use crate::numerical_derivative::Jacobian;
 use crate::optimization::trust_region::determine_lambda_and_parameter_update;
 use crate::optimization::{MinimizationReport, TerminationReason, is_finite, report};
-use crate::scalar::{Numeric, Primal, VectorFn};
+use crate::scalar::{Numeric, VectorFn};
 
 /// Safety cap on the trust-region retries within one outer iteration; the `xtol` test ends the
 /// retries long before this on any real problem.
@@ -137,7 +137,6 @@ impl<D: DerivatorMultiVariable> LevenbergMarquardt<D> {
     ) -> Result<MinimizationReport<N, D::Scalar>, SolveError>
     where
         D: Clone,
-        D::Scalar: Primal,
         F: VectorFn<N, M>,
     {
         let zero = D::Scalar::ZERO;
@@ -283,7 +282,6 @@ impl<D: DerivatorMultiVariable> LevenbergMarquardt<D> {
 
         Err(SolveError::DidNotConverge {
             iters: evaluations,
-            residual: fnorm.to_f64(),
         })
     }
 }

--- a/crates/multicalc/src/optimization/levenberg_marquardt.rs
+++ b/crates/multicalc/src/optimization/levenberg_marquardt.rs
@@ -280,8 +280,6 @@ impl<D: DerivatorMultiVariable> LevenbergMarquardt<D> {
             }
         }
 
-        Err(SolveError::DidNotConverge {
-            iters: evaluations,
-        })
+        Err(SolveError::DidNotConverge { iters: evaluations })
     }
 }

--- a/crates/multicalc/src/root_finding/bisection.rs
+++ b/crates/multicalc/src/root_finding/bisection.rs
@@ -83,8 +83,7 @@ impl<T: Numeric> Bisection<T> {
     /// [`NonFinite`](SolveError::NonFinite) if `f` returns a non-finite value,
     /// [`InvalidBracket`](SolveError::InvalidBracket) if `f(a)` and `f(b)` share a sign, or
     /// [`DidNotConverge`](SolveError::DidNotConverge) if the budget is exhausted.
-    pub fn solve<F: ScalarFn>(&self, f: &F, a: T, b: T) -> Result<RootReport<T>, SolveError>
-    {
+    pub fn solve<F: ScalarFn>(&self, f: &F, a: T, b: T) -> Result<RootReport<T>, SolveError> {
         let fa = f.eval(a);
         let fb = f.eval(b);
 

--- a/crates/multicalc/src/root_finding/bisection.rs
+++ b/crates/multicalc/src/root_finding/bisection.rs
@@ -2,7 +2,7 @@
 
 use crate::error::SolveError;
 use crate::root_finding::{RootReport, RootTermination, same_sign};
-use crate::scalar::{Numeric, Primal, ScalarFn};
+use crate::scalar::{Numeric, ScalarFn};
 
 /// A bracketed scalar root solver using bisection.
 ///
@@ -84,8 +84,6 @@ impl<T: Numeric> Bisection<T> {
     /// [`InvalidBracket`](SolveError::InvalidBracket) if `f(a)` and `f(b)` share a sign, or
     /// [`DidNotConverge`](SolveError::DidNotConverge) if the budget is exhausted.
     pub fn solve<F: ScalarFn>(&self, f: &F, a: T, b: T) -> Result<RootReport<T>, SolveError>
-    where
-        T: Primal,
     {
         let fa = f.eval(a);
         let fb = f.eval(b);
@@ -116,7 +114,6 @@ impl<T: Numeric> Bisection<T> {
         // Order so lo < hi numerically; the midpoint formula lo + (hi - lo)/2 then
         // always lands strictly inside the interval.
         let (mut lo, mut flo, mut hi) = if a <= b { (a, fa, b) } else { (b, fb, a) };
-        let mut last_residual = fa;
 
         for iter in 1..=self.max_iterations {
             let mid = lo + (hi - lo) * T::HALF;
@@ -124,7 +121,6 @@ impl<T: Numeric> Bisection<T> {
             if !fmid.is_finite() {
                 return Err(SolveError::NonFinite);
             }
-            last_residual = fmid;
             if fmid.abs() <= self.ftol {
                 return Ok(RootReport {
                     root: mid,
@@ -153,7 +149,6 @@ impl<T: Numeric> Bisection<T> {
 
         Err(SolveError::DidNotConverge {
             iters: self.max_iterations,
-            residual: last_residual.abs().to_f64(),
         })
     }
 }

--- a/crates/multicalc/src/root_finding/newton.rs
+++ b/crates/multicalc/src/root_finding/newton.rs
@@ -4,7 +4,7 @@ use crate::error::{LinalgError, SolveError};
 use crate::numerical_derivative::AutoDiffSingle;
 use crate::numerical_derivative::DerivatorSingleVariable;
 use crate::root_finding::{RootReport, RootTermination};
-use crate::scalar::{Numeric, Primal, ScalarFn};
+use crate::scalar::{Numeric, ScalarFn};
 
 /// Maximum step halvings per iteration when backtracking is enabled.
 const MAX_BACKTRACK: usize = 20;
@@ -126,8 +126,6 @@ impl<D: DerivatorSingleVariable> Newton<D> {
         f: &F,
         x0: D::Scalar,
     ) -> Result<RootReport<D::Scalar>, SolveError>
-    where
-        D::Scalar: Primal,
     {
         let one = D::Scalar::ONE;
         let half = D::Scalar::HALF;
@@ -197,7 +195,6 @@ impl<D: DerivatorSingleVariable> Newton<D> {
 
         Err(SolveError::DidNotConverge {
             iters: self.max_iterations,
-            residual: fx.abs().to_f64(),
         })
     }
 }

--- a/crates/multicalc/src/root_finding/newton.rs
+++ b/crates/multicalc/src/root_finding/newton.rs
@@ -125,8 +125,7 @@ impl<D: DerivatorSingleVariable> Newton<D> {
         &self,
         f: &F,
         x0: D::Scalar,
-    ) -> Result<RootReport<D::Scalar>, SolveError>
-    {
+    ) -> Result<RootReport<D::Scalar>, SolveError> {
         let one = D::Scalar::ONE;
         let half = D::Scalar::HALF;
 

--- a/crates/multicalc/src/root_finding/newton_system.rs
+++ b/crates/multicalc/src/root_finding/newton_system.rs
@@ -7,7 +7,7 @@ use crate::numerical_derivative::AutoDiffMulti;
 use crate::numerical_derivative::DerivatorMultiVariable;
 use crate::numerical_derivative::Jacobian;
 use crate::root_finding::{RootReportN, RootTermination, all_finite};
-use crate::scalar::{Numeric, Primal, VectorFn};
+use crate::scalar::{Numeric, VectorFn};
 
 /// Maximum step halvings per iteration when backtracking is enabled.
 const MAX_BACKTRACK: usize = 20;
@@ -128,7 +128,6 @@ impl<D: DerivatorMultiVariable> NewtonSystem<D> {
     ) -> Result<RootReportN<N, D::Scalar>, SolveError>
     where
         D: Clone,
-        D::Scalar: Primal,
         F: VectorFn<N, N>,
     {
         let one = D::Scalar::ONE;
@@ -211,7 +210,6 @@ impl<D: DerivatorMultiVariable> NewtonSystem<D> {
 
         Err(SolveError::DidNotConverge {
             iters: self.max_iterations,
-            residual: fnorm.to_f64(),
         })
     }
 }

--- a/crates/multicalc/tests/suite/utils.rs
+++ b/crates/multicalc/tests/suite/utils.rs
@@ -132,10 +132,9 @@ fn data_carrying_display() {
     assert_eq!(
         SolveError::DidNotConverge {
             iters: 7,
-            residual: 0.5,
         }
         .to_string(),
-        "solver did not converge after 7 iterations (residual 0.5)"
+        "solver did not converge after 7 iterations"
     );
     assert_eq!(
         IntegrateError::DidNotConverge { steps: 12 }.to_string(),

--- a/crates/multicalc/tests/suite/utils.rs
+++ b/crates/multicalc/tests/suite/utils.rs
@@ -130,10 +130,7 @@ fn wrapped_errors_forward() {
 #[test]
 fn data_carrying_display() {
     assert_eq!(
-        SolveError::DidNotConverge {
-            iters: 7,
-        }
-        .to_string(),
+        SolveError::DidNotConverge { iters: 7 }.to_string(),
         "solver did not converge after 7 iterations"
     );
     assert_eq!(


### PR DESCRIPTION
## What & why
This is related to issue #231.

What's new:
- `Solve::DidNotConverge` now has not `residual` field, also impl `Display` updated accordingly
- Remove `Primal` bound from impl that return `Solve::DisNotConverge`
- Update test cases in `utils.rs`

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
