### PR TITLE
Avoid copying FollowTheGap scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `FollowTheGap::compute` now sanitizes readings where they are consumed instead of copying the
+  whole scan into a second stack array. (#225)
 - Apply `#[must_use]` consistently across `multicalc` (and `multicalc-mjcf`) on
   value-returning accessors, builders, and helpers, so discarded results warn under
   `unused_must_use`. Engine constructors and returns already covered by `Result` /

--- a/crates/multicalc/src/control/follow_the_gap.rs
+++ b/crates/multicalc/src/control/follow_the_gap.rs
@@ -307,18 +307,10 @@ impl<const BEAMS: usize, T: Numeric> FollowTheGap<BEAMS, T> {
             return Err(ControlError::NonFinite);
         }
 
-        // Treat invalid or zero-or-negative readings as empty space at `maximum_range`.
-        let sanitized_ranges: [T; BEAMS] =
-            core::array::from_fn(|index| match beam_ranges.get(index) {
-                Some(&range) if range.is_finite() && range > T::ZERO => {
-                    range.min(self.maximum_range)
-                }
-                _ => self.maximum_range,
-            });
-
         // Track the nearest obstacle across the whole scan, reported in the output.
         let mut minimum_clearance = self.maximum_range;
-        for &range in &sanitized_ranges {
+        for &range in beam_ranges {
+            let range = self.sanitized_range(range);
             if range < minimum_clearance {
                 minimum_clearance = range;
             }
@@ -332,10 +324,9 @@ impl<const BEAMS: usize, T: Numeric> FollowTheGap<BEAMS, T> {
         let mut run_start: Option<usize> = None;
 
         for index in 0..=BEAMS {
-            let is_free = match sanitized_ranges.get(index) {
-                Some(&range) => range >= self.free_range_threshold,
-                None => false,
-            };
+            let is_free = beam_ranges
+                .get(index)
+                .is_some_and(|&range| self.sanitized_range(range) >= self.free_range_threshold);
             match (is_free, run_start) {
                 // A free beam with nothing open yet begins a new stretch.
                 (true, None) => run_start = Some(index),
@@ -346,14 +337,14 @@ impl<const BEAMS: usize, T: Numeric> FollowTheGap<BEAMS, T> {
 
                     // Drop this stretch if it is too narrow for the robot to fit through.
                     if self
-                        .gap_width(&sanitized_ranges, start, end)
+                        .gap_width(beam_ranges, start, end)
                         .is_some_and(|width| width < self.chassis_width)
                     {
                         continue;
                     }
 
                     // Choose where to aim inside this gap.
-                    let (low, high) = self.aim_bounds(&sanitized_ranges, start, end);
+                    let (low, high) = self.aim_bounds(beam_ranges, start, end);
                     let aim = if low > high {
                         // The safety margins from both edges overlap, so aim at the middle — the
                         // spot farthest from either obstacle.
@@ -395,7 +386,8 @@ impl<const BEAMS: usize, T: Numeric> FollowTheGap<BEAMS, T> {
         // Speed depends only on the beams pointing forward, so something off to the side does not
         // slow the robot until it comes around to the front.
         let mut frontal_clearance = self.maximum_range;
-        for (index, &range) in sanitized_ranges.iter().enumerate() {
+        for (index, &range) in beam_ranges.iter().enumerate() {
+            let range = self.sanitized_range(range);
             if self.beam_angle_unchecked(index).abs() <= self.frontal_half_angle
                 && range < frontal_clearance
             {
@@ -424,6 +416,17 @@ impl<const BEAMS: usize, T: Numeric> FollowTheGap<BEAMS, T> {
         })
     }
 
+    /// Treats an unusable reading as empty space and clamps usable readings to sensor range.
+    #[inline]
+    #[must_use]
+    fn sanitized_range(&self, range: T) -> T {
+        if range.is_finite() && range > T::ZERO {
+            range.min(self.maximum_range)
+        } else {
+            self.maximum_range
+        }
+    }
+
     /// The angle for a beam whose index is already known to be in range.
     #[inline]
     #[must_use]
@@ -446,8 +449,8 @@ impl<const BEAMS: usize, T: Numeric> FollowTheGap<BEAMS, T> {
     fn gap_width(&self, beam_ranges: &[T; BEAMS], start: usize, end: usize) -> Option<T> {
         let before = start.checked_sub(1)?;
         let after = end.checked_add(1).filter(|&index| index < BEAMS)?;
-        let range_a = *beam_ranges.get(before)?;
-        let range_b = *beam_ranges.get(after)?;
+        let range_a = self.sanitized_range(*beam_ranges.get(before)?);
+        let range_b = self.sanitized_range(*beam_ranges.get(after)?);
         let separation = self.beam_angle_unchecked(after) - self.beam_angle_unchecked(before);
         let squared =
             range_a * range_a + range_b * range_b - T::TWO * range_a * range_b * separation.cos();
@@ -467,8 +470,8 @@ impl<const BEAMS: usize, T: Numeric> FollowTheGap<BEAMS, T> {
     fn aim_bounds(&self, beam_ranges: &[T; BEAMS], start: usize, end: usize) -> (T, T) {
         let half_width = self.chassis_width * T::HALF;
         let inset = |index: usize| match beam_ranges.get(index) {
-            Some(&range) if range > T::ZERO => (half_width / range).atan(),
-            _ => T::ZERO,
+            Some(&range) => (half_width / self.sanitized_range(range)).atan(),
+            None => T::ZERO,
         };
         let low = self.beam_angle_unchecked(start) + start.checked_sub(1).map_or(T::ZERO, inset);
         let high = self.beam_angle_unchecked(end)

--- a/crates/multicalc/tests/suite/control/follow_the_gap.rs
+++ b/crates/multicalc/tests/suite/control/follow_the_gap.rs
@@ -1,5 +1,6 @@
 //! Follow-the-Gap tests: the clear-scan case, gap selection and goal bias, the chassis-width gate,
-//! dropped beams, speed scaling, the blocked stop, configuration validation, and an f32 run.
+//! dropped and clamped beams, speed scaling, the blocked stop, configuration validation, and an
+//! f32 run.
 
 use core::f64::consts::PI;
 
@@ -115,10 +116,41 @@ fn dropped_beams_read_as_free_space() {
     ranges[11] = -1.0;
     ranges[12] = 0.0;
     let output = follower().compute(&ranges, 0.0).unwrap();
-    assert!(!output.is_blocked());
-    assert!(output.heading().abs() < 1e-12);
-    assert_eq!(output.gap_start_index(), 0);
-    assert_eq!(output.gap_end_index(), 30);
+    let clear_output = follower().compute(&[4.0; 31], 0.0).unwrap();
+    assert_eq!(output, clear_output);
+}
+
+#[test]
+fn readings_beyond_the_sensor_range_are_clamped() {
+    let output = follower().compute(&[8.0; 31], 0.0).unwrap();
+    let clear_output = follower().compute(&[4.0; 31], 0.0).unwrap();
+    assert_eq!(output, clear_output);
+}
+
+#[test]
+fn on_access_sanitizing_matches_a_preprocessed_scan() {
+    let mut raw_ranges = [0.49_f64; 31];
+    for range in raw_ranges.iter_mut().take(26).skip(5) {
+        *range = 2.0;
+    }
+    raw_ranges[10] = f64::NAN;
+    raw_ranges[12] = f64::INFINITY;
+    raw_ranges[14] = f64::NEG_INFINITY;
+    raw_ranges[16] = -1.0;
+    raw_ranges[18] = 0.0;
+    raw_ranges[20] = 8.0;
+
+    let preprocessed_ranges = raw_ranges.map(|range| {
+        if range.is_finite() && range > 0.0 {
+            range.min(4.0)
+        } else {
+            4.0
+        }
+    });
+    let raw_output = follower().compute(&raw_ranges, 0.2).unwrap();
+    let preprocessed_output = follower().compute(&preprocessed_ranges, 0.2).unwrap();
+    assert!(!raw_output.is_blocked());
+    assert_eq!(raw_output, preprocessed_output);
 }
 
 #[test]


### PR DESCRIPTION
## What & why

Closes #225. `FollowTheGap::compute` currently builds a second `[T; BEAMS]` scan on the stack before using it. This change preserves the same invalid-reading and sensor-range normalization while applying it at each read site, so the const-generic stack array is no longer needed. For the issue's 1,080-beam `f64` example, that removed source array structurally holds 8,640 bytes.

## Implementation

- add one private `sanitized_range` helper and use it for clearance, free-run, gap-edge, aiming, and frontal-speed calculations
- keep the public API and output behavior unchanged
- strengthen invalid-reading coverage, add above-range coverage, and compare a mixed raw scan with its explicitly preprocessed equivalent
- document the change in the changelog

## Validation

- `cargo test -p multicalc` (18 unit, 904 integration, 295 doctests, 3 compile-fail doctests)
- `cargo test -p multicalc --features alloc` (18 unit, 917 integration, 346 doctests, 3 compile-fail doctests)
- `cargo test -p multicalc --all-targets --features alloc` (18 unit, 917 integration)
- focused Follow-the-Gap suite (14 passed)
- no-default-features check, all-feature docs, strict Clippy, formatting, and diff checks
- `multicalc-mjcf` and `multicalc-qa` tests; generated fixtures and accuracy tables remained unchanged
- no-default-features demos build and `avoidance` example run
- clean-tree `cargo publish -p multicalc --dry-run`
- current Windows MSVC release assembly reserves the same 312-byte local stack allocation for 31- and 1,080-beam probes, with no `__chkstk`

The assembly check demonstrates that the new optimized frame is not beam-count-scaled; it is not an exact baseline delta or an overall performance claim. Repeated normalization trades the removed array and its memory traffic for extra per-pass scalar work. Rust 1.85, embedded cross-target, QEMU, and on-target stack-budget checks are left to CI because those toolchains are not installed locally.

## Checklist

- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] No public API was added
- [x] No `unwrap`/`expect`/`panic` was added to library paths

## Provenance

Authored, tested, and submitted autonomously by OpenAI Codex using the `LunaMeerkats` GitHub account. No human review or pre-submission attestation is claimed.