### PR TITLE
Apply #[must_use] consistently across the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `zoh` and `van_loan` now reject negative or non-finite timesteps before constructing their
   augmented matrices. (#203)
 
+### Changed
+
+- Apply `#[must_use]` consistently across `multicalc` (and `multicalc-mjcf`) on
+  value-returning accessors, builders, and helpers, so discarded results warn under
+  `unused_must_use`. Engine constructors and returns already covered by `Result` /
+  `Vector` / `Matrix` stay unmarked. @rtmongold (#251)
+
 ## [0.9.0] - 2026-07-26
 
 A feature release adding state estimation, feedback control, wheeled kinematics, and

--- a/crates/multicalc-mjcf/src/body.rs
+++ b/crates/multicalc-mjcf/src/body.rs
@@ -175,6 +175,7 @@ fn shifted(mass: f64, offset: Vector3D) -> Matrix3D {
 }
 
 /// The error for an attribute the file has to carry and does not.
+#[must_use]
 fn required(node: Node, attribute: &str) -> MjcfError {
     bad_attribute(
         node,

--- a/crates/multicalc-mjcf/src/defaults.rs
+++ b/crates/multicalc-mjcf/src/defaults.rs
@@ -36,6 +36,7 @@ impl GeomDefaults {
     }
 
     /// A copy of these settings with everything `other` states written over the top.
+    #[must_use]
     pub(crate) fn overridden_by(&self, other: &GeomDefaults) -> GeomDefaults {
         GeomDefaults {
             geom_type: other.geom_type.clone().or_else(|| self.geom_type.clone()),
@@ -109,6 +110,7 @@ pub(crate) fn elements<'a, 'input>(
 }
 
 /// The first child element of `node` with the given tag.
+#[must_use]
 pub(crate) fn element<'a, 'input>(
     node: Node<'a, 'input>,
     tag: &'static str,
@@ -135,6 +137,7 @@ pub(crate) fn unit_quaternion(
 }
 
 /// The error for an attribute that does not hold the numbers it should.
+#[must_use]
 pub(crate) fn bad_attribute(node: Node, attribute: &str, text: &str) -> MjcfError {
     MjcfError::BadAttribute {
         element: node.tag_name().name().to_owned(),

--- a/crates/multicalc-mjcf/tests/loading.rs
+++ b/crates/multicalc-mjcf/tests/loading.rs
@@ -6,19 +6,23 @@
 use multicalc_mjcf::{MjcfError, RigidBodyModel, load_str};
 
 /// A model file holding whatever the case needs inside its `<worldbody>`.
+#[must_use]
 fn model(inner: &str) -> String {
     format!("<mujoco><worldbody>{inner}</worldbody></mujoco>")
 }
 
+#[must_use]
 fn load(inner: &str) -> RigidBodyModel {
     load_str(&model(inner)).unwrap()
 }
 
+#[must_use]
 fn refuse(inner: &str) -> MjcfError {
     load_str(&model(inner)).unwrap_err()
 }
 
 /// The three numbers down the diagonal of how the body resists being spun.
+#[must_use]
 fn diagonal(body: &RigidBodyModel) -> [f64; 3] {
     let inertia = body.inertia().rotational_inertia();
     [inertia[(0, 0)], inertia[(1, 1)], inertia[(2, 2)]]

--- a/crates/multicalc-mjcf/tests/skydio_x2.rs
+++ b/crates/multicalc-mjcf/tests/skydio_x2.rs
@@ -29,6 +29,7 @@ const ROTATIONAL_INERTIA: [[f64; 3]; 3] = [
 
 const TOLERANCE: f64 = 1e-12;
 
+#[must_use]
 fn x2() -> RigidBodyModel {
     let path =
         Path::new(env!("CARGO_MANIFEST_DIR")).join("../../third_party/menagerie/skydio_x2/x2.xml");

--- a/crates/multicalc/src/approximation/linear_approximation.rs
+++ b/crates/multicalc/src/approximation/linear_approximation.rs
@@ -33,23 +33,27 @@ pub struct LinearApproximationPredictionMetrics<T = f64> {
 impl<const NUM_VARS: usize, T: Numeric> LinearApproximation<NUM_VARS, T> {
     /// Evaluates the approximation at `x`.
     #[inline]
+    #[must_use]
     pub fn predict(&self, x: &[T; NUM_VARS]) -> T {
         let dx = Vector::from(*x) - Vector::from(self.point);
         self.value + Vector::from(self.gradient).dot(dx)
     }
 
     /// The base point the approximation is centered on.
+    #[must_use]
     pub fn point(&self) -> &[T; NUM_VARS] {
         &self.point
     }
 
     /// The gradient at the base point. These are also the coefficients of the expanded
     /// linear form `intercept + Σ coefficients[i] * x[i]`.
+    #[must_use]
     pub fn coefficients(&self) -> &[T; NUM_VARS] {
         &self.gradient
     }
 
     /// The intercept of the expanded form `intercept + Σ coefficients[i] * x[i]`.
+    #[must_use]
     pub fn intercept(&self) -> T {
         let mut intercept = self.value;
         for i in 0..NUM_VARS {
@@ -66,6 +70,7 @@ impl<const NUM_VARS: usize, T: Numeric> LinearApproximation<NUM_VARS, T> {
     ///
     /// `r_squared` is `NaN` when the truth is constant over `points`;
     /// `adjusted_r_squared` is `NaN` when there are too few points.
+    #[must_use]
     pub fn prediction_metrics<O: ScalarFnN<NUM_VARS>, const NUM_POINTS: usize>(
         &self,
         points: &[[T; NUM_VARS]; NUM_POINTS],
@@ -132,6 +137,7 @@ impl<D: DerivatorMultiVariable> LinearApproximator<D> {
     ///
     /// Pairwise summation remains the default. Call this before [`Self::approximate`] so the
     /// resulting [`LinearApproximation`] accumulates metrics with Kahan.
+    #[must_use]
     pub fn with_kahan_summation(mut self) -> Self {
         self.summation = SummationMethod::Kahan;
         self

--- a/crates/multicalc/src/approximation/mod.rs
+++ b/crates/multicalc/src/approximation/mod.rs
@@ -23,6 +23,7 @@ pub use quadratic_approximation::{
 /// number of fitted terms (`p`), used only for the adjusted R². `r_squared` is `NaN` when
 /// the truth is constant over `points` (zero total variance); `adjusted_r_squared` is
 /// `NaN` when there are too few points (`num_points <= num_predictors + 1`).
+#[must_use]
 pub(crate) fn compute_metrics<T, P, O, const NUM_VARS: usize, const NUM_POINTS: usize>(
     predict: P,
     points: &[[T; NUM_VARS]; NUM_POINTS],

--- a/crates/multicalc/src/approximation/quadratic_approximation.rs
+++ b/crates/multicalc/src/approximation/quadratic_approximation.rs
@@ -36,6 +36,7 @@ impl<const NUM_VARS: usize, T: Numeric> QuadraticApproximation<NUM_VARS, T> {
     /// Evaluates the approximation at `x`. The `½` keeps the quadratic term correct for
     /// both diagonal and off-diagonal Hessian entries.
     #[inline]
+    #[must_use]
     pub fn predict(&self, x: &[T; NUM_VARS]) -> T {
         let dx = Vector::from(*x) - Vector::from(self.point);
         let hessian = Matrix::from(self.hessian);
@@ -43,16 +44,19 @@ impl<const NUM_VARS: usize, T: Numeric> QuadraticApproximation<NUM_VARS, T> {
     }
 
     /// The base point the approximation is centered on.
+    #[must_use]
     pub fn point(&self) -> &[T; NUM_VARS] {
         &self.point
     }
 
     /// The gradient at the base point.
+    #[must_use]
     pub fn gradient(&self) -> &[T; NUM_VARS] {
         &self.gradient
     }
 
     /// The Hessian matrix at the base point.
+    #[must_use]
     pub fn hessian(&self) -> &[[T; NUM_VARS]; NUM_VARS] {
         &self.hessian
     }
@@ -65,6 +69,7 @@ impl<const NUM_VARS: usize, T: Numeric> QuadraticApproximation<NUM_VARS, T> {
     ///
     /// `r_squared` is `NaN` when the truth is constant over `points`;
     /// `adjusted_r_squared` is `NaN` when there are too few points.
+    #[must_use]
     pub fn prediction_metrics<O: ScalarFnN<NUM_VARS>, const NUM_POINTS: usize>(
         &self,
         points: &[[T; NUM_VARS]; NUM_POINTS],
@@ -131,6 +136,7 @@ impl<D: DerivatorMultiVariable> QuadraticApproximator<D> {
     ///
     /// Pairwise summation remains the default. Call this before [`Self::approximate`] so the
     /// resulting [`QuadraticApproximation`] accumulates metrics with Kahan.
+    #[must_use]
     pub fn with_kahan_summation(mut self) -> Self {
         self.summation = SummationMethod::Kahan;
         self

--- a/crates/multicalc/src/control/follow_the_gap.rs
+++ b/crates/multicalc/src/control/follow_the_gap.rs
@@ -62,6 +62,7 @@ pub struct FollowTheGapOutput<T: Numeric = f64> {
 impl<T: Numeric> FollowTheGapOutput<T> {
     /// A full stop, used when no gap is wide enough for the robot.
     #[inline]
+    #[must_use]
     fn stopped(minimum_clearance: T) -> Self {
         FollowTheGapOutput {
             body_twist: BodyTwist::new(T::ZERO, T::ZERO),
@@ -425,6 +426,7 @@ impl<const BEAMS: usize, T: Numeric> FollowTheGap<BEAMS, T> {
 
     /// The angle for a beam whose index is already known to be in range.
     #[inline]
+    #[must_use]
     fn beam_angle_unchecked(&self, index: usize) -> T {
         // `try_new` is the only way to build this and rejects fewer than two beams, so `BEAMS - 1`
         // never underflows.
@@ -440,6 +442,7 @@ impl<const BEAMS: usize, T: Numeric> FollowTheGap<BEAMS, T> {
     /// ranges) and the angle between them, and the third side is the gap. Measuring it in metres is
     /// what matters — the same spread of beams is a wide gap at four metres but a tight one at forty
     /// centimetres.
+    #[must_use]
     fn gap_width(&self, beam_ranges: &[T; BEAMS], start: usize, end: usize) -> Option<T> {
         let before = start.checked_sub(1)?;
         let after = end.checked_add(1).filter(|&index| index < BEAMS)?;
@@ -460,6 +463,7 @@ impl<const BEAMS: usize, T: Numeric> FollowTheGap<BEAMS, T> {
     /// An edge that runs off the scan has no obstacle, so it gets no inward margin, matching
     /// [`Self::gap_width`]. If the two margins overlap, the low bound ends up above the high one;
     /// the caller handles that case.
+    #[must_use]
     fn aim_bounds(&self, beam_ranges: &[T; BEAMS], start: usize, end: usize) -> (T, T) {
         let half_width = self.chassis_width * T::HALF;
         let inset = |index: usize| match beam_ranges.get(index) {

--- a/crates/multicalc/src/control/pid.rs
+++ b/crates/multicalc/src/control/pid.rs
@@ -113,6 +113,7 @@ impl<T: Numeric> Pid<T> {
     }
 
     /// Advances the controller one timestep and returns the saturated output.
+    #[must_use]
     pub fn update(&mut self, setpoint: T, measurement: T) -> T {
         let error = setpoint - measurement;
         let proportional_term = self.proportional_gain * error;

--- a/crates/multicalc/src/estimation/particle_filter.rs
+++ b/crates/multicalc/src/estimation/particle_filter.rs
@@ -159,6 +159,7 @@ fn residual<T: Numeric, R: RandomSource>(weights: &[T], random: &mut R, indices:
 }
 
 /// The smallest source whose cumulative weight reaches `draw`.
+#[must_use]
 fn draw_from_weights<T: Numeric>(weights: &[T], draw: T) -> usize {
     let mut running_sum = T::ZERO;
     for (source, &weight) in weights.iter().enumerate() {
@@ -171,6 +172,7 @@ fn draw_from_weights<T: Numeric>(weights: &[T], draw: T) -> usize {
 }
 
 /// The smallest source whose cumulative fractional remainder reaches `draw`.
+#[must_use]
 fn draw_from_remainders<T: Numeric>(
     weights: &[T],
     count_scalar: T,
@@ -194,6 +196,7 @@ fn draw_from_remainders<T: Numeric>(
 pub trait Likelihood<const MEASUREMENT_DIMENSION: usize, T: Numeric> {
     /// The log of the (unnormalized) weight for a particle whose model predicts `predicted` when the
     /// sensor read `measurement`. Larger means a better match.
+    #[must_use]
     fn log_weight(
         &self,
         predicted: &[T; MEASUREMENT_DIMENSION],

--- a/crates/multicalc/src/kinematics/differential_drive.rs
+++ b/crates/multicalc/src/kinematics/differential_drive.rs
@@ -8,12 +8,14 @@ use crate::spatial::SE2;
 /// Left/right wheel motion to linear/angular body motion. Unit-agnostic: velocities in, twist out;
 /// rotations in, arc out.
 #[inline]
+#[must_use]
 fn to_body<T: Numeric>(r: T, b: T, left: T, right: T) -> (T, T) {
     (r * (right + left) * T::HALF, r * (right - left) / b)
 }
 
 /// The inverse of [`to_body`].
 #[inline]
+#[must_use]
 fn to_wheels<T: Numeric>(r: T, b: T, linear: T, angular: T) -> (T, T) {
     let half_span = angular * b * T::HALF;
     ((linear - half_span) / r, (linear + half_span) / r)
@@ -56,24 +58,28 @@ pub struct BodyArc<T: Numeric = f64> {
 impl<T: Numeric> WheelVelocities<T> {
     /// Velocities of the left and right wheel, in `[rad/s]`.
     #[inline]
+    #[must_use]
     pub fn new(left: T, right: T) -> Self {
         WheelVelocities { left, right }
     }
 
     /// The left wheel velocity.
     #[inline]
+    #[must_use]
     pub fn left(self) -> T {
         self.left
     }
 
     /// The right wheel velocity.
     #[inline]
+    #[must_use]
     pub fn right(self) -> T {
         self.right
     }
 
     /// Both wheels stopped.
     #[inline]
+    #[must_use]
     pub fn zeros() -> Self {
         WheelVelocities {
             left: T::ZERO,
@@ -85,24 +91,28 @@ impl<T: Numeric> WheelVelocities<T> {
 impl<T: Numeric> WheelRotations<T> {
     /// Rotations of the left and right wheel, in `[rad]`.
     #[inline]
+    #[must_use]
     pub fn new(left: T, right: T) -> Self {
         WheelRotations { left, right }
     }
 
     /// The left wheel rotation.
     #[inline]
+    #[must_use]
     pub fn left(self) -> T {
         self.left
     }
 
     /// The right wheel rotation.
     #[inline]
+    #[must_use]
     pub fn right(self) -> T {
         self.right
     }
 
     /// Neither wheel turned.
     #[inline]
+    #[must_use]
     pub fn zeros() -> Self {
         WheelRotations {
             left: T::ZERO,
@@ -114,24 +124,28 @@ impl<T: Numeric> WheelRotations<T> {
 impl<T: Numeric> BodyTwist<T> {
     /// A twist from a forward speed `[m/s]` and a yaw rate `[rad/s]`.
     #[inline]
+    #[must_use]
     pub fn new(linear: T, angular: T) -> Self {
         BodyTwist { linear, angular }
     }
 
     /// The forward speed.
     #[inline]
+    #[must_use]
     pub fn linear(self) -> T {
         self.linear
     }
 
     /// The yaw rate.
     #[inline]
+    #[must_use]
     pub fn angular(self) -> T {
         self.angular
     }
 
     /// The body at rest.
     #[inline]
+    #[must_use]
     pub fn zeros() -> Self {
         BodyTwist {
             linear: T::ZERO,
@@ -151,6 +165,7 @@ impl<T: Numeric> BodyTwist<T> {
     /// Lossy: `BodyTwist::project_tangent(xi).to_tangent()` equals `xi` only when the
     /// lateral is zero. `tangent_slip` reports what is discarded.
     #[inline]
+    #[must_use]
     pub fn project_tangent(xi: Vector3D<T>) -> Self {
         let [linear, _, angular] = *xi.as_array();
         BodyTwist { linear, angular }
@@ -159,6 +174,7 @@ impl<T: Numeric> BodyTwist<T> {
     /// The lateral component of `xi`, which [`project_tangent`](Self::project_tangent) discards.
     /// Zero for any motion a differential drive can produce.
     #[inline]
+    #[must_use]
     pub fn tangent_slip(xi: Vector3D<T>) -> T {
         let [_, lateral, _] = *xi.as_array();
         lateral
@@ -166,6 +182,7 @@ impl<T: Numeric> BodyTwist<T> {
 
     /// The arc traced over `dt` by holding this twist constant.
     #[inline]
+    #[must_use]
     pub fn integrate_over(self, dt: T) -> BodyArc<T> {
         BodyArc {
             linear: self.linear * dt,
@@ -177,24 +194,28 @@ impl<T: Numeric> BodyTwist<T> {
 impl<T: Numeric> BodyArc<T> {
     /// An arc from an arc length `[m]` and a heading change `[rad]`.
     #[inline]
+    #[must_use]
     pub fn new(linear: T, angular: T) -> Self {
         BodyArc { linear, angular }
     }
 
     /// The arc length.
     #[inline]
+    #[must_use]
     pub fn linear(self) -> T {
         self.linear
     }
 
     /// The heading change.
     #[inline]
+    #[must_use]
     pub fn angular(self) -> T {
         self.angular
     }
 
     /// The body did not move.
     #[inline]
+    #[must_use]
     pub fn zeros() -> Self {
         BodyArc {
             linear: T::ZERO,
@@ -251,18 +272,21 @@ impl<T: Numeric> DifferentialDrive<T> {
 
     /// The wheel radius.
     #[inline]
+    #[must_use]
     pub fn wheel_radius(self) -> T {
         self.wheel_radius
     }
 
     /// The track width.
     #[inline]
+    #[must_use]
     pub fn wheelbase(self) -> T {
         self.wheelbase
     }
 
     /// The body twist produced by wheel velocities.
     #[inline]
+    #[must_use]
     pub fn forward(self, w: WheelVelocities<T>) -> BodyTwist<T> {
         let (linear, angular) = to_body(self.wheel_radius, self.wheelbase, w.left(), w.right());
         BodyTwist::new(linear, angular)
@@ -270,6 +294,7 @@ impl<T: Numeric> DifferentialDrive<T> {
 
     /// The wheel velocities that produce a body twist.
     #[inline]
+    #[must_use]
     pub fn inverse(self, c: BodyTwist<T>) -> WheelVelocities<T> {
         let (left, right) = to_wheels(self.wheel_radius, self.wheelbase, c.linear(), c.angular());
         WheelVelocities::new(left, right)
@@ -277,6 +302,7 @@ impl<T: Numeric> DifferentialDrive<T> {
 
     /// The arc traced by wheel rotations over one tick.
     #[inline]
+    #[must_use]
     pub fn forward_arc(self, d: WheelRotations<T>) -> BodyArc<T> {
         let (linear, angular) = to_body(self.wheel_radius, self.wheelbase, d.left(), d.right());
         BodyArc::new(linear, angular)
@@ -284,6 +310,7 @@ impl<T: Numeric> DifferentialDrive<T> {
 
     /// The wheel rotations that trace an arc over one tick.
     #[inline]
+    #[must_use]
     pub fn inverse_arc(self, d: BodyArc<T>) -> WheelRotations<T> {
         let (left, right) = to_wheels(self.wheel_radius, self.wheelbase, d.linear(), d.angular());
         WheelRotations::new(left, right)
@@ -291,18 +318,21 @@ impl<T: Numeric> DifferentialDrive<T> {
 
     /// Wheel rotations from the distance each wheel travelled, in metres.
     #[inline]
+    #[must_use]
     pub fn wheel_rotations_from_travel(self, left_m: T, right_m: T) -> WheelRotations<T> {
         WheelRotations::new(left_m / self.wheel_radius, right_m / self.wheel_radius)
     }
 
     /// The distance each wheel travelled, in metres, from its rotation.
     #[inline]
+    #[must_use]
     pub fn wheel_travel(self, d: WheelRotations<T>) -> (T, T) {
         (d.left() * self.wheel_radius, d.right() * self.wheel_radius)
     }
 
     /// The pose after one tick of wheel motion, along the exact constant-twist arc.
     #[inline]
+    #[must_use]
     pub fn odometry_step(self, pose: SE2<T>, d: WheelRotations<T>) -> SE2<T> {
         crate::kinematics::odometry::integrate(pose, self.forward_arc(d))
     }

--- a/crates/multicalc/src/kinematics/odometry.rs
+++ b/crates/multicalc/src/kinematics/odometry.rs
@@ -26,6 +26,7 @@ use crate::spatial::{SE2, SO2};
 /// assert!((pose.rotation().log() - 0.1).abs() < 1e-12);
 /// ```
 #[inline]
+#[must_use]
 pub fn integrate<T: Numeric>(pose: SE2<T>, d: BodyArc<T>) -> SE2<T> {
     pose * SE2::exp(Vector::new([d.linear(), T::ZERO, d.angular()]))
 }

--- a/crates/multicalc/src/kinematics/unicycle.rs
+++ b/crates/multicalc/src/kinematics/unicycle.rs
@@ -30,6 +30,7 @@ pub struct Unicycle<T: Numeric = f64> {
 impl<T: Numeric> Unicycle<T> {
     /// A plant holding `twist`.
     #[inline]
+    #[must_use]
     pub fn new(twist: BodyTwist<T>) -> Self {
         Unicycle { twist }
     }

--- a/crates/multicalc/src/linear_algebra/matrix.rs
+++ b/crates/multicalc/src/linear_algebra/matrix.rs
@@ -53,6 +53,7 @@ impl<const ROWS: usize, const COLS: usize, T> Matrix<ROWS, COLS, T> {
     // Crate-internal panic path (also used by Index). Public: prefer `[]`; use `get` when fallible.
     #[inline]
     #[track_caller]
+    #[must_use]
     pub(crate) fn at(&self, row: usize, col: usize) -> &T {
         #[allow(clippy::indexing_slicing)]
         &self.data[row][col]
@@ -394,6 +395,7 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
     }
 
     #[inline]
+    #[must_use]
     fn determinant_2x2(self) -> T {
         self.data[0][0] * self.data[1][1] - self.data[0][1] * self.data[1][0]
     }
@@ -414,6 +416,7 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
     }
 
     #[inline]
+    #[must_use]
     fn determinant_3x3(self) -> T {
         let m = self.data;
         m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
@@ -458,6 +461,7 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
     /// indexed by column pair `01, 02, 03, 12, 13, 23`. Both the 4×4 determinant and its
     /// adjugate are built from these, so they are computed once and shared.
     #[inline]
+    #[must_use]
     fn row_pair_minors(self) -> ([T; 6], [T; 6]) {
         let m = self.data;
         let top = [
@@ -480,6 +484,7 @@ impl<const N: usize, T: Numeric> Matrix<N, N, T> {
     }
 
     #[inline]
+    #[must_use]
     fn determinant_4x4(self) -> T {
         let (top, bottom) = self.row_pair_minors();
         top[0] * bottom[5] - top[1] * bottom[4] + top[2] * bottom[3] + top[3] * bottom[2]

--- a/crates/multicalc/src/linear_algebra/qr.rs
+++ b/crates/multicalc/src/linear_algebra/qr.rs
@@ -14,6 +14,7 @@ use crate::scalar::Numeric;
 /// Components are split into three magnitude bands. Small and large components are summed
 /// against a running maximum in that band, so every squared term stays within range; only
 /// the mid band is squared directly. This is the MINPACK `enorm` scheme.
+#[must_use]
 pub(crate) fn enorm<T: Numeric>(v: &[T]) -> T {
     // Below `rdwarf`, squaring underflows; above `agiant`, summing the squares overflows.
     let rdwarf = T::MIN_POSITIVE.sqrt();
@@ -69,12 +70,14 @@ pub(crate) fn enorm<T: Numeric>(v: &[T]) -> T {
 
 /// Returns the larger of `a` and `b`. If the two do not compare (a NaN is involved),
 /// returns `a`.
+#[must_use]
 pub(crate) fn max<T: PartialOrd>(a: T, b: T) -> T {
     if b > a { b } else { a }
 }
 
 /// Returns the smaller of `a` and `b`. If the two do not compare (a NaN is involved),
 /// returns `a`.
+#[must_use]
 pub(crate) fn min<T: PartialOrd>(a: T, b: T) -> T {
     if b < a { b } else { a }
 }

--- a/crates/multicalc/src/linear_algebra/svd.rs
+++ b/crates/multicalc/src/linear_algebra/svd.rs
@@ -276,6 +276,7 @@ impl<const M: usize, const N: usize, T: Numeric> Svd<M, N, T> {
     }
 
     /// The default cutoff below which a singular value counts as zero.
+    #[must_use]
     fn default_tol(&self) -> T {
         if N == 0 {
             return T::ZERO;

--- a/crates/multicalc/src/linear_algebra/vector.rs
+++ b/crates/multicalc/src/linear_algebra/vector.rs
@@ -87,6 +87,7 @@ impl<const N: usize, T> Vector<N, T> {
     // Crate-internal panic path (also used by Index). Public: prefer `[]`; use `get` when fallible.
     #[inline]
     #[track_caller]
+    #[must_use]
     pub(crate) fn at(&self, i: usize) -> &T {
         #[allow(clippy::indexing_slicing)]
         &self.data[i]

--- a/crates/multicalc/src/numerical_derivative/finite_difference.rs
+++ b/crates/multicalc/src/numerical_derivative/finite_difference.rs
@@ -12,6 +12,7 @@ use crate::scalar::{Numeric, ScalarFn, ScalarFnN, VectorFn};
 /// Low and high sample offsets (in units of the step size) and the divisor factor
 /// for each finite-difference mode.
 #[inline]
+#[must_use]
 fn offsets<T: Numeric>(method: FiniteDifferenceMode) -> (T, T, T) {
     match method {
         FiniteDifferenceMode::Forward => (T::ZERO, T::ONE, T::ONE),
@@ -45,6 +46,7 @@ impl<T: Numeric> Default for FiniteDifferenceConfig<T> {
 
 impl<T: Numeric> FiniteDifferenceConfig<T> {
     /// Builds a config with explicit parameters.
+    #[must_use]
     pub fn from_parameters(step: T, method: FiniteDifferenceMode, multiplier: T) -> Self {
         FiniteDifferenceConfig {
             step_size: step,
@@ -78,6 +80,7 @@ impl<T: Numeric> Default for FiniteDifferenceSingle<T> {
 
 impl<T: Numeric> FiniteDifferenceSingle<T> {
     /// Builds a differentiator with explicit parameters.
+    #[must_use]
     pub fn from_parameters(step: T, method: FiniteDifferenceMode, multiplier: T) -> Self {
         FiniteDifferenceSingle {
             config: FiniteDifferenceConfig::from_parameters(step, method, multiplier),
@@ -85,6 +88,7 @@ impl<T: Numeric> FiniteDifferenceSingle<T> {
     }
 
     #[inline]
+    #[must_use]
     fn diff<F: ScalarFn>(&self, order: usize, func: &F, point: T, step: T) -> T {
         let (lo, hi, denom) = offsets::<T>(self.config.method);
 
@@ -129,6 +133,7 @@ impl<T: Numeric> Default for FiniteDifferenceMulti<T> {
 
 impl<T: Numeric> FiniteDifferenceMulti<T> {
     /// Builds a differentiator with explicit parameters.
+    #[must_use]
     pub fn from_parameters(step: T, method: FiniteDifferenceMode, multiplier: T) -> Self {
         FiniteDifferenceMulti {
             config: FiniteDifferenceConfig::from_parameters(step, method, multiplier),
@@ -136,6 +141,7 @@ impl<T: Numeric> FiniteDifferenceMulti<T> {
     }
 
     #[inline]
+    #[must_use]
     fn diff<F: ScalarFnN<NUM_VARS>, const NUM_VARS: usize, const NUM_ORDER: usize>(
         &self,
         order: usize,

--- a/crates/multicalc/src/numerical_integration/gaussian_integration.rs
+++ b/crates/multicalc/src/numerical_integration/gaussian_integration.rs
@@ -32,6 +32,7 @@ impl Default for GaussianConfig {
 
 impl GaussianConfig {
     /// Builds a config with an explicit order and quadrature family.
+    #[must_use]
     pub const fn from_parameters(
         order: usize,
         integration_method: GaussianQuadratureMethod,
@@ -92,6 +93,7 @@ impl<T> Default for GaussianSingle<T> {
 
 impl<T> GaussianSingle<T> {
     /// custom constructor, optimal for fine-tuning for specific cases
+    #[must_use]
     pub const fn from_parameters(
         order: usize,
         integration_method: GaussianQuadratureMethod,
@@ -232,6 +234,7 @@ impl<T> Default for GaussianMulti<T> {
 
 impl<T> GaussianMulti<T> {
     /// custom constructor, optimal for fine-tuning for specific cases
+    #[must_use]
     pub const fn from_parameters(
         order: usize,
         integration_method: GaussianQuadratureMethod,

--- a/crates/multicalc/src/numerical_integration/integrator.rs
+++ b/crates/multicalc/src/numerical_integration/integrator.rs
@@ -44,6 +44,7 @@ pub(crate) fn is_finite<T: Numeric>(sample: T) -> Result<T, IntegrateError> {
 /// semi-infinite domain sits at `t = 0` and is perfectly regular, so it is included;
 /// only an infinite end needs the `T::EPSILON` inset that keeps the transform away from
 /// its singular limit.
+#[must_use]
 pub(crate) fn t_bounds<T: Numeric>(d: &Domain<T>) -> (T, T) {
     match d {
         Domain::Finite(a, b) => (*a, *b),
@@ -55,6 +56,7 @@ pub(crate) fn t_bounds<T: Numeric>(d: &Domain<T>) -> (T, T) {
 
 /// Maps a sample `t` to its position `x` and the Jacobian `dx/dt` for a domain.
 /// Finite domains are the identity, so the finite path pays nothing extra.
+#[must_use]
 pub(crate) fn map_sample<T: Numeric>(d: &Domain<T>, t: T) -> (T, T) {
     match *d {
         Domain::Finite(_, _) => (t, T::ONE),

--- a/crates/multicalc/src/numerical_integration/iterative_integration.rs
+++ b/crates/multicalc/src/numerical_integration/iterative_integration.rs
@@ -34,6 +34,7 @@ impl Default for IterativeConfig {
 
 impl IterativeConfig {
     /// Builds a config with an explicit iteration count and rule.
+    #[must_use]
     pub fn from_parameters(total_iterations: u64, integration_method: IterativeMethod) -> Self {
         IterativeConfig {
             total_iterations,
@@ -185,6 +186,7 @@ impl<T> Default for IterativeSingle<T> {
 
 impl<T> IterativeSingle<T> {
     /// custom constructor. Optimal for fine-tuning for more complex equations
+    #[must_use]
     pub fn from_parameters(total_iterations: u64, integration_method: IterativeMethod) -> Self {
         IterativeSingle {
             config: IterativeConfig::from_parameters(total_iterations, integration_method),
@@ -196,6 +198,7 @@ impl<T> IterativeSingle<T> {
     ///
     /// Default is [`SummationMethod::Pairwise`]. Pass [`SummationMethod::Kahan`]
     /// for opt-in compensated summation.
+    #[must_use]
     pub fn with_kahan_summation(mut self) -> Self {
         self.config.summation = SummationMethod::Kahan;
         self
@@ -335,6 +338,7 @@ impl<T> Default for IterativeMulti<T> {
 
 impl<T> IterativeMulti<T> {
     /// custom constructor, optimal for fine-tuning the integrator for more complex equations
+    #[must_use]
     pub fn from_parameters(total_iterations: u64, integration_method: IterativeMethod) -> Self {
         IterativeMulti {
             config: IterativeConfig::from_parameters(total_iterations, integration_method),
@@ -343,6 +347,7 @@ impl<T> IterativeMulti<T> {
     }
 
     /// Opt in to Kahan compensated summation for the composite-rule accumulators.
+    #[must_use]
     pub fn with_kahan_summation(mut self) -> Self {
         self.config.summation = SummationMethod::Kahan;
         self

--- a/crates/multicalc/src/ode/rk45.rs
+++ b/crates/multicalc/src/ode/rk45.rs
@@ -68,33 +68,44 @@ impl<T: Numeric> Default for Rk45<T> {
 
 impl<T: Numeric> Rk45<T> {
     /// Sets the relative tolerance (default `1e-6`).
+    /// ```compile_fail
+    /// #![deny(unused_must_use)]
+    /// use multicalc::ode::Rk45;
+    /// Rk45::default().with_rtol(1e-8); //discarded builder result
+    /// ```
+    #[must_use]
     pub fn with_rtol(mut self, rtol: T) -> Self {
         self.rtol = rtol;
         self
     }
     /// Sets the absolute tolerance (default `1e-9`).
+    #[must_use]
     pub fn with_atol(mut self, atol: T) -> Self {
         self.atol = atol;
         self
     }
     /// Sets the first step size; `0` (the default) auto-selects it.
+    #[must_use]
     pub fn with_first_step(mut self, h: T) -> Self {
         self.first_step = h;
         self
     }
     /// Sets the minimum step magnitude; falling below it returns [`IntegrateError::StepSizeTooSmall`].
     /// `0` (the default) disables the floor.
+    #[must_use]
     pub fn with_min_step(mut self, h: T) -> Self {
         self.min_step = h;
         self
     }
     /// Sets the maximum step magnitude (default unbounded).
+    #[must_use]
     pub fn with_max_step(mut self, h: T) -> Self {
         self.max_step = h;
         self
     }
     /// Sets the maximum number of step attempts before [`IntegrateError::DidNotConverge`]
     /// (default `100_000`).
+    #[must_use]
     pub fn with_max_steps(mut self, n: usize) -> Self {
         self.max_steps = n;
         self
@@ -103,6 +114,7 @@ impl<T: Numeric> Rk45<T> {
 
 /// RMS of `err_i / (atol + rtol * max(|y0_i|, |y1_i|))` over the components.
 /// Returns `T::ZERO` when `N == 0`.
+#[must_use]
 fn error_norm<const N: usize, T: Numeric>(
     err: &Vector<N, T>,
     y0: &Vector<N, T>,
@@ -124,6 +136,7 @@ fn error_norm<const N: usize, T: Numeric>(
 
 /// RMS of `v_i / (atol + rtol * |y_i|)` — used by the initial-step heuristic.
 /// Returns `T::ZERO` when `N == 0`.
+#[must_use]
 fn scaled_norm<const N: usize, T: Numeric>(
     v: &Vector<N, T>,
     y: &Vector<N, T>,
@@ -220,6 +233,7 @@ impl<T: Numeric> Rk45<T> {
     /// scaled norms of `y0` and `f0`, take one explicit Euler probe to estimate the second
     /// derivative, then combine them for a step matched to the method order (5). `f0` is
     /// `f(t0, y0)` and `span` is `|tf − t0|`; the result never exceeds `max_step` or `span`.
+    #[must_use]
     fn select_initial_step<const N: usize, F>(
         &self,
         f: &F,

--- a/crates/multicalc/src/optimization/mod.rs
+++ b/crates/multicalc/src/optimization/mod.rs
@@ -50,6 +50,7 @@ pub struct MinimizationReport<const N: usize, T = f64> {
 }
 
 /// Whether every element of `v` is finite.
+#[must_use]
 pub(crate) fn is_finite<const K: usize, T: Numeric>(v: &[T; K]) -> bool {
     v.iter().all(|value| value.is_finite())
 }

--- a/crates/multicalc/src/optimization/trust_region.rs
+++ b/crates/multicalc/src/optimization/trust_region.rs
@@ -17,6 +17,7 @@ pub(crate) struct LmParameter<const N: usize, T = f64> {
 ///
 /// Runs a bounded Newton iteration on `λ` (at most 10 steps), reusing the one factorization in
 /// `dls` for every trial. `delta` must be positive and every entry of `diag` must be positive.
+#[must_use]
 pub(crate) fn determine_lambda_and_parameter_update<const N: usize, T: Numeric>(
     dls: &DampedLeastSquares<N, T>,
     diag: &[T; N],

--- a/crates/multicalc/src/random.rs
+++ b/crates/multicalc/src/random.rs
@@ -11,14 +11,17 @@
 /// A source of random 32-bit words, and the uniform and normal draws built from them.
 pub trait RandomSource {
     /// The next raw 32-bit word.
+    #[must_use]
     fn next_u32(&mut self) -> u32;
 
     /// The next 64-bit word, from two 32-bit words (high word first).
+    #[must_use]
     fn next_u64(&mut self) -> u64 {
         ((self.next_u32() as u64) << 32) | (self.next_u32() as u64)
     }
 
     /// A uniform draw in the half-open range 0.0 up to 1.0, with 53 bits of precision.
+    #[must_use]
     fn next_unit_f64(&mut self) -> f64 {
         // Top 53 bits scaled into [0, 1); the low 11 bits are dropped so the result never reaches 1.
         (self.next_u64() >> 11) as f64 * (1.0 / (1u64 << 53) as f64)
@@ -28,6 +31,7 @@ pub trait RandomSource {
     ///
     /// Uses the polar pair method and returns one of the pair, consuming two uniform draws. The
     /// first draw is nudged off zero so the logarithm stays finite.
+    #[must_use]
     fn standard_normal(&mut self) -> f64 {
         let mut first = self.next_unit_f64();
         if first <= f64::MIN_POSITIVE {

--- a/crates/multicalc/src/root_finding/mod.rs
+++ b/crates/multicalc/src/root_finding/mod.rs
@@ -61,11 +61,13 @@ pub struct RootReportN<const N: usize, T = f64> {
 ///
 /// Built from comparisons rather than multiplication so it is correct for infinities
 /// and does not overflow.
+#[must_use]
 pub(crate) fn same_sign<T: Numeric>(a: T, b: T) -> bool {
     (a >= T::ZERO) == (b >= T::ZERO)
 }
 
 /// Returns `true` when every element of `v` is finite.
+#[must_use]
 pub(crate) fn all_finite<const K: usize, T: Numeric>(v: &[T; K]) -> bool {
     v.iter().all(|x| x.is_finite())
 }

--- a/crates/multicalc/src/scalar/dual.rs
+++ b/crates/multicalc/src/scalar/dual.rs
@@ -25,12 +25,14 @@ pub struct Dual<T: Numeric = f64> {
 impl<T: Numeric> Dual<T> {
     /// A dual number with an explicit value and derivative.
     #[inline]
+    #[must_use]
     pub fn new(value: T, deriv: T) -> Self {
         Dual { value, deriv }
     }
 
     /// A constant, whose derivative with respect to the variable is zero.
     #[inline]
+    #[must_use]
     pub fn constant(value: T) -> Self {
         Dual {
             value,
@@ -40,6 +42,7 @@ impl<T: Numeric> Dual<T> {
 
     /// The independent variable, seeded with derivative one.
     #[inline]
+    #[must_use]
     pub fn variable(value: T) -> Self {
         Dual {
             value,

--- a/crates/multicalc/src/scalar/function.rs
+++ b/crates/multicalc/src/scalar/function.rs
@@ -40,6 +40,7 @@ pub(crate) struct Component<'a, F, const N: usize, const M: usize> {
 impl<'a, F: VectorFn<N, M>, const N: usize, const M: usize> Component<'a, F, N, M> {
     /// Wraps output `index` of `func`. `N`/`M` are inferred from the function's [`VectorFn`] impl.
     #[inline]
+    #[must_use]
     pub fn new(func: &'a F, index: usize) -> Self {
         Component { func, index }
     }
@@ -63,6 +64,7 @@ pub struct Const(f64);
 /// Marks a scalar constant in a `scalar_fn!` body. Place it on the left of the operator
 /// (`c(2.0) * x`, `c(1.0) + x`); the constant takes the function's scalar type.
 #[inline]
+#[must_use]
 pub fn c(value: f64) -> Const {
     Const(value)
 }

--- a/crates/multicalc/src/scalar/hyper_dual.rs
+++ b/crates/multicalc/src/scalar/hyper_dual.rs
@@ -31,6 +31,7 @@ pub struct HyperDual<T: Numeric = f64> {
 impl<T: Numeric> HyperDual<T> {
     /// A hyper-dual number with explicit components.
     #[inline]
+    #[must_use]
     pub fn new(real: T, eps1: T, eps2: T, eps1eps2: T) -> Self {
         HyperDual {
             real,
@@ -42,6 +43,7 @@ impl<T: Numeric> HyperDual<T> {
 
     /// A constant, whose derivatives are all zero.
     #[inline]
+    #[must_use]
     pub fn constant(real: T) -> Self {
         HyperDual {
             real,
@@ -55,6 +57,7 @@ impl<T: Numeric> HyperDual<T> {
     /// single-variable function. For a mixed partial, seed two inputs on separate directions with
     /// `new(xᵢ, 1, 0, 0)` and `new(xⱼ, 0, 1, 0)`.
     #[inline]
+    #[must_use]
     pub fn variable(real: T) -> Self {
         HyperDual {
             real,
@@ -69,6 +72,7 @@ impl<T: Numeric> HyperDual<T> {
     /// With `val = φ(real)`, `d1 = φ'(real)`, `d2 = φ''(real)`, this carries the chain rule
     /// through to second order.
     #[inline]
+    #[must_use]
     fn chain(self, val: T, d1: T, d2: T) -> Self {
         HyperDual {
             real: val,
@@ -80,6 +84,7 @@ impl<T: Numeric> HyperDual<T> {
 
     /// The reciprocal `1/self`, via `φ(x) = 1/x` (`φ' = -1/x²`, `φ'' = 2/x³`).
     #[inline]
+    #[must_use]
     fn recip(self) -> Self {
         let t = T::ONE / self.real;
         self.chain(t, -(t * t), T::TWO * t * t * t)

--- a/crates/multicalc/src/scalar/jet.rs
+++ b/crates/multicalc/src/scalar/jet.rs
@@ -24,12 +24,14 @@ pub struct Jet<T: Numeric, const N: usize> {
 impl<T: Numeric, const N: usize> Jet<T, N> {
     /// A jet with explicit coefficients.
     #[inline]
+    #[must_use]
     pub fn new(coeffs: [T; N]) -> Self {
         Jet { coeffs }
     }
 
     /// A constant: value in `coeffs[0]`, all derivatives zero.
     #[inline]
+    #[must_use]
     pub const fn constant(value: T) -> Self {
         let mut coeffs = [T::ZERO; N];
         coeffs[0] = value;
@@ -39,6 +41,7 @@ impl<T: Numeric, const N: usize> Jet<T, N> {
     /// The independent variable, seeded to read every derivative of a single-variable function
     /// (`coeffs[0] = x`, `coeffs[1] = 1`). Requires `N >= 2`.
     #[inline]
+    #[must_use]
     pub fn variable(value: T) -> Self {
         const { assert!(N >= 2, "Jet::variable needs at least 2 coefficients") };
         let mut coeffs = [T::ZERO; N];
@@ -49,18 +52,21 @@ impl<T: Numeric, const N: usize> Jet<T, N> {
 
     /// The value `f(x)` (= `coeffs[0]`).
     #[inline]
+    #[must_use]
     pub fn value(&self) -> T {
         self.coeffs[0]
     }
 
     /// The `k`-th Taylor coefficient `f⁽ᵏ⁾(x) / k!`.
     #[inline]
+    #[must_use]
     pub fn coefficient(&self, k: usize) -> T {
         self.coeffs[k]
     }
 
     /// The `k`-th derivative `f⁽ᵏ⁾(x)` (= `k! · coeffs[k]`).
     #[inline]
+    #[must_use]
     pub fn derivative(&self, k: usize) -> T {
         let mut factorial = T::ONE;
         for i in 2..=k {
@@ -184,6 +190,7 @@ impl<T: Numeric, const N: usize> PartialOrd for Jet<T, N> {
 impl<T: Numeric, const N: usize> Jet<T, N> {
     /// `sin` and `cos` of the jet, computed together (each recurrence needs the other).
     #[inline]
+    #[must_use]
     fn sin_cos(self) -> (Self, Self) {
         let v = &self.coeffs;
         let mut s = [T::ZERO; N];

--- a/crates/multicalc/src/signal_processing/biquad.rs
+++ b/crates/multicalc/src/signal_processing/biquad.rs
@@ -272,6 +272,7 @@ impl<T: Numeric> BiquadCoefficients<T> {
 
     /// The response at one frequency, as the real and imaginary part of the input side followed by
     /// the real and imaginary part of the output side.
+    #[must_use]
     fn response_parts(&self, frequency_hz: T) -> (T, T, T, T) {
         let angle = T::TWO * T::PI * frequency_hz * self.dt;
         let cosine = angle.cos();
@@ -353,6 +354,7 @@ impl<T: Numeric> BiquadCoefficients<T> {
     /// Divides the six raw weights through by the leading output weight and keeps the five that
     /// are left. [`Self::build`] reaches this only after its arguments pass
     /// [`Self::check_design`], which leaves the divisor above one.
+    #[must_use]
     fn from_unnormalized(feed_forward: [T; 3], feedback: [T; 3], dt: T) -> Self {
         let leading = feedback[0];
         Self {
@@ -400,7 +402,7 @@ impl<T: Numeric> BiquadCoefficients<T> {
 /// // A notch passes a steady input through, so this settles on 1.
 /// let mut running = Biquad::new(BiquadCoefficients::notch(180.0_f64, 4.0, 0.001).unwrap());
 /// for _ in 0..1000 {
-///     running.filter(1.0);
+///     let _ = running.filter(1.0);
 /// }
 ///
 /// // Moving the notch to 210 Hz barely disturbs the output.
@@ -424,6 +426,7 @@ impl<T: Numeric> Biquad<T> {
     /// Builds a filter at rest from a set of weights.
     ///
     /// This cannot fail: the weights were checked when they were designed.
+    #[must_use]
     pub fn new(coefficients: BiquadCoefficients<T>) -> Self {
         Self {
             coefficients,
@@ -435,6 +438,7 @@ impl<T: Numeric> Biquad<T> {
 
     /// Feeds one sample and returns the filtered output.
     #[inline]
+    #[must_use]
     pub fn filter(&mut self, input: T) -> T {
         let feed_forward = self.coefficients.feed_forward();
         let feedback = self.coefficients.feedback();

--- a/crates/multicalc/src/signal_processing/cascade.rs
+++ b/crates/multicalc/src/signal_processing/cascade.rs
@@ -22,7 +22,7 @@ use crate::signal_processing::{Biquad, BiquadCoefficients};
 ///
 /// // A steady input still comes through untouched.
 /// for _ in 0..500 {
-///     cascade.filter(5.0);
+///     let _ = cascade.filter(5.0);
 /// }
 /// assert!((cascade.value() - 5.0).abs() < 1e-9);
 /// ```
@@ -33,6 +33,7 @@ pub struct BiquadCascade<const SECTIONS: usize, T: Numeric = f64> {
 
 impl<const SECTIONS: usize, T: Numeric> BiquadCascade<SECTIONS, T> {
     /// Builds a cascade at rest, one section per set of weights.
+    #[must_use]
     pub fn new(coefficients: [BiquadCoefficients<T>; SECTIONS]) -> Self {
         Self {
             sections: core::array::from_fn(|index| Biquad::new(coefficients[index])),
@@ -41,6 +42,7 @@ impl<const SECTIONS: usize, T: Numeric> BiquadCascade<SECTIONS, T> {
 
     /// Feeds one sample through every section in order and returns what comes out the far end.
     #[inline]
+    #[must_use]
     pub fn filter(&mut self, input: T) -> T {
         let mut value = input;
         for section in &mut self.sections {
@@ -151,7 +153,7 @@ impl<const SECTIONS: usize, T: Numeric> BiquadCascade<SECTIONS, T> {
 /// // Three axes held steady come through untouched, each on its own.
 /// let reading = Vector::new([1.0, -2.0, 0.5]);
 /// for _ in 0..500 {
-///     filter.filter(reading);
+///     let _ = filter.filter(reading);
 /// }
 /// let settled = filter.value();
 /// for channel in 0..3 {
@@ -165,6 +167,7 @@ pub struct MultiChannelBiquad<const CHANNELS: usize, T: Numeric = f64> {
 
 impl<const CHANNELS: usize, T: Numeric> MultiChannelBiquad<CHANNELS, T> {
     /// Builds a filter at rest, giving every channel the same shape and its own memory.
+    #[must_use]
     pub fn new(coefficients: BiquadCoefficients<T>) -> Self {
         Self {
             channels: core::array::from_fn(|_| Biquad::new(coefficients)),

--- a/crates/multicalc/src/signal_processing/conditioning.rs
+++ b/crates/multicalc/src/signal_processing/conditioning.rs
@@ -142,6 +142,7 @@ impl<T: Numeric> Hysteresis<T> {
 
     /// Feeds one value and returns the answer it leaves behind.
     #[inline]
+    #[must_use]
     pub fn update(&mut self, input: T) -> bool {
         if input > self.upper {
             self.is_high = true;
@@ -184,7 +185,7 @@ impl<T: Numeric> Hysteresis<T> {
 /// // A jump to 10 comes out as a ramp: a tenth of a unit per call.
 /// assert!((limited.filter(10.0) - 0.1).abs() < 1e-12);
 /// for _ in 0..9 {
-///     limited.filter(10.0);
+///     let _ = limited.filter(10.0);
 /// }
 /// assert!((limited.value() - 1.0).abs() < 1e-12);
 ///
@@ -244,6 +245,7 @@ impl<T: Numeric> SlewRateLimiter<T> {
 
     /// Moves one step toward the target and returns where the output now sits.
     #[inline]
+    #[must_use]
     pub fn filter(&mut self, target: T) -> T {
         if !self.initialized {
             self.state = target;

--- a/crates/multicalc/src/signal_processing/one_pole.rs
+++ b/crates/multicalc/src/signal_processing/one_pole.rs
@@ -24,7 +24,7 @@ use crate::scalar::Numeric;
 /// let mut smoother = OnePoleLowPass::new(half_new_half_old).unwrap();
 /// let steady_input = 10.0;
 /// for _ in 0..64 {
-///     smoother.filter(steady_input);
+///     let _ = smoother.filter(steady_input);
 /// }
 /// assert!((smoother.value() - steady_input).abs() < 1e-9);
 /// ```
@@ -77,6 +77,7 @@ impl<T: Numeric> OnePoleLowPass<T> {
 
     /// Feeds one sample and returns the updated output.
     #[inline]
+    #[must_use]
     pub fn filter(&mut self, input: T) -> T {
         if self.initialized {
             self.state = self.smoothing * input + (T::ONE - self.smoothing) * self.state;

--- a/crates/multicalc/src/signal_processing/savitzky_golay.rs
+++ b/crates/multicalc/src/signal_processing/savitzky_golay.rs
@@ -33,7 +33,7 @@ use crate::scalar::Numeric;
 /// let mut time = 0.0;
 /// for sample in 0..200 {
 ///     time = sample as f64 * dt;
-///     fitted.filter(0.5 * time * time);
+///     let _ = fitted.filter(0.5 * time * time);
 /// }
 /// assert!((fitted.first_derivative() - time).abs() < 1e-6);
 /// assert!((fitted.second_derivative() - 1.0).abs() < 1e-6);
@@ -95,6 +95,7 @@ impl<const WINDOW: usize, const POLYNOMIAL_TERMS: usize, T: Numeric>
 
     /// Feeds one sample and returns the smoothed value of the window it now sits in.
     #[inline]
+    #[must_use]
     pub fn filter(&mut self, input: T) -> T {
         if self.initialized {
             self.samples[self.next] = input;
@@ -199,6 +200,7 @@ impl<const WINDOW: usize, const POLYNOMIAL_TERMS: usize, T: Numeric>
 
     /// The window against one weight row, walked oldest to newest from the write index.
     #[inline]
+    #[must_use]
     fn weighted_sum(&self, weights: &[T; WINDOW]) -> T {
         let mut total = T::ZERO;
         #[allow(clippy::needless_range_loop)]

--- a/crates/multicalc/src/signal_processing/window.rs
+++ b/crates/multicalc/src/signal_processing/window.rs
@@ -51,6 +51,7 @@ impl<const WINDOW: usize, T: Numeric> MovingAverage<WINDOW, T> {
 
     /// Feeds one sample and returns the average of the window it now sits in.
     #[inline]
+    #[must_use]
     pub fn filter(&mut self, input: T) -> T {
         push(
             &mut self.samples,
@@ -104,7 +105,7 @@ impl<const WINDOW: usize, T: Numeric> MovingAverage<WINDOW, T> {
 ///
 /// let mut median = RunningMedian::<5, f64>::new().unwrap();
 /// for reading in [1.0, 1.1, 0.9, 50.0, 1.05] {
-///     median.filter(reading);
+///     let _ = median.filter(reading);
 /// }
 ///
 /// // The one wild reading does not move the answer at all.
@@ -147,6 +148,7 @@ impl<const WINDOW: usize, T: Numeric> RunningMedian<WINDOW, T> {
 
     /// Feeds one sample and returns the middle value of the window it now sits in.
     #[inline]
+    #[must_use]
     pub fn filter(&mut self, input: T) -> T {
         push(
             &mut self.samples,

--- a/crates/multicalc/src/spatial/free_joint.rs
+++ b/crates/multicalc/src/spatial/free_joint.rs
@@ -44,6 +44,7 @@ impl<T: Numeric> FreeJointState<T> {
     /// assert_eq!(state.velocity(), Twist::zeros());
     /// ```
     #[inline]
+    #[must_use]
     pub fn new(pose: SE3<T>, velocity: Twist<T>) -> Self {
         FreeJointState { pose, velocity }
     }
@@ -58,6 +59,7 @@ impl<T: Numeric> FreeJointState<T> {
     /// );
     /// ```
     #[inline]
+    #[must_use]
     pub fn identity() -> Self {
         FreeJointState {
             pose: SE3::identity(),
@@ -92,6 +94,7 @@ impl<T: Numeric> FreeJointState<T> {
     ///
     /// assert!(FreeJointState::from_generalized_vectors([0.0_f64; 7], [0.0; 6]).is_none());
     /// ```
+    #[must_use]
     pub fn from_generalized_vectors(position: [T; 7], velocity: [T; 6]) -> Option<Self> {
         let [x, y, z, w, qx, qy, qz] = position;
         let orientation = Quaternion::new(w, qx, qy, qz).try_normalized()?;

--- a/crates/multicalc/src/spatial/lie/se2.rs
+++ b/crates/multicalc/src/spatial/lie/se2.rs
@@ -18,6 +18,7 @@ pub struct SE2<T: Numeric = f64> {
 impl<T: Numeric> SE2<T> {
     /// The identity transform.
     #[inline]
+    #[must_use]
     pub fn identity() -> Self {
         SE2 {
             rotation: SO2::identity(),
@@ -27,6 +28,7 @@ impl<T: Numeric> SE2<T> {
 
     /// A transform from a rotation and translation.
     #[inline]
+    #[must_use]
     pub fn from_parts(rotation: SO2<T>, translation: Vector2D<T>) -> Self {
         SE2 {
             rotation,
@@ -36,6 +38,7 @@ impl<T: Numeric> SE2<T> {
 
     /// The rotation part.
     #[inline]
+    #[must_use]
     pub fn rotation(self) -> SO2<T> {
         self.rotation
     }
@@ -48,6 +51,7 @@ impl<T: Numeric> SE2<T> {
 
     /// Composition (also available as `*`).
     #[inline]
+    #[must_use]
     pub fn compose(self, rhs: Self) -> Self {
         SE2 {
             rotation: self.rotation.compose(rhs.rotation),
@@ -57,6 +61,7 @@ impl<T: Numeric> SE2<T> {
 
     /// The inverse transform.
     #[inline]
+    #[must_use]
     pub fn inverse(self) -> Self {
         let r_inv = self.rotation.inverse();
         SE2 {
@@ -74,6 +79,7 @@ impl<T: Numeric> SE2<T> {
     /// The exponential map from a `[vx, vy, ω]` twist. Near ω = 0 the `V(θ)` block uses a Taylor
     /// series, keeping the value and its derivative finite.
     #[inline]
+    #[must_use]
     pub fn exp(xi: Vector3D<T>) -> Self {
         let [vx, vy, omega] = *xi.as_array();
         let theta_sq = omega * omega;
@@ -143,6 +149,7 @@ impl<T: Numeric> SE2<T> {
 
     /// Builds a transform from a 3×3 homogeneous matrix; `None` if the rotation block is degenerate.
     #[inline]
+    #[must_use]
     pub fn try_from_matrix(m: Matrix3D<T>) -> Option<Self> {
         let [[m00, m01, m02], [m10, m11, m12], _] = m.into_array();
         let r = SO2::try_from_matrix(Matrix::new([[m00, m01], [m10, m11]]))?;
@@ -154,6 +161,7 @@ impl<T: Numeric> SE2<T> {
 
     /// Geodesic interpolation; `t = 0` gives `self`, `t = 1` gives `other`.
     #[inline]
+    #[must_use]
     pub fn interpolate(self, other: Self, t: T) -> Self {
         self.compose(Self::exp(self.inverse().compose(other).log() * t))
     }

--- a/crates/multicalc/src/spatial/lie/se3.rs
+++ b/crates/multicalc/src/spatial/lie/se3.rs
@@ -20,6 +20,7 @@ pub struct SE3<T: Numeric = f64> {
 impl<T: Numeric> SE3<T> {
     /// The identity transform.
     #[inline]
+    #[must_use]
     pub fn identity() -> Self {
         SE3 {
             rotation: SO3::identity(),
@@ -29,6 +30,7 @@ impl<T: Numeric> SE3<T> {
 
     /// A transform from a rotation and translation.
     #[inline]
+    #[must_use]
     pub fn from_parts(rotation: SO3<T>, translation: Vector3D<T>) -> Self {
         SE3 {
             rotation,
@@ -38,6 +40,7 @@ impl<T: Numeric> SE3<T> {
 
     /// The rotation part.
     #[inline]
+    #[must_use]
     pub fn rotation(self) -> SO3<T> {
         self.rotation
     }
@@ -50,6 +53,7 @@ impl<T: Numeric> SE3<T> {
 
     /// Composition (also available as `*`).
     #[inline]
+    #[must_use]
     pub fn compose(self, rhs: Self) -> Self {
         SE3 {
             rotation: self.rotation.compose(rhs.rotation),
@@ -59,6 +63,7 @@ impl<T: Numeric> SE3<T> {
 
     /// The inverse transform.
     #[inline]
+    #[must_use]
     pub fn inverse(self) -> Self {
         let r_inv = self.rotation.inverse();
         SE3 {
@@ -76,6 +81,7 @@ impl<T: Numeric> SE3<T> {
     /// The exponential map from a `[v; ω]` twist. Near θ = 0 the SO(3) left Jacobian uses a Taylor
     /// series, keeping the value and its derivative finite.
     #[inline]
+    #[must_use]
     pub fn exp(xi: Vector6D<T>) -> Self {
         let [vx, vy, vz, px, py, pz] = *xi.as_array();
         let v = Vector::new([vx, vy, vz]);
@@ -151,6 +157,7 @@ impl<T: Numeric> SE3<T> {
 
     /// Builds a transform from a 4×4 homogeneous matrix; `None` if the rotation block is degenerate.
     #[inline]
+    #[must_use]
     pub fn try_from_matrix(m: Matrix4D<T>) -> Option<Self> {
         let mut r = Matrix::zeros();
         for i in 0..3 {
@@ -168,6 +175,7 @@ impl<T: Numeric> SE3<T> {
 
     /// Geodesic (screw-motion) interpolation; `t = 0` gives `self`, `t = 1` gives `other`.
     #[inline]
+    #[must_use]
     pub fn interpolate(self, other: Self, t: T) -> Self {
         self.compose(Self::exp(self.inverse().compose(other).log() * t))
     }

--- a/crates/multicalc/src/spatial/lie/so2.rs
+++ b/crates/multicalc/src/spatial/lie/so2.rs
@@ -17,6 +17,7 @@ pub struct SO2<T: Numeric = f64> {
 impl<T: Numeric> SO2<T> {
     /// The zero rotation.
     #[inline]
+    #[must_use]
     pub fn identity() -> Self {
         SO2 {
             c: T::ONE,
@@ -26,6 +27,7 @@ impl<T: Numeric> SO2<T> {
 
     /// The rotation by `theta` radians.
     #[inline]
+    #[must_use]
     pub fn from_angle(theta: T) -> Self {
         SO2 {
             c: theta.cos(),
@@ -35,12 +37,14 @@ impl<T: Numeric> SO2<T> {
 
     /// The `(cos, sin)` components.
     #[inline]
+    #[must_use]
     pub fn cos_sin(self) -> (T, T) {
         (self.c, self.s)
     }
 
     /// Composition (also available as `*`).
     #[inline]
+    #[must_use]
     pub fn compose(self, rhs: Self) -> Self {
         SO2 {
             c: self.c * rhs.c - self.s * rhs.s,
@@ -50,6 +54,7 @@ impl<T: Numeric> SO2<T> {
 
     /// The inverse rotation.
     #[inline]
+    #[must_use]
     pub fn inverse(self) -> Self {
         SO2 {
             c: self.c,
@@ -66,12 +71,14 @@ impl<T: Numeric> SO2<T> {
 
     /// The exponential map from the tangent angle.
     #[inline]
+    #[must_use]
     pub fn exp(theta: T) -> Self {
         Self::from_angle(theta)
     }
 
     /// The logarithm, the tangent angle in `(−π, π]`.
     #[inline]
+    #[must_use]
     pub fn log(self) -> T {
         self.s.atan2(self.c)
     }
@@ -84,6 +91,7 @@ impl<T: Numeric> SO2<T> {
 
     /// The inverse of [`SO2::hat`].
     #[inline]
+    #[must_use]
     pub fn vee(m: Matrix2D<T>) -> T {
         let [[_, _], [m10, _]] = m.into_array();
         m10
@@ -91,6 +99,7 @@ impl<T: Numeric> SO2<T> {
 
     /// The adjoint, which is `1` (SO(2) is abelian).
     #[inline]
+    #[must_use]
     pub fn adjoint(self) -> T {
         T::ONE
     }
@@ -104,6 +113,7 @@ impl<T: Numeric> SO2<T> {
     /// Builds a rotation from a 2×2 matrix, normalizing its first column; `None` if that column is
     /// non-finite or degenerate.
     #[inline]
+    #[must_use]
     pub fn try_from_matrix(m: Matrix2D<T>) -> Option<Self> {
         let [[c, _], [s, _]] = m.into_array();
         let n = (c * c + s * s).sqrt();
@@ -116,12 +126,14 @@ impl<T: Numeric> SO2<T> {
 
     /// Geodesic interpolation; `t = 0` gives `self`, `t = 1` gives `other`.
     #[inline]
+    #[must_use]
     pub fn interpolate(self, other: Self, t: T) -> Self {
         self.compose(Self::exp(self.inverse().compose(other).log() * t))
     }
 
     /// The squared norm `c² + s²`.
     #[inline]
+    #[must_use]
     fn norm_squared(self) -> T {
         self.c * self.c + self.s * self.s
     }
@@ -153,6 +165,7 @@ impl<T: Numeric> SO2<T> {
     /// assert!((normalized.norm() - 1.0).abs() <= <f64 as multicalc::Numeric>::EPSILON);
     /// ```
     #[inline]
+    #[must_use]
     pub fn normalized(self) -> Self {
         let scale = self.norm().recip();
         SO2 {
@@ -163,24 +176,28 @@ impl<T: Numeric> SO2<T> {
 
     /// The SO(2) left Jacobian, which is `1` (SO(2) is abelian).
     #[inline]
+    #[must_use]
     pub fn left_jacobian(_theta: T) -> T {
         T::ONE
     }
 
     /// The SO(2) right Jacobian, which is `1` (SO(2) is abelian).
     #[inline]
+    #[must_use]
     pub fn right_jacobian(_theta: T) -> T {
         T::ONE
     }
 
     /// The inverse SO(2) left Jacobian, which is `1` (SO(2) is abelian).
     #[inline]
+    #[must_use]
     pub fn left_jacobian_inverse(_theta: T) -> T {
         T::ONE
     }
 
     /// The inverse SO(2) right Jacobian, which is `1` (SO(2) is abelian).
     #[inline]
+    #[must_use]
     pub fn right_jacobian_inverse(_theta: T) -> T {
         T::ONE
     }

--- a/crates/multicalc/src/spatial/lie/so3.rs
+++ b/crates/multicalc/src/spatial/lie/so3.rs
@@ -31,6 +31,7 @@ pub struct SO3<T: Numeric = f64> {
 impl<T: Numeric> SO3<T> {
     /// The zero rotation.
     #[inline]
+    #[must_use]
     pub fn identity() -> Self {
         SO3 {
             q: Quaternion::identity(),
@@ -40,30 +41,35 @@ impl<T: Numeric> SO3<T> {
     /// From a quaternion, normalized to unit norm. Yields NaN components for a zero quaternion, as
     /// float division does; use [`SO3::try_from_quaternion`] for a checked version.
     #[inline]
+    #[must_use]
     pub fn from_quaternion(q: Quaternion<T>) -> Self {
         SO3 { q: q.normalized() }
     }
 
     /// From a quaternion, or `None` if its norm is non-finite or underflows.
     #[inline]
+    #[must_use]
     pub fn try_from_quaternion(q: Quaternion<T>) -> Option<Self> {
         q.try_normalized().map(|q| SO3 { q })
     }
 
     /// The underlying unit quaternion.
     #[inline]
+    #[must_use]
     pub fn quaternion(self) -> Quaternion<T> {
         self.q
     }
 
     /// Composition (also available as `*`).
     #[inline]
+    #[must_use]
     pub fn compose(self, rhs: Self) -> Self {
         SO3 { q: self.q * rhs.q }
     }
 
     /// The inverse rotation.
     #[inline]
+    #[must_use]
     pub fn inverse(self) -> Self {
         SO3 {
             q: self.q.conjugate(),
@@ -79,6 +85,7 @@ impl<T: Numeric> SO3<T> {
     /// The exponential map from a rotation vector `φ = θ·n̂`. Near θ = 0 the underlying quaternion
     /// uses a Taylor series, so the derivative stays finite at φ = 0.
     #[inline]
+    #[must_use]
     pub fn exp(phi: Vector3D<T>) -> Self {
         SO3 {
             q: Quaternion::from_scaled_axis(phi),
@@ -118,12 +125,14 @@ impl<T: Numeric> SO3<T> {
 
     /// Builds a rotation from a 3×3 matrix; `None` if it is degenerate.
     #[inline]
+    #[must_use]
     pub fn try_from_matrix(m: Matrix3D<T>) -> Option<Self> {
         Quaternion::try_from_rotation_matrix(m).map(|q| SO3 { q })
     }
 
     /// Geodesic interpolation (slerp); `t = 0` gives `self`, `t = 1` gives `other`.
     #[inline]
+    #[must_use]
     pub fn interpolate(self, other: Self, t: T) -> Self {
         SO3 {
             q: self.q.slerp(other.q, t),
@@ -132,6 +141,7 @@ impl<T: Numeric> SO3<T> {
 
     /// This rotation renormalized, removing drift accumulated over long composition chains.
     #[inline]
+    #[must_use]
     pub fn normalized(self) -> Self {
         SO3 {
             q: self.q.normalized(),

--- a/crates/multicalc/src/spatial/mod.rs
+++ b/crates/multicalc/src/spatial/mod.rs
@@ -26,6 +26,7 @@ pub use wrench::Wrench;
 /// Also used for eps-scale proximity checks (e.g. Euler gimbal lock vs ±1).
 /// Scaled as `30 · EPSILON` so each scalar type gets a type-appropriate cutoff.
 #[inline]
+#[must_use]
 pub(crate) fn small_angle<T: Numeric>() -> T {
     T::EPSILON_X30
 }
@@ -33,6 +34,7 @@ pub(crate) fn small_angle<T: Numeric>() -> T {
 /// Squared small-angle threshold, `(30 · EPSILON)²`, for branches on θ² / ‖v‖² before
 /// `sqrt`.
 #[inline]
+#[must_use]
 pub(crate) fn small_angle_sq<T: Numeric>() -> T {
     small_angle::<T>() * small_angle::<T>()
 }

--- a/crates/multicalc/src/spatial/quaternion.rs
+++ b/crates/multicalc/src/spatial/quaternion.rs
@@ -47,6 +47,7 @@ pub struct Quaternion<T: Numeric = f64> {
 /// to an infinite norm and comes back as the zero vector, and `[1e-200, 0, 0]` underflows to a
 /// zero norm and comes back as `None`, though both name a perfectly good axis.
 #[inline]
+#[must_use]
 fn unit_direction<T: Numeric>(v: Vector<3, T>) -> Option<Vector<3, T>> {
     if !v.is_finite() {
         return None;
@@ -67,6 +68,7 @@ fn unit_direction<T: Numeric>(v: Vector<3, T>) -> Option<Vector<3, T>> {
 impl<T: Numeric> Quaternion<T> {
     /// A quaternion from its four components, in `[w, x, y, z]` order.
     #[inline]
+    #[must_use]
     pub fn new(w: T, x: T, y: T, z: T) -> Self {
         Quaternion { w, x, y, z }
     }
@@ -78,6 +80,7 @@ impl<T: Numeric> Quaternion<T> {
     /// assert_eq!(Quaternion::<f64>::identity().as_array(), [1.0, 0.0, 0.0, 0.0]);
     /// ```
     #[inline]
+    #[must_use]
     pub fn identity() -> Self {
         Quaternion {
             w: T::ONE,
@@ -89,6 +92,7 @@ impl<T: Numeric> Quaternion<T> {
 
     /// Builds a quaternion from a `[w, x, y, z]` array.
     #[inline]
+    #[must_use]
     pub fn from_array(a: [T; 4]) -> Self {
         let [w, x, y, z] = a;
         Quaternion { w, x, y, z }
@@ -96,6 +100,7 @@ impl<T: Numeric> Quaternion<T> {
 
     /// Builds a quaternion from a scalar part and a vector part.
     #[inline]
+    #[must_use]
     pub fn from_scalar_vector(w: T, v: Vector3D<T>) -> Self {
         let [x, y, z] = *v.as_array();
         Quaternion { w, x, y, z }
@@ -103,24 +108,28 @@ impl<T: Numeric> Quaternion<T> {
 
     /// The scalar (real) component.
     #[inline]
+    #[must_use]
     pub fn w(self) -> T {
         self.w
     }
 
     /// The `i` component.
     #[inline]
+    #[must_use]
     pub fn x(self) -> T {
         self.x
     }
 
     /// The `j` component.
     #[inline]
+    #[must_use]
     pub fn y(self) -> T {
         self.y
     }
 
     /// The `k` component.
     #[inline]
+    #[must_use]
     pub fn z(self) -> T {
         self.z
     }
@@ -133,12 +142,14 @@ impl<T: Numeric> Quaternion<T> {
 
     /// The components as a `[w, x, y, z]` array.
     #[inline]
+    #[must_use]
     pub fn as_array(self) -> [T; 4] {
         [self.w, self.x, self.y, self.z]
     }
 
     /// The conjugate `w − x·i − y·j − z·k`.
     #[inline]
+    #[must_use]
     pub fn conjugate(self) -> Self {
         Quaternion {
             w: self.w,
@@ -150,18 +161,21 @@ impl<T: Numeric> Quaternion<T> {
 
     /// The squared norm `w² + x² + y² + z²`.
     #[inline]
+    #[must_use]
     pub fn norm_squared(self) -> T {
         self.w * self.w + self.x * self.x + self.y * self.y + self.z * self.z
     }
 
     /// The Euclidean norm.
     #[inline]
+    #[must_use]
     pub fn norm(self) -> T {
         self.norm_squared().sqrt()
     }
 
     /// The four-component dot product.
     #[inline]
+    #[must_use]
     pub fn dot(self, r: Self) -> T {
         self.w * r.w + self.x * r.x + self.y * r.y + self.z * r.z
     }
@@ -169,6 +183,7 @@ impl<T: Numeric> Quaternion<T> {
     /// The inverse `conjugate / norm²`. For a unit quaternion this equals the conjugate. Yields
     /// `inf`/`NaN` for a zero quaternion, exactly as plain-float division does elsewhere.
     #[inline]
+    #[must_use]
     pub fn inverse(self) -> Self {
         self.conjugate() * self.norm_squared().recip()
     }
@@ -176,12 +191,14 @@ impl<T: Numeric> Quaternion<T> {
     /// This quaternion scaled to unit norm. Yields `NaN` components for a zero quaternion, as
     /// plain-float division does; use [`Quaternion::try_normalized`] for a checked version.
     #[inline]
+    #[must_use]
     pub fn normalized(self) -> Self {
         self * self.norm().recip()
     }
 
     /// This quaternion scaled to unit norm, or `None` if the norm is non-finite or underflows.
     #[inline]
+    #[must_use]
     pub fn try_normalized(self) -> Option<Self> {
         let n = self.norm();
         if !n.is_finite() || n <= T::EPSILON {
@@ -195,6 +212,7 @@ impl<T: Numeric> Quaternion<T> {
     /// part. Near `‖v‖ = 0` the `cos‖v‖` and `sin‖v‖/‖v‖` factors use Taylor series in `‖v‖²`,
     /// so no `sqrt` is taken there and the AD derivative stays finite at `v = 0`.
     #[inline]
+    #[must_use]
     pub fn exp(self) -> Self {
         let vn_sq = self.x * self.x + self.y * self.y + self.z * self.z;
         let ew = self.w.exp();
@@ -222,6 +240,7 @@ impl<T: Numeric> Quaternion<T> {
     /// direction is ill-defined, so the branch cut is left unhandled. For rotation logarithms use
     /// [`Quaternion::to_scaled_axis`], which resolves this region via the shortest-path sign fix.
     #[inline]
+    #[must_use]
     pub fn ln(self) -> Self {
         let n = self.norm();
         let vn = (self.x * self.x + self.y * self.y + self.z * self.z).sqrt();
@@ -257,6 +276,7 @@ impl<T: Numeric> Quaternion<T> {
     /// assert!((rotated[2] - 0.0).abs() < 1e-12);
     /// ```
     #[inline]
+    #[must_use]
     pub fn from_axis_angle(axis: Vector3D<T>, angle: T) -> Self {
         let an = axis.dot(axis).sqrt();
         if an <= T::EPSILON {
@@ -278,6 +298,7 @@ impl<T: Numeric> Quaternion<T> {
     /// Taylor series in `θ²`, so no `sqrt` is taken there and the AD derivative stays finite at
     /// `φ = 0` (a robot at rest).
     #[inline]
+    #[must_use]
     pub fn from_scaled_axis(rotvec: Vector3D<T>) -> Self {
         let theta_sq = rotvec.dot(rotvec);
         let (w, scale) = if theta_sq < small_angle_sq::<T>() {
@@ -303,6 +324,7 @@ impl<T: Numeric> Quaternion<T> {
     /// The rotation from ZYX intrinsic Euler angles: `R = Rz(yaw)·Ry(pitch)·Rx(roll)`. The result
     /// is a unit quaternion.
     #[inline]
+    #[must_use]
     pub fn from_euler_zyx(roll: T, pitch: T, yaw: T) -> Self {
         let (cr, sr) = ((roll * T::HALF).cos(), (roll * T::HALF).sin());
         let (cp, sp) = ((pitch * T::HALF).cos(), (pitch * T::HALF).sin());
@@ -391,6 +413,7 @@ impl<T: Numeric> Quaternion<T> {
     /// (orthonormal, determinant +1) rotation is assumed; `None` guards only against a degenerate
     /// pivot that would divide by zero.
     #[inline]
+    #[must_use]
     pub fn try_from_rotation_matrix(m: Matrix3D<T>) -> Option<Self> {
         let quarter = T::from_f64(0.25);
         let [[m00, m01, m02], [m10, m11, m12], [m20, m21, m22]] = m.into_array();
@@ -492,6 +515,7 @@ impl<T: Numeric> Quaternion<T> {
     /// (`pitch = ±π/2`) the roll/yaw split is not unique; this returns `pitch = ±π/2` and a
     /// consistent roll/yaw.
     #[inline]
+    #[must_use]
     pub fn to_euler_zyx(self) -> (T, T, T) {
         let (w, x, y, z) = (self.w, self.x, self.y, self.z);
         let two = T::TWO;
@@ -579,6 +603,7 @@ impl<T: Numeric> Quaternion<T> {
     /// product is negative) and falls back to normalized linear interpolation when the endpoints
     /// are nearly parallel. The result is renormalized.
     #[inline]
+    #[must_use]
     pub fn slerp(self, other: Self, t: T) -> Self {
         let mut d = self.dot(other);
         let mut q2 = other;

--- a/crates/multicalc/src/spatial/twist.rs
+++ b/crates/multicalc/src/spatial/twist.rs
@@ -43,6 +43,7 @@ impl<T: Numeric> Twist<T> {
     /// assert_eq!(t.angular(), Vector::new([4.0, 5.0, 6.0]));
     /// ```
     #[inline]
+    #[must_use]
     pub fn new(linear: Vector3D<T>, angular: Vector3D<T>) -> Self {
         Twist { linear, angular }
     }
@@ -54,6 +55,7 @@ impl<T: Numeric> Twist<T> {
     /// assert_eq!(Twist::<f64>::zeros().as_array(), [0.0; 6]);
     /// ```
     #[inline]
+    #[must_use]
     pub fn zeros() -> Self {
         Twist {
             linear: Vector::zeros(),
@@ -70,6 +72,7 @@ impl<T: Numeric> Twist<T> {
     /// assert_eq!(t.angular(), Vector::new([4.0, 5.0, 6.0]));
     /// ```
     #[inline]
+    #[must_use]
     pub fn from_array(a: [T; 6]) -> Self {
         let [vx, vy, vz, wx, wy, wz] = a;
         Twist {
@@ -86,6 +89,7 @@ impl<T: Numeric> Twist<T> {
     /// assert_eq!(t.as_array(), [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     /// ```
     #[inline]
+    #[must_use]
     pub fn as_array(self) -> [T; 6] {
         let [vx, vy, vz] = *self.linear.as_array();
         let [wx, wy, wz] = *self.angular.as_array();
@@ -101,6 +105,7 @@ impl<T: Numeric> Twist<T> {
     /// assert_eq!(t.linear(), Vector::new([1.0, 2.0, 3.0]));
     /// ```
     #[inline]
+    #[must_use]
     pub fn from_vector(v: Vector6D<T>) -> Self {
         Self::from_array(v.into_array())
     }
@@ -138,6 +143,7 @@ impl<T: Numeric> Twist<T> {
     /// assert_eq!(t.scale(2.0).as_array(), [2.0, 4.0, 6.0, 8.0, 10.0, 12.0]);
     /// ```
     #[inline]
+    #[must_use]
     pub fn scale(self, scalar: T) -> Self {
         Twist {
             linear: self.linear.scale(scalar),

--- a/crates/multicalc/src/spatial/wrench.rs
+++ b/crates/multicalc/src/spatial/wrench.rs
@@ -41,6 +41,7 @@ impl<T: Numeric> Wrench<T> {
     /// assert_eq!(w.torque(), Vector::new([4.0, 5.0, 6.0]));
     /// ```
     #[inline]
+    #[must_use]
     pub fn new(force: Vector3D<T>, torque: Vector3D<T>) -> Self {
         Wrench { force, torque }
     }
@@ -52,6 +53,7 @@ impl<T: Numeric> Wrench<T> {
     /// assert_eq!(Wrench::<f64>::zeros().as_array(), [0.0; 6]);
     /// ```
     #[inline]
+    #[must_use]
     pub fn zeros() -> Self {
         Wrench {
             force: Vector::zeros(),
@@ -68,6 +70,7 @@ impl<T: Numeric> Wrench<T> {
     /// assert_eq!(w.torque(), Vector::new([4.0, 5.0, 6.0]));
     /// ```
     #[inline]
+    #[must_use]
     pub fn from_array(a: [T; 6]) -> Self {
         let [vx, vy, vz, wx, wy, wz] = a;
         Wrench {
@@ -84,6 +87,7 @@ impl<T: Numeric> Wrench<T> {
     /// assert_eq!(w.as_array(), [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     /// ```
     #[inline]
+    #[must_use]
     pub fn as_array(self) -> [T; 6] {
         let [fx, fy, fz] = *self.force.as_array();
         let [tx, ty, tz] = *self.torque.as_array();
@@ -99,6 +103,7 @@ impl<T: Numeric> Wrench<T> {
     /// assert_eq!(w.force(), Vector::new([1.0, 2.0, 3.0]));
     /// ```
     #[inline]
+    #[must_use]
     pub fn from_vector(v: Vector6D<T>) -> Self {
         Self::from_array(v.into_array())
     }
@@ -136,6 +141,7 @@ impl<T: Numeric> Wrench<T> {
     /// assert_eq!(w.scale(2.0).as_array(), [2.0, 4.0, 6.0, 8.0, 10.0, 12.0]);
     /// ```
     #[inline]
+    #[must_use]
     pub fn scale(self, scalar: T) -> Self {
         Wrench {
             force: self.force.scale(scalar),

--- a/crates/multicalc/src/utils/summation.rs
+++ b/crates/multicalc/src/utils/summation.rs
@@ -30,6 +30,7 @@ pub(crate) struct PairwiseSum<T: Numeric> {
 
 impl<T: Numeric> PairwiseSum<T> {
     #[inline]
+    #[must_use]
     pub(crate) fn new() -> Self {
         Self {
             tree: [T::ZERO; LEVELS],
@@ -70,6 +71,7 @@ impl<T: Numeric> PairwiseSum<T> {
     }
 
     #[inline]
+    #[must_use]
     pub(crate) fn total(&self) -> T {
         // Combine the live tree slots (smallest first) with the partial block. Scan only up
         // to the highest occupied level (~log2 n): an unfilled block leaves the tree empty,
@@ -110,6 +112,7 @@ pub(crate) struct KahanSum<T: Numeric> {
 
 impl<T: Numeric> KahanSum<T> {
     #[inline]
+    #[must_use]
     pub(crate) fn new() -> Self {
         Self {
             sum: T::ZERO,
@@ -126,6 +129,7 @@ impl<T: Numeric> KahanSum<T> {
     }
 
     #[inline]
+    #[must_use]
     pub(crate) fn total(&self) -> T {
         self.sum
     }
@@ -138,6 +142,7 @@ pub(crate) enum Acc<T: Numeric> {
 
 impl<T: Numeric> Acc<T> {
     #[inline]
+    #[must_use]
     pub(crate) fn new(method: SummationMethod) -> Self {
         match method {
             SummationMethod::Pairwise => Acc::Pairwise(PairwiseSum::new()),
@@ -154,6 +159,7 @@ impl<T: Numeric> Acc<T> {
     }
 
     #[inline]
+    #[must_use]
     pub(crate) fn total(self) -> T {
         match self {
             Acc::Pairwise(a) => a.total(),

--- a/crates/multicalc/src/vector_field/line_integral.rs
+++ b/crates/multicalc/src/vector_field/line_integral.rs
@@ -3,6 +3,7 @@ use crate::numerical_integration::DEFAULT_TOTAL_ITERATIONS;
 use crate::scalar::Numeric;
 
 /// Builds the curve position [transformations[0](t), ..., transformations[N-1](t)].
+#[must_use]
 fn curve_point<T: Numeric, const N: usize>(transformations: &[&dyn Fn(T) -> T; N], t: T) -> [T; N] {
     let mut point = [T::ZERO; N];
     for i in 0..N {

--- a/crates/multicalc/tests/suite/control/pid.rs
+++ b/crates/multicalc/tests/suite/control/pid.rs
@@ -96,7 +96,7 @@ fn reset_zeroes_the_integral() {
     let mut controller =
         Pid::new(proportional_gain, integral_gain, derivative_gain, timestep).unwrap();
     for _ in 0..100 {
-        controller.update(1.0, 0.0);
+        let _ = controller.update(1.0, 0.0);
     }
     assert!(controller.integral() != 0.0);
     controller.reset();
@@ -159,7 +159,7 @@ fn output_of_one_step<T: Numeric>(setpoint: T) -> T {
     let timestep = T::from_f64(0.01);
     let mut controller =
         Pid::new(proportional_gain, integral_gain, derivative_gain, timestep).unwrap();
-    controller.update(setpoint, T::ZERO);
+    let _ = controller.update(setpoint, T::ZERO);
     controller.update(setpoint, T::from_f64(0.3))
 }
 

--- a/crates/multicalc/tests/suite/signal_processing/biquad.rs
+++ b/crates/multicalc/tests/suite/signal_processing/biquad.rs
@@ -22,7 +22,7 @@ fn assert_low_pass_passes_a_constant<T: Numeric>(tolerance: T) {
     let mut filter = Biquad::new(coefficients);
     let input = T::from_f64(5.0);
     for _ in 0..500 {
-        filter.filter(input);
+        let _ = filter.filter(input);
     }
     assert!((filter.value() - input).abs() < tolerance);
 }
@@ -43,7 +43,7 @@ fn assert_high_pass_blocks_a_constant<T: Numeric>(tolerance: T) {
             .unwrap();
     let mut filter = Biquad::new(coefficients);
     for _ in 0..500 {
-        filter.filter(T::from_f64(5.0));
+        let _ = filter.filter(T::from_f64(5.0));
     }
     assert!(filter.value().abs() < tolerance);
 }
@@ -121,7 +121,7 @@ fn swapping_weights_keeps_the_output_continuous() {
     // A notch passes a constant untouched, so this settles on 1.
     let mut running = Biquad::new(first);
     for _ in 0..1000 {
-        running.filter(1.0);
+        let _ = running.filter(1.0);
     }
     running.set_coefficients(second);
     assert!((running.filter(1.0) - 1.0).abs() < 0.03);

--- a/crates/multicalc/tests/suite/signal_processing/conditioning.rs
+++ b/crates/multicalc/tests/suite/signal_processing/conditioning.rs
@@ -145,7 +145,7 @@ fn rate_limited_output_never_moves_faster_than_its_limit() {
 fn rate_limited_output_reaches_a_held_target() {
     let (rise, dt, target) = (1.5_f64, 0.01, 3.0);
     let mut limited = SlewRateLimiter::new(rise, 0.5, dt).unwrap();
-    limited.filter(0.0);
+    let _ = limited.filter(0.0);
 
     let steps = (target / (rise * dt)).ceil() as usize + 10;
     for _ in 0..steps {

--- a/crates/multicalc/tests/suite/signal_processing/one_pole.rs
+++ b/crates/multicalc/tests/suite/signal_processing/one_pole.rs
@@ -12,7 +12,7 @@ fn assert_dc_gain_is_one<T: Numeric>(tolerance: T) {
     let mut filter = OnePoleLowPass::new(smoothing).unwrap();
     let input = T::from_f64(5.0);
     for _ in 0..500 {
-        filter.filter(input);
+        let _ = filter.filter(input);
     }
     assert!((filter.value() - input).abs() < tolerance);
 }
@@ -52,7 +52,7 @@ fn alpha_one_is_pass_through_f32() {
 fn assert_step_attenuated_and_monotone<T: Numeric>(tolerance: T) {
     let smoothing = T::from_f64(0.25);
     let mut filter = OnePoleLowPass::new(smoothing).unwrap();
-    filter.filter(T::ZERO); // seed at zero, then step the input to one
+    let _ = filter.filter(T::ZERO); // seed at zero, then step the input to one
     let target = T::ONE;
     let mut previous = T::ZERO;
     // Strict checks only while the gap to the target stays above f32 resolution.
@@ -63,7 +63,7 @@ fn assert_step_attenuated_and_monotone<T: Numeric>(tolerance: T) {
         previous = output;
     }
     for _ in 0..200 {
-        filter.filter(target);
+        let _ = filter.filter(target);
     }
     assert!((filter.value() - target).abs() < tolerance);
 }
@@ -119,7 +119,7 @@ fn from_cutoff_rejects_negative_cutoff() {
 #[test]
 fn reset_clears_state() {
     let mut filter = OnePoleLowPass::new(0.5_f64).unwrap();
-    filter.filter(3.0);
+    let _ = filter.filter(3.0);
     filter.reset();
     assert_eq!(filter.value(), 0.0);
     // The next sample seeds the filter again, so it passes straight through.

--- a/crates/multicalc/tests/suite/signal_processing/savitzky_golay.rs
+++ b/crates/multicalc/tests/suite/signal_processing/savitzky_golay.rs
@@ -37,7 +37,7 @@ fn assert_reproduces_a_curve_of_its_own_order<T: Numeric>(
     let mut time = 0.0;
     for sample in 0..SAMPLES {
         time = sample as f64 * DT;
-        fitted.filter(T::from_f64(curve(time)));
+        let _ = fitted.filter(T::from_f64(curve(time)));
     }
 
     assert!((fitted.value() - T::from_f64(curve(time))).abs() < value_tolerance);
@@ -62,7 +62,7 @@ fn assert_centered_reproduces_the_curve_at_its_own_delay<T: Numeric>(tolerance: 
     let mut time = 0.0;
     for sample in 0..SAMPLES {
         time = sample as f64 * DT;
-        fitted.filter(T::from_f64(curve(time)));
+        let _ = fitted.filter(T::from_f64(curve(time)));
     }
 
     // Half of an eleven-sample window at a millisecond a sample.
@@ -98,7 +98,7 @@ fn smoothing_beats_a_plain_difference_on_noise() {
         let time = sample as f64 * DT;
         let wobble = 0.002 * (noise.next_unit_f64() - 0.5);
         let reading = (2.0 * core::f64::consts::PI * 2.0 * time).sin() + wobble;
-        fitted.filter(reading);
+        let _ = fitted.filter(reading);
 
         let true_slope =
             2.0 * core::f64::consts::PI * 2.0 * (2.0 * core::f64::consts::PI * 2.0 * time).cos();
@@ -119,7 +119,7 @@ fn assert_a_line_has_no_bend<T: Numeric>() {
     let mut fitted = SavitzkyGolay::<9, 2, T>::latest(T::from_f64(DT)).unwrap();
     for sample in 0..50 {
         let time = sample as f64 * DT;
-        fitted.filter(T::from_f64(3.0 * time + 1.0));
+        let _ = fitted.filter(T::from_f64(3.0 * time + 1.0));
     }
     // Two terms describe a straight line, so there is no bend to report at all.
     assert_eq!(fitted.second_derivative(), T::ZERO);

--- a/crates/multicalc/tests/suite/signal_processing/window.rs
+++ b/crates/multicalc/tests/suite/signal_processing/window.rs
@@ -11,7 +11,7 @@ fn assert_average_of_a_constant_is_that_constant<T: Numeric>(tolerance: T) {
     let mut average = MovingAverage::<8, T>::new().unwrap();
     let input = T::from_f64(3.0);
     for _ in 0..20 {
-        average.filter(input);
+        let _ = average.filter(input);
     }
     assert!((average.value() - input).abs() < tolerance);
 }
@@ -43,10 +43,10 @@ fn average_is_exact_on_a_known_window() {
 fn average_does_not_drift_at_single_precision() {
     let mut average = MovingAverage::<16, f32>::new().unwrap();
     for _ in 0..100_000 {
-        average.filter(1.0e6);
+        let _ = average.filter(1.0e6);
     }
     for _ in 0..16 {
-        average.filter(0.0);
+        let _ = average.filter(0.0);
     }
     assert!(average.value().abs() < 1.0);
 }
@@ -76,7 +76,7 @@ fn assert_median_of_a_constant_is_that_constant<T: Numeric>() {
     let mut median = RunningMedian::<7, T>::new().unwrap();
     let input = T::from_f64(2.5);
     for _ in 0..10 {
-        median.filter(input);
+        let _ = median.filter(input);
     }
     assert_eq!(median.value(), input);
 }


### PR DESCRIPTION
Ref #227 

Mark value-returning accessors, builders, and helpers so discarded results warn under unused_must_use. Leave engine constructors and Result/Vector/Matrix returns unmarked (already covered or intentionally bare). Include multicalc-mjcf and fix suite call sites that only needed the side effect of filter/update.

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
