### PR TITLE
Repeat form for vector and matrix macros

### DIFF
--- a/crates/multicalc/src/linear_algebra/macros.rs
+++ b/crates/multicalc/src/linear_algebra/macros.rs
@@ -6,6 +6,14 @@
 /// let v = vector![1.0, 2.0, 3.0];
 /// assert_eq!(v, Vector::new([1.0, 2.0, 3.0]));
 /// ```
+///
+/// Supports repeat syntax:
+///
+/// ```
+/// use multicalc::{vector, Vector};
+/// let v = vector![1.0; 3];
+/// assert_eq!(v, Vector::new([1.0, 1.0, 1.0]));
+/// ```
 #[macro_export]
 macro_rules! vector {
     ($($component:expr),+ $(,)?) => {
@@ -29,6 +37,14 @@ macro_rules! vector {
 /// ```compile_fail
 /// use multicalc::matrix;
 /// let _ = matrix![[1.0, 2.0], [3.0]];
+/// ```
+///
+/// Supports repeat syntax:
+///
+/// ```
+/// use multicalc::{matrix, Matrix};
+/// let m = matrix![[1.0; 2]; 2];
+/// assert_eq!(m, Matrix::new([[1.0, 1.0], [1.0, 1.0]]));
 /// ```
 #[macro_export]
 macro_rules! matrix {

--- a/crates/multicalc/src/linear_algebra/macros.rs
+++ b/crates/multicalc/src/linear_algebra/macros.rs
@@ -11,6 +11,9 @@ macro_rules! vector {
     ($($component:expr),+ $(,)?) => {
         $crate::Vector::new([$($component),+])
     };
+    ($component:expr; $length:expr) => {
+        $crate::Vector::new([$component; $length])
+    };
 }
 
 /// Builds a [`Matrix`](crate::Matrix) from bracketed row literals.
@@ -31,5 +34,11 @@ macro_rules! vector {
 macro_rules! matrix {
     ($([$($entry:expr),+ $(,)?]),+ $(,)?) => {
         $crate::Matrix::new([$([$($entry),+]),+])
+    };
+    ([$($entry:expr),+ $(,)?]; $length:expr) => {
+        $crate::Matrix::new([[$($entry),+]; $length])
+    };
+    ([$entry:expr; $inner_length:expr]; $outer_length:expr) => {
+        $crate::Matrix::new([[$entry; $inner_length]; $outer_length])
     };
 }

--- a/crates/multicalc/tests/suite/linear_algebra/macros.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/macros.rs
@@ -10,6 +10,10 @@ fn vector_macro_matches_new() {
 
     // single element
     assert_eq!(vector![42.0], Vector::new([42.0]));
+
+    // repeat form
+    assert_eq!(vector![0.0; 3], Vector::<3>::zeros());
+    assert_eq!(vector![1.0; 3], Vector::new([1.0, 1.0, 1.0]));
 }
 
 #[test]
@@ -25,4 +29,18 @@ fn matrix_macro_matches_new() {
         matrix![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
         Matrix::new([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     );
+
+    // repeat form
+    assert_eq!(
+        matrix![[1.0, 2.0, 3.0]; 2],
+        Matrix::new([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
+    );
+    assert_eq!(
+        matrix![[0.0, 0.0,]; 2],
+        Matrix::new([[0.0, 0.0], [0.0, 0.0]])
+    );
+
+    // nested repeat form
+    assert_eq!(matrix![[0.0; 3]; 4], Matrix::<4, 3>::zeros());
+    assert_eq!(matrix![[1.0; 2]; 2], Matrix::new([[1.0, 1.0], [1.0, 1.0]]));
 }

--- a/crates/multicalc/tests/suite/linear_algebra/macros.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/macros.rs
@@ -35,10 +35,7 @@ fn matrix_macro_matches_new() {
         matrix![[1.0, 2.0, 3.0]; 2],
         Matrix::new([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
     );
-    assert_eq!(
-        matrix![[0.0, 0.0,]; 2],
-        Matrix::new([[0.0, 0.0], [0.0, 0.0]])
-    );
+    assert_eq!(matrix![[0.0, 0.0,]; 2], Matrix::<2, 2>::zeros());
 
     // nested repeat form
     assert_eq!(matrix![[0.0; 3]; 4], Matrix::<4, 3>::zeros());


### PR DESCRIPTION
## What & why

Resolves #221

New macro arms to support `[x; N]` syntax for vector! and matrix! with corresponding tests and doctests.

Unsure whether this change warrants an entry in the changelog.

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
