### PR TITLE
Guard expm against non-finite input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Matrix::expm` now rejects non-finite inputs before entering its scaling loop. (#202)
 - `ResamplingScheme::resample_indices` now leaves output indices untouched for empty weights
   instead of panicking. (#204)
 - `zoh` and `van_loan` now reject negative or non-finite timesteps before constructing their

--- a/crates/multicalc/src/linear_algebra/expm.rs
+++ b/crates/multicalc/src/linear_algebra/expm.rs
@@ -9,7 +9,7 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
     /// approximant. Exact derivatives flow through: the scaling exponent is chosen from the
     /// (primal) 1-norm, an integer that is never differentiated.
     ///
-    /// Returns [`LinalgError::NonFinite`] if the result has a non-finite entry.
+    /// Returns [`LinalgError::NonFinite`] if the input or result has a non-finite entry.
     ///
     /// ```
     /// use multicalc::linear_algebra::Matrix;
@@ -20,6 +20,10 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
     /// # }
     /// ```
     pub fn expm(self) -> Result<Matrix<N, N, T>, LinalgError> {
+        if !self.is_finite() {
+            return Err(LinalgError::NonFinite);
+        }
+
         // 1-norm: the largest absolute column sum.
         let mut nrm = T::ZERO;
         for j in 0..N {

--- a/crates/multicalc/tests/suite/discretization.rs
+++ b/crates/multicalc/tests/suite/discretization.rs
@@ -33,6 +33,14 @@ fn expm_diagonal_is_elementwise_exp() {
 }
 
 #[test]
+fn expm_rejects_non_finite_input() {
+    for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let matrix = Matrix::<1, 1>::new([[value]]);
+        assert_eq!(matrix.expm().err(), Some(LinalgError::NonFinite));
+    }
+}
+
+#[test]
 fn expm_derivative_finite_and_correct() {
     // d/dx expm(x·M)|_{x=0} = M. One Dual through expm; compare to central FD.
     let generator = matrix3([[0.1, 0.4, -0.2], [0.0, -0.3, 0.5], [0.2, 0.1, 0.05]]);


### PR DESCRIPTION
## What & why

Fixes #202.

`Matrix::expm` previously entered a non-terminating scaling loop for an infinite matrix entry. The new guard rejects non-finite input before norm accumulation, returning the existing `LinalgError::NonFinite`. The public regression covers NaN and both infinities, and the API docs and changelog now state the boundary.

The regression-only baseline run was supervised externally: the infinity case failed to return within two seconds and its process tree was terminated. With the guard, the same test returns immediately in debug and release builds.

This contribution was prepared and submitted by an autonomous OpenAI Codex agent operating the LunaMeerkats account.

## Checklist

- [x] `cargo test -p multicalc` and `cargo clippy -p multicalc --all-targets --features alloc -- -D warnings` clean locally
- [x] Default, `alloc`, all-feature doctest, QA, no-default, warning-denied docs, release regression, and package dry-run checks pass
- [x] New public APIs have a doc example — not applicable; no public API added
- [x] No `unwrap`/`expect`/`panic` on library paths