### PR TITLE
Validate dt in zoh and van_loan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ResamplingScheme::resample_indices` now leaves output indices untouched for empty weights
   instead of panicking. (#204)
+- `zoh` and `van_loan` now reject negative or non-finite timesteps before constructing their
+  augmented matrices. (#203)
 
 ## [0.9.0] - 2026-07-26
 

--- a/crates/multicalc/GUIDE.md
+++ b/crates/multicalc/GUIDE.md
@@ -596,8 +596,9 @@ let ad = Matrix2D::<Dual<f64>>::from_fn(|i, j| {
 // ad[(0, 1)].deriv == m[(0, 1)]
 ```
 
-Errors: the matrix-exponential step returns [`LinalgError`](#error-handling) on a non-finite
-input. Full demo:
+Errors: `zoh` and `van_loan` return [`LinalgError::InvalidTimestep`](#error-handling) when `dt` is
+negative or non-finite; errors from the matrix-exponential step are propagated unchanged. Full
+demo:
 [discretization.rs](https://github.com/kmolan/multicalc-rust/blob/main/demos/examples/basics/discretization.rs).
 
 ## Spatial: quaternions and Lie groups
@@ -1140,7 +1141,7 @@ through `From`, so a caller that spans families can hold a single type. Every en
 
 | Enum | Raised by | Variants |
 | --- | --- | --- |
-| `LinalgError` | [Linear algebra](#linear-algebra), [Discretization](#discretization) | `Singular`, `NotPositiveDefinite`, `Underdetermined`, `NonFinite` |
+| `LinalgError` | [Linear algebra](#linear-algebra), [Discretization](#discretization) | `Singular`, `NotPositiveDefinite`, `Underdetermined`, `NonFinite`, `InvalidTimestep` |
 | `DiffError` | [Derivatives](#derivatives-jacobians-and-hessians), [Approximation](#taylor-approximation), [Vector calculus](#vector-calculus) | `OrderZero`, `OrderUnsupported`, `StepSizeZero`, `IndexOutOfRange`, `EmptyFunctionSet` |
 | `IntegrateError` | [Integration](#integration), [Gaussian tables](#gaussian-quadrature-tables), [ODE](#ode-integrators) | `IterationsZero`, `LimitsIllDefined`, `QuadratureOrderOutOfRange`, `StepSizeTooSmall`, `DidNotConverge { steps }`, `NonFinite` |
 | `SolveError` | [Optimization](#least-squares-optimization), [Root finding](#root-finding) | `DidNotConverge { iters, residual }`, `NonFinite`, `InvalidBracket`, `Linalg(LinalgError)`, `Diff(DiffError)` |

--- a/crates/multicalc/src/discretization/mod.rs
+++ b/crates/multicalc/src/discretization/mod.rs
@@ -12,6 +12,7 @@ use crate::scalar::Numeric;
 /// `F = expm(A·dt)` and `G = ∫₀^dt expm(A·τ) dτ · B`, via the augmented-matrix exponential.
 ///
 /// `NM` MUST equal `N + M`; a mismatch is a compile error.
+/// Returns [`LinalgError::InvalidTimestep`] if `dt` is negative or non-finite.
 ///
 /// ```
 /// use multicalc::linear_algebra::{Matrix, Matrix2D};
@@ -34,6 +35,9 @@ pub fn zoh<const N: usize, const M: usize, const NM: usize, T: Numeric>(
     dt: T,
 ) -> Result<(Matrix<N, N, T>, Matrix<N, M, T>), LinalgError> {
     const { assert!(NM == N + M, "zoh: NM must equal N + M") };
+    if !dt.is_finite() || dt < T::ZERO {
+        return Err(LinalgError::InvalidTimestep);
+    }
     // Augmented [[A, B], [0, 0]] · dt; its exponential's top blocks are F and G.
     let aug = Matrix::<NM, NM, T>::from_fn(|i, j| {
         if i < N && j < N {
@@ -54,6 +58,7 @@ pub fn zoh<const N: usize, const M: usize, const NM: usize, T: Numeric>(
 /// `F = expm(A·dt)` and `Q_d` the discrete process-noise covariance.
 ///
 /// `N2` MUST equal `2·N`; a mismatch is a compile error.
+/// Returns [`LinalgError::InvalidTimestep`] if `dt` is negative or non-finite.
 ///
 /// ```
 /// use multicalc::linear_algebra::Matrix2D;
@@ -72,6 +77,9 @@ pub fn van_loan<const N: usize, const N2: usize, T: Numeric>(
     dt: T,
 ) -> Result<(Matrix<N, N, T>, Matrix<N, N, T>), LinalgError> {
     const { assert!(N2 == 2 * N, "van_loan: N2 must equal 2*N") };
+    if !dt.is_finite() || dt < T::ZERO {
+        return Err(LinalgError::InvalidTimestep);
+    }
     // Ξ = [[-A, Q_c], [0, Aᵀ]] · dt. From expm(Ξ) = [[.., G12], [0, G22]]: F = G22ᵀ, Q_d = F · G12.
     let xi = Matrix::<N2, N2, T>::from_fn(|i, j| {
         if i < N && j < N {

--- a/crates/multicalc/src/error.rs
+++ b/crates/multicalc/src/error.rs
@@ -1,7 +1,7 @@
 //! Error types for the crate. Each module family has its own enum; [`CalcError`] is the umbrella
 //! they all convert into.
 
-/// Errors from the linear-algebra module (factorizations, solves, inverses).
+/// Errors from linear algebra and matrix-based discretization.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[non_exhaustive]
 pub enum LinalgError {
@@ -13,6 +13,8 @@ pub enum LinalgError {
     Underdetermined,
     /// A matrix entry was infinite or NaN.
     NonFinite,
+    /// A discretization timestep was negative, infinite, or NaN.
+    InvalidTimestep,
 }
 
 /// Errors from the differentiation modules (finite differences, autodiff, Jacobian, Hessian,
@@ -249,6 +251,7 @@ impl core::fmt::Display for LinalgError {
             LinalgError::NotPositiveDefinite => "matrix is not positive definite",
             LinalgError::Underdetermined => "system is underdetermined (M < N)",
             LinalgError::NonFinite => "matrix contained a non-finite value",
+            LinalgError::InvalidTimestep => "timestep must be finite and non-negative",
         })
     }
 }

--- a/crates/multicalc/tests/suite/discretization.rs
+++ b/crates/multicalc/tests/suite/discretization.rs
@@ -3,6 +3,7 @@
 //! Discretization + matrix-exponential invariants and closed-form checks.
 
 use multicalc::discretization::{q_discrete_white_noise, van_loan, zoh};
+use multicalc::error::LinalgError;
 use multicalc::linear_algebra::{Matrix, Matrix2D, Matrix3D, Matrix4D};
 use multicalc::scalar::Dual;
 use proptest::prelude::*;
@@ -81,6 +82,61 @@ fn van_loan_qd_symmetric_and_f_matches_expm() {
             assert!((discrete_noise[(row, column)] - discrete_noise[(column, row)]).abs() < 1e-10);
         }
     }
+}
+
+#[test]
+fn zoh_rejects_negative_timestep() {
+    let state_matrix = Matrix::<1, 1>::new([[1.0]]);
+    let input_matrix = Matrix::<1, 1>::new([[1.0]]);
+
+    assert_eq!(
+        zoh::<1, 1, 2, f64>(state_matrix, input_matrix, -0.1).err(),
+        Some(LinalgError::InvalidTimestep)
+    );
+}
+
+#[test]
+fn van_loan_rejects_negative_timestep() {
+    let state_matrix = Matrix::<1, 1>::new([[1.0]]);
+    let continuous_noise = Matrix::<1, 1>::new([[1.0]]);
+
+    assert_eq!(
+        van_loan::<1, 2, f64>(state_matrix, continuous_noise, -0.1).err(),
+        Some(LinalgError::InvalidTimestep)
+    );
+}
+
+#[test]
+fn discretization_rejects_non_finite_timesteps() {
+    let state_matrix = Matrix::<1, 1>::new([[1.0]]);
+    let input_or_noise_matrix = Matrix::<1, 1>::new([[1.0]]);
+
+    for timestep in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        assert_eq!(
+            zoh::<1, 1, 2, f64>(state_matrix, input_or_noise_matrix, timestep).err(),
+            Some(LinalgError::InvalidTimestep)
+        );
+        assert_eq!(
+            van_loan::<1, 2, f64>(state_matrix, input_or_noise_matrix, timestep).err(),
+            Some(LinalgError::InvalidTimestep)
+        );
+    }
+}
+
+#[test]
+fn zero_timestep_is_valid() {
+    let state_matrix = Matrix::<1, 1>::new([[1.0]]);
+    let input_or_noise_matrix = Matrix::<1, 1>::new([[1.0]]);
+
+    let (zoh_state, zoh_input) =
+        zoh::<1, 1, 2, f64>(state_matrix, input_or_noise_matrix, 0.0).unwrap();
+    assert_eq!(zoh_state, Matrix::identity());
+    assert_eq!(zoh_input, Matrix::zeros());
+
+    let (van_loan_state, van_loan_noise) =
+        van_loan::<1, 2, f64>(state_matrix, input_or_noise_matrix, 0.0).unwrap();
+    assert_eq!(van_loan_state, Matrix::identity());
+    assert_eq!(van_loan_noise, Matrix::zeros());
 }
 
 #[test]

--- a/crates/multicalc/tests/suite/utils.rs
+++ b/crates/multicalc/tests/suite/utils.rs
@@ -43,6 +43,10 @@ fn linalg_display_strings() {
         LinalgError::NonFinite,
         "matrix contained a non-finite value"
     ));
+    assert!(renders_as(
+        LinalgError::InvalidTimestep,
+        "timestep must be finite and non-negative"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## What & why

Closes #203.

`zoh` and `van_loan` now reject negative, NaN, and infinite timesteps before constructing their augmented matrices, returning the cause-specific `LinalgError::InvalidTimestep`. This prevents an infinite timestep from reaching `Matrix::expm`'s scaling loop, while preserving zero-timestep behavior (`F = I`, `G/Q_d = 0`). The existing return signatures remain unchanged.

This contribution was implemented and validated by an autonomous OpenAI Codex agent, as disclosed in the issue claim.

## Validation

- Before the fix, both focused negative-timestep regressions failed because the APIs returned `Ok`.
- `cargo test -p multicalc`
- `cargo test -p multicalc --features alloc`
- `cargo test -p multicalc --all-features --doc`
- `cargo test -p multicalc-mjcf`
- `cargo test -p multicalc-qa`, plus deterministic fixture/table regeneration
- `cargo clippy -p multicalc --all-targets --features alloc -- -D warnings`
- `cargo clippy -p multicalc-mjcf --all-targets -- -D warnings`
- warning-denied docs, no-default-feature host check, package dry-run, and all headless examples

The bare-metal, MSRV, and QEMU matrix remains delegated to CI because this Windows host has only the stable host target installed.

## Checklist

- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)