### PR TITLE
Validate rigid-transform matrix constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - LU factorization now distinguishes an exactly singular pivot from one that is negligible
   relative to the matrix, rejecting unreliable solves and inverses while preserving a nonzero
   determinant. (#207)
-- `SE3::try_from_matrix` now rejects non-homogeneous bottom rows, while `SO2::try_from_matrix`
-  and the rotation block used by `SE2::try_from_matrix` reject improper rotations. (#209)
+- Matrix constructors for `SO2` and `SO3` now reject reflections, shears, and scaling, while `SE2`
+  and `SE3` also reject non-homogeneous bottom rows and non-finite translations. (#209)
 - `Matrix::expm` now rejects non-finite inputs before entering its scaling loop. (#202)
 - `ResamplingScheme::resample_indices` now leaves output indices untouched for empty weights
   instead of panicking. (#204)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - LU factorization now distinguishes an exactly singular pivot from one that is negligible
   relative to the matrix, rejecting unreliable solves and inverses while preserving a nonzero
   determinant. (#207)
+- `SE3::try_from_matrix` now rejects non-homogeneous bottom rows, while `SO2::try_from_matrix`
+  and the rotation block used by `SE2::try_from_matrix` reject improper rotations. (#209)
 - `Matrix::expm` now rejects non-finite inputs before entering its scaling loop. (#202)
 - `ResamplingScheme::resample_indices` now leaves output indices untouched for empty weights
   instead of panicking. (#204)

--- a/crates/multicalc/src/spatial/lie/se2.rs
+++ b/crates/multicalc/src/spatial/lie/se2.rs
@@ -147,7 +147,8 @@ impl<T: Numeric> SE2<T> {
         Matrix::new([[c, -s, tx], [s, c, ty], [T::ZERO, T::ZERO, T::ONE]])
     }
 
-    /// Builds a transform from a 3×3 homogeneous matrix; `None` if the rotation block is degenerate.
+    /// Builds a transform from a 3×3 homogeneous matrix; `None` if the rotation block is not a
+    /// proper unit rotation.
     #[inline]
     #[must_use]
     pub fn try_from_matrix(m: Matrix3D<T>) -> Option<Self> {

--- a/crates/multicalc/src/spatial/lie/se2.rs
+++ b/crates/multicalc/src/spatial/lie/se2.rs
@@ -147,12 +147,25 @@ impl<T: Numeric> SE2<T> {
         Matrix::new([[c, -s, tx], [s, c, ty], [T::ZERO, T::ZERO, T::ONE]])
     }
 
-    /// Builds a transform from a 3×3 homogeneous matrix; `None` if the rotation block is not a
-    /// proper unit rotation.
+    /// Builds a transform from a finite 3×3 homogeneous matrix; `None` if the rotation block is not
+    /// a proper unit rotation or the bottom row differs from `[0, 0, 1]` by more than scalar
+    /// round-off.
     #[inline]
     #[must_use]
     pub fn try_from_matrix(m: Matrix3D<T>) -> Option<Self> {
-        let [[m00, m01, m02], [m10, m11, m12], _] = m.into_array();
+        let [[m00, m01, m02], [m10, m11, m12], [m20, m21, m22]] = m.into_array();
+        if !m02.is_finite()
+            || !m12.is_finite()
+            || !m20.is_finite()
+            || !m21.is_finite()
+            || !m22.is_finite()
+            || m20.abs() > T::EPSILON_X30
+            || m21.abs() > T::EPSILON_X30
+            || (m22 - T::ONE).abs() > T::EPSILON_X30
+        {
+            return None;
+        }
+
         let r = SO2::try_from_matrix(Matrix::new([[m00, m01], [m10, m11]]))?;
         Some(SE2 {
             rotation: r,

--- a/crates/multicalc/src/spatial/lie/se3.rs
+++ b/crates/multicalc/src/spatial/lie/se3.rs
@@ -155,10 +155,24 @@ impl<T: Numeric> SE3<T> {
         m
     }
 
-    /// Builds a transform from a 4×4 homogeneous matrix; `None` if the rotation block is degenerate.
+    /// Builds a transform from a 4×4 homogeneous matrix; `None` if the rotation block is degenerate
+    /// or the bottom row differs from `[0, 0, 0, 1]` by more than scalar round-off.
     #[inline]
     #[must_use]
     pub fn try_from_matrix(m: Matrix4D<T>) -> Option<Self> {
+        let [m30, m31, m32, m33] = [m[(3, 0)], m[(3, 1)], m[(3, 2)], m[(3, 3)]];
+        if !m30.is_finite()
+            || !m31.is_finite()
+            || !m32.is_finite()
+            || !m33.is_finite()
+            || m30.abs() > T::EPSILON_X30
+            || m31.abs() > T::EPSILON_X30
+            || m32.abs() > T::EPSILON_X30
+            || (m33 - T::ONE).abs() > T::EPSILON_X30
+        {
+            return None;
+        }
+
         let mut r = Matrix::zeros();
         for i in 0..3 {
             for j in 0..3 {

--- a/crates/multicalc/src/spatial/lie/se3.rs
+++ b/crates/multicalc/src/spatial/lie/se3.rs
@@ -155,13 +155,22 @@ impl<T: Numeric> SE3<T> {
         m
     }
 
-    /// Builds a transform from a 4×4 homogeneous matrix; `None` if the rotation block is degenerate
-    /// or the bottom row differs from `[0, 0, 0, 1]` by more than scalar round-off.
+    /// Builds a transform from a finite 4×4 homogeneous matrix; `None` if the rotation block is not
+    /// a proper unit rotation or the bottom row differs from `[0, 0, 0, 1]` by more than scalar
+    /// round-off.
     #[inline]
     #[must_use]
     pub fn try_from_matrix(m: Matrix4D<T>) -> Option<Self> {
-        let [m30, m31, m32, m33] = [m[(3, 0)], m[(3, 1)], m[(3, 2)], m[(3, 3)]];
-        if !m30.is_finite()
+        let [
+            [m00, m01, m02, m03],
+            [m10, m11, m12, m13],
+            [m20, m21, m22, m23],
+            [m30, m31, m32, m33],
+        ] = m.into_array();
+        if !m03.is_finite()
+            || !m13.is_finite()
+            || !m23.is_finite()
+            || !m30.is_finite()
             || !m31.is_finite()
             || !m32.is_finite()
             || !m33.is_finite()
@@ -173,14 +182,8 @@ impl<T: Numeric> SE3<T> {
             return None;
         }
 
-        let mut r = Matrix::zeros();
-        for i in 0..3 {
-            for j in 0..3 {
-                r[(i, j)] = m[(i, j)];
-            }
-        }
+        let r = Matrix::new([[m00, m01, m02], [m10, m11, m12], [m20, m21, m22]]);
         let rotation = SO3::try_from_matrix(r)?;
-        let [[_, _, _, m03], [_, _, _, m13], [_, _, _, m23], _] = m.into_array();
         Some(SE3 {
             rotation,
             translation: Vector::new([m03, m13, m23]),

--- a/crates/multicalc/src/spatial/lie/so2.rs
+++ b/crates/multicalc/src/spatial/lie/so2.rs
@@ -110,18 +110,25 @@ impl<T: Numeric> SO2<T> {
         Matrix::new([[self.c, -self.s], [self.s, self.c]])
     }
 
-    /// Builds a rotation from a 2×2 matrix, normalizing its first column; `None` if that column is
-    /// non-finite or degenerate.
+    /// Builds a rotation from a finite 2×2 matrix sufficiently close to a proper unit rotation,
+    /// removing small round-off drift; `None` otherwise.
     #[inline]
     #[must_use]
     pub fn try_from_matrix(m: Matrix2D<T>) -> Option<Self> {
-        let [[c, _], [s, _]] = m.into_array();
-        let n = (c * c + s * s).sqrt();
-        if !n.is_finite() || n <= T::EPSILON {
-            None
-        } else {
-            Some(SO2 { c: c / n, s: s / n })
+        let [[c, m01], [s, m11]] = m.into_array();
+        let n = c.hypot(s);
+        if !n.is_finite() || n <= T::EPSILON || (n - T::ONE).abs() > T::EPSILON_X30 {
+            return None;
         }
+
+        let c = c / n;
+        let s = s / n;
+        let second_column_error = (m01 + s).hypot(m11 - c);
+        if !second_column_error.is_finite() || second_column_error > T::EPSILON_X30 {
+            return None;
+        }
+
+        Some(SO2 { c, s })
     }
 
     /// Geodesic interpolation; `t = 0` gives `self`, `t = 1` gives `other`.

--- a/crates/multicalc/src/spatial/lie/so3.rs
+++ b/crates/multicalc/src/spatial/lie/so3.rs
@@ -123,10 +123,27 @@ impl<T: Numeric> SO3<T> {
         self.q.to_rotation_matrix()
     }
 
-    /// Builds a rotation from a 3×3 matrix; `None` if it is degenerate.
+    /// Builds a rotation from a finite 3×3 matrix sufficiently close to a proper unit rotation;
+    /// `None` otherwise.
     #[inline]
     #[must_use]
     pub fn try_from_matrix(m: Matrix3D<T>) -> Option<Self> {
+        let gram = m.transpose() * m;
+        for row in 0..3 {
+            for column in 0..3 {
+                let target = if row == column { T::ONE } else { T::ZERO };
+                let error = (gram[(row, column)] - target).abs();
+                if !error.is_finite() || error > T::EPSILON_X30 {
+                    return None;
+                }
+            }
+        }
+
+        let determinant = m.determinant();
+        if !determinant.is_finite() || determinant <= T::ZERO {
+            return None;
+        }
+
         Quaternion::try_from_rotation_matrix(m).map(|q| SO3 { q })
     }
 

--- a/crates/multicalc/tests/suite/spatial/lie.rs
+++ b/crates/multicalc/tests/suite/spatial/lie.rs
@@ -290,6 +290,74 @@ fn se3_matrix_roundtrip() {
 }
 
 #[test]
+fn se3_matrix_constructor_rejects_non_homogeneous_bottom_row() {
+    for column in 0..4 {
+        let mut projective = SE3::<f64>::identity().to_matrix();
+        projective[(3, column)] = if column == 3 { 0.5 } else { 0.25 };
+        assert!(SE3::try_from_matrix(projective).is_none());
+    }
+
+    let mut non_finite = SE3::<f64>::identity().to_matrix();
+    non_finite[(3, 0)] = f64::NAN;
+    assert!(SE3::try_from_matrix(non_finite).is_none());
+}
+
+#[test]
+fn so2_matrix_constructor_rejects_reflection() {
+    let reflection = Matrix::new([[1.0, 0.0], [0.0, -1.0]]);
+    assert!(SO2::try_from_matrix(reflection).is_none());
+}
+
+#[test]
+fn so2_matrix_constructor_rejects_shear() {
+    let shear = Matrix::new([[1.0, 0.25], [0.0, 1.0]]);
+    assert!(SO2::try_from_matrix(shear).is_none());
+}
+
+#[test]
+fn so2_matrix_constructor_rejects_scale_and_non_finite_columns() {
+    let scaled = Matrix::new([[2.0, 0.0], [0.0, 2.0]]);
+    assert!(SO2::try_from_matrix(scaled).is_none());
+
+    let non_finite = Matrix::new([[1.0, f64::NAN], [0.0, 1.0]]);
+    assert!(SO2::try_from_matrix(non_finite).is_none());
+
+    let extreme = Matrix::new([[f64::MAX, 0.0], [f64::MAX, 1.0]]);
+    assert!(SO2::try_from_matrix(extreme).is_none());
+}
+
+#[test]
+fn se2_matrix_constructor_validates_rotation_block() {
+    let pose = SE2::from_parts(SO2::from_angle(0.3), Vector2D::new([1.0, 2.0]));
+    assert!(SE2::try_from_matrix(pose.to_matrix()).is_some());
+
+    let reflection = Matrix::new([[1.0, 0.0, 1.0], [0.0, -1.0, 2.0], [0.0, 0.0, 1.0]]);
+    assert!(SE2::try_from_matrix(reflection).is_none());
+}
+
+#[test]
+fn matrix_constructors_accept_valid_f32_roundtrips() {
+    let rotation = SO2::<f32>::from_angle(0.3);
+    assert!(SO2::try_from_matrix(rotation.to_matrix()).is_some());
+
+    let pose = SE3::<f32>::identity();
+    assert!(SE3::try_from_matrix(pose.to_matrix()).is_some());
+}
+
+#[test]
+fn matrix_constructors_accept_roundoff_sized_drift() {
+    let tolerance = <f64 as Numeric>::EPSILON_X4;
+
+    let mut rotation = SO2::<f64>::from_angle(0.3).to_matrix();
+    rotation[(0, 0)] += tolerance;
+    assert!(SO2::try_from_matrix(rotation).is_some());
+
+    let mut pose = SE3::<f64>::identity().to_matrix();
+    pose[(3, 0)] = tolerance;
+    assert!(SE3::try_from_matrix(pose).is_some());
+}
+
+#[test]
 fn se3_hat_vee_roundtrip() {
     let mut rng = StdRng::seed_from_u64(15);
     for _ in 0..100 {
@@ -334,6 +402,11 @@ fn so2_group_and_roundtrip() {
         assert_entries_close(
             (first * first.inverse()).to_matrix(),
             SO2::identity().to_matrix(),
+            TOL,
+        );
+        assert_entries_close(
+            SO2::try_from_matrix(first.to_matrix()).unwrap().to_matrix(),
+            first.to_matrix(),
             TOL,
         );
         for &angle in &[1e-9, 0.3, PI - 1e-6] {

--- a/crates/multicalc/tests/suite/spatial/lie.rs
+++ b/crates/multicalc/tests/suite/spatial/lie.rs
@@ -303,6 +303,38 @@ fn se3_matrix_constructor_rejects_non_homogeneous_bottom_row() {
 }
 
 #[test]
+fn so3_matrix_constructor_rejects_non_rotations() {
+    let reflection = Matrix::new([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, -1.0]]);
+    assert!(SO3::try_from_matrix(reflection).is_none());
+
+    let shear = Matrix::new([[1.0, 0.25, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]);
+    assert!(SO3::try_from_matrix(shear).is_none());
+
+    let scaled = Matrix::new([[2.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 2.0]]);
+    assert!(SO3::try_from_matrix(scaled).is_none());
+
+    let non_finite = Matrix::new([[1.0, 0.0, f64::NAN], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]);
+    assert!(SO3::try_from_matrix(non_finite).is_none());
+}
+
+#[test]
+fn se3_matrix_constructor_rejects_invalid_rotation_and_translation() {
+    let mut reflection = SE3::<f64>::identity().to_matrix();
+    reflection[(2, 2)] = -1.0;
+    assert!(SE3::try_from_matrix(reflection).is_none());
+
+    for row in 0..3 {
+        let mut non_finite = SE3::<f64>::identity().to_matrix();
+        non_finite[(row, 3)] = match row {
+            0 => f64::NAN,
+            1 => f64::INFINITY,
+            _ => f64::NEG_INFINITY,
+        };
+        assert!(SE3::try_from_matrix(non_finite).is_none());
+    }
+}
+
+#[test]
 fn so2_matrix_constructor_rejects_reflection() {
     let reflection = Matrix::new([[1.0, 0.0], [0.0, -1.0]]);
     assert!(SO2::try_from_matrix(reflection).is_none());
@@ -336,9 +368,31 @@ fn se2_matrix_constructor_validates_rotation_block() {
 }
 
 #[test]
+fn se2_matrix_constructor_rejects_invalid_homogeneous_components() {
+    for column in 0..3 {
+        let mut projective = SE2::<f64>::identity().to_matrix();
+        projective[(2, column)] = if column == 2 { 0.5 } else { 0.25 };
+        assert!(SE2::try_from_matrix(projective).is_none());
+    }
+
+    let mut non_finite_bottom_row = SE2::<f64>::identity().to_matrix();
+    non_finite_bottom_row[(2, 0)] = f64::NAN;
+    assert!(SE2::try_from_matrix(non_finite_bottom_row).is_none());
+
+    for row in 0..2 {
+        let mut non_finite = SE2::<f64>::identity().to_matrix();
+        non_finite[(row, 2)] = if row == 0 { f64::NAN } else { f64::INFINITY };
+        assert!(SE2::try_from_matrix(non_finite).is_none());
+    }
+}
+
+#[test]
 fn matrix_constructors_accept_valid_f32_roundtrips() {
     let rotation = SO2::<f32>::from_angle(0.3);
     assert!(SO2::try_from_matrix(rotation.to_matrix()).is_some());
+
+    let rotation = SO3::<f32>::exp(Vector::new([0.1, -0.2, 0.3]));
+    assert!(SO3::try_from_matrix(rotation.to_matrix()).is_some());
 
     let pose = SE3::<f32>::identity();
     assert!(SE3::try_from_matrix(pose.to_matrix()).is_some());
@@ -351,6 +405,14 @@ fn matrix_constructors_accept_roundoff_sized_drift() {
     let mut rotation = SO2::<f64>::from_angle(0.3).to_matrix();
     rotation[(0, 0)] += tolerance;
     assert!(SO2::try_from_matrix(rotation).is_some());
+
+    let mut rotation = SO3::<f64>::exp(Vector::new([0.1, -0.2, 0.3])).to_matrix();
+    rotation[(0, 0)] += tolerance;
+    assert!(SO3::try_from_matrix(rotation).is_some());
+
+    let mut pose = SE2::<f64>::identity().to_matrix();
+    pose[(2, 0)] = tolerance;
+    assert!(SE2::try_from_matrix(pose).is_some());
 
     let mut pose = SE3::<f64>::identity().to_matrix();
     pose[(3, 0)] = tolerance;


### PR DESCRIPTION
## What & why

Fixes #209.

`SE3::try_from_matrix` previously ignored the homogeneous bottom row, while `SO2::try_from_matrix` normalized only the first column and therefore accepted reflections, shears, and scaled rotations. This change validates the complete reported structure with finite, generic `Numeric` operations and preserves small round-off correction. The stricter SO2 check is also documented and tested through `SE2::try_from_matrix`.

## Validation

The focused regression failed 0/3 against the pinned pre-fix `main` and passes 7/7 after the change. Local checks also passed:

- `cargo test -p multicalc`
- `cargo test -p multicalc --features alloc`
- `cargo test -p multicalc --all-targets --features alloc`
- `cargo test -p multicalc --all-features --doc`
- `cargo test -p multicalc-qa`
- `cargo check -p multicalc --no-default-features`
- `cargo clippy -p multicalc --all-targets --features alloc -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p multicalc --no-deps --all-features`
- `cargo publish -p multicalc --dry-run`

The repository's embedded and aarch64 matrix remains delegated to CI as documented in `CONTRIBUTING.md`.

## Disclosure

This pull request was prepared and submitted by an autonomous OpenAI Codex agent operating the LunaMeerkats account.

## Checklist

- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example (no new public APIs)
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)