### PR TITLE
Make standard normal generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   value-returning accessors, queries, and helpers, so discarded results warn under
   `unused_must_use`. Returns already covered by `Result` / `Vector` / `Matrix`
   stay unmarked; `embedded-smoke` is excluded. @rtmongold (#258)
+- `RandomSource::standard_normal` is now generic, uses the Marsaglia polar method to avoid
+  trigonometry functions, and caches values to save work. @kirloo (#223)
 
 ## [0.9.0] - 2026-07-26
 

--- a/crates/multicalc/src/estimation/monte_carlo_localizer.rs
+++ b/crates/multicalc/src/estimation/monte_carlo_localizer.rs
@@ -4,6 +4,7 @@ use crate::error::EstimationError;
 use crate::estimation::ParticleFilter;
 use crate::linear_algebra::{Matrix, Vector};
 use crate::mapping::{OccupancyMap, ScanGeometry};
+use crate::random::RandomScalar;
 use crate::scalar::{Numeric, Primal, VectorFn};
 
 /// How the guesses are scattered before the robot has seen anything.
@@ -99,12 +100,12 @@ impl<T: Numeric> Default for BeamModel<T> {
 /// # Ok::<(), multicalc::CalcError>(())
 /// ```
 #[derive(Debug, Clone)]
-pub struct MonteCarloLocalizer<const NUM_BEAMS: usize, T: Numeric + Primal = f64> {
+pub struct MonteCarloLocalizer<const NUM_BEAMS: usize, T: RandomScalar + Primal = f64> {
     filter: ParticleFilter<3, 1, T>,
     beam_model: BeamModel<T>,
 }
 
-impl<const NUM_BEAMS: usize, T: Numeric + Primal> MonteCarloLocalizer<NUM_BEAMS, T> {
+impl<const NUM_BEAMS: usize, T: RandomScalar + Primal> MonteCarloLocalizer<NUM_BEAMS, T> {
     /// A localizer seeded from a rough guess, with the guesses scattered as `cloud` says.
     ///
     /// The spread added on every [`predict`](Self::predict) starts at `1e-4` on each of `x`, `y`,

--- a/crates/multicalc/src/estimation/monte_carlo_localizer.rs
+++ b/crates/multicalc/src/estimation/monte_carlo_localizer.rs
@@ -80,7 +80,7 @@ impl<T: Numeric> Default for BeamModel<T> {
 /// let hint = [2.3, 2.7, 0.4];
 /// let cloud = InitialParticleCloud { particle_count: 300, ..Default::default() };
 /// let beam_model = BeamModel { range_deviation: 0.3, ..Default::default() };
-/// let seed = 20260804;
+/// let seed = 20260802;
 /// let mut localizer = MonteCarloLocalizer::<NUM_BEAMS>::new(hint, cloud, beam_model, seed)?;
 ///
 /// // Standing still, taking the same reading a few times over.

--- a/crates/multicalc/src/estimation/particle_filter.rs
+++ b/crates/multicalc/src/estimation/particle_filter.rs
@@ -80,7 +80,7 @@ impl ResamplingScheme {
 fn systematic<T: Numeric, R: RandomSource>(weights: &[T], random: &mut R, indices: &mut [usize]) {
     let count = indices.len();
     let count_scalar = T::from_usize(count);
-    let offset = T::from_f64(random.next_unit_f64());
+    let offset = T::from_f64(random.next_unit::<f64>());
 
     // Picks sit at one-stratum spacing, all shifted by the same offset. Walk a running total of the
     // weights and place each pick on the first source whose total reaches it, so heavier sources,
@@ -107,7 +107,7 @@ fn stratified<T: Numeric, R: RandomSource>(weights: &[T], random: &mut R, indice
     let mut running_sum = weights[0];
     let mut source = 0;
     for (step, slot) in indices.iter_mut().enumerate() {
-        let offset = T::from_f64(random.next_unit_f64());
+        let offset = T::from_f64(random.next_unit::<f64>());
         let position = (offset + T::from_usize(step)) / count_scalar;
         while position >= running_sum && source + 1 < count {
             source += 1;
@@ -122,7 +122,7 @@ fn multinomial<T: Numeric, R: RandomSource>(weights: &[T], random: &mut R, indic
     // Every pick is an independent throw at the 0-to-1 line; each lands on the source whose weight
     // covers where it fell. Simple, but the picks clump more than the spaced schemes above.
     for slot in indices.iter_mut() {
-        let draw = T::from_f64(random.next_unit_f64());
+        let draw = T::from_f64(random.next_unit::<f64>());
         *slot = draw_from_weights(weights, draw);
     }
 }
@@ -153,7 +153,7 @@ fn residual<T: Numeric, R: RandomSource>(weights: &[T], random: &mut R, indices:
     }
 
     for slot in indices.iter_mut().skip(filled) {
-        let draw = T::from_f64(random.next_unit_f64());
+        let draw = T::from_f64(random.next_unit::<f64>());
         *slot = draw_from_remainders(weights, count_scalar, remainder_sum, draw);
     }
 }

--- a/crates/multicalc/src/estimation/particle_filter.rs
+++ b/crates/multicalc/src/estimation/particle_filter.rs
@@ -24,7 +24,7 @@ use alloc::vec::Vec;
 
 use crate::error::EstimationError;
 use crate::linear_algebra::{Cholesky, Matrix, Vector};
-use crate::random::{Pcg32, RandomSource};
+use crate::random::{Pcg32, RandomScalar, RandomSource};
 use crate::scalar::{Numeric, VectorFn};
 
 /// How the filter draws a fresh, equally-weighted cloud from the current weighted one.
@@ -57,7 +57,7 @@ impl ResamplingScheme {
     /// down.
     ///
     /// An empty `weights` slice returns without consuming randomness or modifying `indices`.
-    pub fn resample_indices<T: Numeric, R: RandomSource>(
+    pub fn resample_indices<T: RandomScalar, R: RandomSource<T>>(
         self,
         weights: &[T],
         random: &mut R,
@@ -77,10 +77,14 @@ impl ResamplingScheme {
 }
 
 /// One random offset shared by every pick, spaced one stratum apart. Draws a single uniform.
-fn systematic<T: Numeric, R: RandomSource>(weights: &[T], random: &mut R, indices: &mut [usize]) {
+fn systematic<T: RandomScalar, R: RandomSource<T>>(
+    weights: &[T],
+    random: &mut R,
+    indices: &mut [usize],
+) {
     let count = indices.len();
     let count_scalar = T::from_usize(count);
-    let offset = T::from_f64(random.next_unit::<f64>());
+    let offset = random.next_unit();
 
     // Picks sit at one-stratum spacing, all shifted by the same offset. Walk a running total of the
     // weights and place each pick on the first source whose total reaches it, so heavier sources,
@@ -98,7 +102,11 @@ fn systematic<T: Numeric, R: RandomSource>(weights: &[T], random: &mut R, indice
 }
 
 /// A fresh random pick inside each evenly spaced stratum. Draws one uniform per pick.
-fn stratified<T: Numeric, R: RandomSource>(weights: &[T], random: &mut R, indices: &mut [usize]) {
+fn stratified<T: RandomScalar, R: RandomSource<T>>(
+    weights: &[T],
+    random: &mut R,
+    indices: &mut [usize],
+) {
     let count = indices.len();
     let count_scalar = T::from_usize(count);
 
@@ -107,7 +115,7 @@ fn stratified<T: Numeric, R: RandomSource>(weights: &[T], random: &mut R, indice
     let mut running_sum = weights[0];
     let mut source = 0;
     for (step, slot) in indices.iter_mut().enumerate() {
-        let offset = T::from_f64(random.next_unit::<f64>());
+        let offset = random.next_unit();
         let position = (offset + T::from_usize(step)) / count_scalar;
         while position >= running_sum && source + 1 < count {
             source += 1;
@@ -118,18 +126,26 @@ fn stratified<T: Numeric, R: RandomSource>(weights: &[T], random: &mut R, indice
 }
 
 /// Each pick drawn independently from the weight distribution. Draws one uniform per pick.
-fn multinomial<T: Numeric, R: RandomSource>(weights: &[T], random: &mut R, indices: &mut [usize]) {
+fn multinomial<T: RandomScalar, R: RandomSource<T>>(
+    weights: &[T],
+    random: &mut R,
+    indices: &mut [usize],
+) {
     // Every pick is an independent throw at the 0-to-1 line; each lands on the source whose weight
     // covers where it fell. Simple, but the picks clump more than the spaced schemes above.
     for slot in indices.iter_mut() {
-        let draw = T::from_f64(random.next_unit::<f64>());
+        let draw = random.next_unit();
         *slot = draw_from_weights(weights, draw);
     }
 }
 
 /// The whole-number share of each weight first, then the leftover slots filled by independent draws
 /// on the normalized fractional remainders. Draws one uniform per leftover slot.
-fn residual<T: Numeric, R: RandomSource>(weights: &[T], random: &mut R, indices: &mut [usize]) {
+fn residual<T: RandomScalar, R: RandomSource<T>>(
+    weights: &[T],
+    random: &mut R,
+    indices: &mut [usize],
+) {
     let count = indices.len();
     let count_scalar = T::from_usize(count);
 
@@ -153,7 +169,7 @@ fn residual<T: Numeric, R: RandomSource>(weights: &[T], random: &mut R, indices:
     }
 
     for slot in indices.iter_mut().skip(filled) {
-        let draw = T::from_f64(random.next_unit::<f64>());
+        let draw = random.next_unit();
         *slot = draw_from_remainders(weights, count_scalar, remainder_sum, draw);
     }
 }
@@ -304,7 +320,7 @@ pub struct ParticleFilter<
     const STATE_DIMENSION: usize,
     const MEASUREMENT_DIMENSION: usize,
     T = f64,
-    R = Pcg32,
+    R = Pcg32<T>,
 > {
     particles: Vec<Vector<STATE_DIMENSION, T>>,
     weights: Vec<T>,
@@ -318,8 +334,8 @@ pub struct ParticleFilter<
     log_weight_scratch: Vec<T>,
 }
 
-impl<const STATE_DIMENSION: usize, const MEASUREMENT_DIMENSION: usize, T: Numeric>
-    ParticleFilter<STATE_DIMENSION, MEASUREMENT_DIMENSION, T, Pcg32>
+impl<const STATE_DIMENSION: usize, const MEASUREMENT_DIMENSION: usize, T: RandomScalar>
+    ParticleFilter<STATE_DIMENSION, MEASUREMENT_DIMENSION, T, Pcg32<T>>
 {
     /// Builds a filter with a [`Pcg32`] seeded from `seed`, sampling the initial cloud from the
     /// Gaussian `initial_mean`/`initial_covariance`.
@@ -344,10 +360,10 @@ impl<const STATE_DIMENSION: usize, const MEASUREMENT_DIMENSION: usize, T: Numeri
     }
 }
 
-impl<const STATE_DIMENSION: usize, const MEASUREMENT_DIMENSION: usize, T: Numeric, R>
+impl<const STATE_DIMENSION: usize, const MEASUREMENT_DIMENSION: usize, T: RandomScalar, R>
     ParticleFilter<STATE_DIMENSION, MEASUREMENT_DIMENSION, T, R>
 where
-    R: RandomSource,
+    R: RandomSource<T>,
 {
     /// Builds a filter with an explicit random backend — the built-in [`Pcg32`] or your own
     /// [`RandomSource`]. [`new`](Self::new) is the seeded-`Pcg32` default.
@@ -398,7 +414,7 @@ where
         // the requested covariance.
         let mut particles = Vec::with_capacity(particle_count);
         for _ in 0..particle_count {
-            let sample = Vector::from_fn(|_| T::from_f64(random.standard_normal()));
+            let sample = Vector::from_fn(|_| random.standard_normal());
             particles.push(initial_mean + initial_factor * sample);
         }
 
@@ -481,7 +497,7 @@ where
         let mut finite = true;
         for particle in self.particles.iter_mut() {
             let propagated = Vector::new(process_model.eval(particle.as_array()));
-            let noise = Vector::from_fn(|_| T::from_f64(self.random.standard_normal()));
+            let noise = Vector::from_fn(|_| self.random.standard_normal());
             *particle = propagated + self.process_noise_factor * noise;
             if !particle.is_finite() {
                 finite = false;
@@ -685,7 +701,7 @@ where
             }
             // Nudge every particle along this axis by an independent draw at that scale.
             for particle in self.particles.iter_mut() {
-                particle[axis] += scale * T::from_f64(self.random.standard_normal());
+                particle[axis] += scale * self.random.standard_normal();
             }
         }
     }

--- a/crates/multicalc/src/random.rs
+++ b/crates/multicalc/src/random.rs
@@ -25,8 +25,6 @@ pub trait RandomSource {
     /// A uniform draw in the half-open range 0.0 up to 1.0
     #[must_use]
     fn next_unit<T: RandomScalar>(&mut self) -> T
-    where
-        Self: Sized,
     {
         T::next_unit(self)
     }
@@ -36,8 +34,6 @@ pub trait RandomSource {
     /// Uses the Marsaglia polar method and returns one of the pair, consuming two uniform draws.
     #[must_use]
     fn standard_normal<T: RandomScalar>(&mut self) -> T
-    where
-        Self: Sized,
     {
         loop {
             let x = T::TWO  * self.next_unit::<T>() - T::ONE;

--- a/crates/multicalc/src/random.rs
+++ b/crates/multicalc/src/random.rs
@@ -38,14 +38,14 @@ pub trait RandomSource<T: RandomScalar> {
         }
 
         loop {
-            let x = T::TWO * self.next_unit() - T::ONE;
-            let y = T::TWO * self.next_unit() - T::ONE;
-            let s = x.powi(2) + y.powi(2);
+            let x_draw = T::TWO * self.next_unit() - T::ONE;
+            let y_draw = T::TWO * self.next_unit() - T::ONE;
+            let radius_squared = x_draw.powi(2) + y_draw.powi(2);
 
-            if s > T::ZERO && s < T::ONE {
-                let scale = (-T::TWO * s.ln() / s).sqrt();
-                self.set_cache(y * scale);
-                return x * scale;
+            if radius_squared > T::ZERO && radius_squared < T::ONE {
+                let scale = (-T::TWO * radius_squared.ln() / radius_squared).sqrt();
+                self.set_cache(y_draw * scale);
+                return x_draw * scale;
             }
         }
     }

--- a/crates/multicalc/src/random.rs
+++ b/crates/multicalc/src/random.rs
@@ -8,6 +8,8 @@
 //! implements, with uniform and normal draws built on top of a raw 32-bit word; [`Pcg32`] is the built-in
 //! generator.
 
+use crate::Numeric;
+
 /// A source of random 32-bit words, and the uniform and normal draws built from them.
 pub trait RandomSource {
     /// The next raw 32-bit word.
@@ -20,25 +22,57 @@ pub trait RandomSource {
         ((self.next_u32() as u64) << 32) | (self.next_u32() as u64)
     }
 
-    /// A uniform draw in the half-open range 0.0 up to 1.0, with 53 bits of precision.
+    /// A uniform draw in the half-open range 0.0 up to 1.0
     #[must_use]
-    fn next_unit_f64(&mut self) -> f64 {
-        // Top 53 bits scaled into [0, 1); the low 11 bits are dropped so the result never reaches 1.
-        (self.next_u64() >> 11) as f64 * (1.0 / (1u64 << 53) as f64)
+    fn next_unit<T: RandomScalar>(&mut self) -> T
+    where
+        Self: Sized,
+    {
+        T::next_unit(self)
     }
 
     /// One draw from the standard normal distribution (mean 0, standard deviation 1).
     ///
-    /// Uses the polar pair method and returns one of the pair, consuming two uniform draws. The
-    /// first draw is nudged off zero so the logarithm stays finite.
+    /// Uses the Marsiagla polar method and returns one of the pair, consuming two uniform draws.
     #[must_use]
-    fn standard_normal(&mut self) -> f64 {
-        let mut first = self.next_unit_f64();
-        if first <= f64::MIN_POSITIVE {
-            first = f64::MIN_POSITIVE;
+    fn standard_normal<T: RandomScalar>(&mut self) -> T
+    where
+        Self: Sized,
+    {
+        loop {
+            let x = T::TWO  * self.next_unit::<T>() - T::ONE;
+            let y = T::TWO  * self.next_unit::<T>() - T::ONE;
+            let s = x.powi(2) + y.powi(2);
+
+            if s > T::ZERO && s < T::ONE {
+                let scale = (-T::TWO * s.ln() / s).sqrt();
+                return x * scale
+            }
+
         }
-        let second = self.next_unit_f64();
-        libm::sqrt(-2.0 * libm::log(first)) * libm::cos(core::f64::consts::TAU * second)
+    }
+}
+
+pub trait RandomScalar: Numeric {
+    /// A uniform draw in the half-open range 0.0 up to 1.0.
+    #[must_use]
+    fn next_unit<R: RandomSource + ?Sized>(source: &mut R) -> Self;
+}
+
+impl RandomScalar for f64 {
+    /// A uniform draw in the half-open range 0.0 up to 1.0, with 53 bits of precision.
+    #[inline]
+    fn next_unit<R: RandomSource + ?Sized>(source: &mut R) -> Self {
+        // Top 53 bits scaled into [0, 1); the low 11 bits are dropped so the result never reaches 1.
+        (source.next_u64() >> 11) as f64 * (1.0 / (1u64 << 53) as f64)
+    }
+}
+
+impl RandomScalar for f32 {
+    /// A uniform draw in the half-open range 0.0 up to 1.0, with 24 bits of precision.
+    #[inline]
+    fn next_unit<R: RandomSource + ?Sized>(source: &mut R) -> Self {
+        (source.next_u32() >> 8) as f32 * (1.0 / (1u32 << 24) as f32)
     }
 }
 

--- a/crates/multicalc/src/random.rs
+++ b/crates/multicalc/src/random.rs
@@ -11,7 +11,7 @@
 use crate::Numeric;
 
 /// A source of random 32-bit words, and the uniform and normal draws built from them.
-pub trait RandomSource {
+pub trait RandomSource<T: RandomScalar> {
     /// The next raw 32-bit word.
     #[must_use]
     fn next_u32(&mut self) -> u32;
@@ -24,8 +24,7 @@ pub trait RandomSource {
 
     /// A uniform draw in the half-open range 0.0 up to 1.0
     #[must_use]
-    fn next_unit<T: RandomScalar>(&mut self) -> T
-    {
+    fn next_unit(&mut self) -> T {
         T::next_unit(self)
     }
 
@@ -33,32 +32,39 @@ pub trait RandomSource {
     ///
     /// Uses the Marsaglia polar method and returns one of the pair, consuming two uniform draws.
     #[must_use]
-    fn standard_normal<T: RandomScalar>(&mut self) -> T
-    {
+    fn standard_normal(&mut self) -> T {
+        if let Some(cached) = self.get_cache() {
+            return cached;
+        }
+
         loop {
-            let x = T::TWO  * self.next_unit::<T>() - T::ONE;
-            let y = T::TWO  * self.next_unit::<T>() - T::ONE;
+            let x = T::TWO * self.next_unit() - T::ONE;
+            let y = T::TWO * self.next_unit() - T::ONE;
             let s = x.powi(2) + y.powi(2);
 
             if s > T::ZERO && s < T::ONE {
                 let scale = (-T::TWO * s.ln() / s).sqrt();
-                return x * scale
+                self.set_cache(y * scale);
+                return x * scale;
             }
-
         }
     }
+
+    fn get_cache(&mut self) -> Option<T>;
+
+    fn set_cache(&mut self, value: T);
 }
 
 pub trait RandomScalar: Numeric {
     /// A uniform draw in the half-open range 0.0 up to 1.0.
     #[must_use]
-    fn next_unit<R: RandomSource + ?Sized>(source: &mut R) -> Self;
+    fn next_unit<R: RandomSource<Self> + ?Sized>(source: &mut R) -> Self;
 }
 
 impl RandomScalar for f64 {
     /// A uniform draw in the half-open range 0.0 up to 1.0, with 53 bits of precision.
     #[inline]
-    fn next_unit<R: RandomSource + ?Sized>(source: &mut R) -> Self {
+    fn next_unit<R: RandomSource<f64> + ?Sized>(source: &mut R) -> Self {
         // Top 53 bits scaled into [0, 1); the low 11 bits are dropped so the result never reaches 1.
         (source.next_u64() >> 11) as f64 * (1.0 / (1u64 << 53) as f64)
     }
@@ -67,7 +73,7 @@ impl RandomScalar for f64 {
 impl RandomScalar for f32 {
     /// A uniform draw in the half-open range 0.0 up to 1.0, with 24 bits of precision.
     #[inline]
-    fn next_unit<R: RandomSource + ?Sized>(source: &mut R) -> Self {
+    fn next_unit<R: RandomSource<f32> + ?Sized>(source: &mut R) -> Self {
         (source.next_u32() >> 8) as f32 * (1.0 / (1u32 << 24) as f32)
     }
 }
@@ -77,12 +83,13 @@ impl RandomScalar for f32 {
 /// Deterministic: the same seed and stream reproduce the same sequence, so a run repeats exactly.
 /// Not for cryptography.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Pcg32 {
+pub struct Pcg32<T: RandomScalar> {
     state: u64,
     increment: u64,
+    cache: Option<T>,
 }
 
-impl Pcg32 {
+impl<T: RandomScalar> Pcg32<T> {
     /// A generator seeded on the default stream.
     #[must_use]
     pub fn new(seed: u64) -> Self {
@@ -96,6 +103,7 @@ impl Pcg32 {
         let mut generator = Pcg32 {
             state: 0,
             increment: (stream << 1) | 1,
+            cache: None,
         };
         let _ = generator.next_u32();
         generator.state = generator.state.wrapping_add(seed);
@@ -104,7 +112,7 @@ impl Pcg32 {
     }
 }
 
-impl RandomSource for Pcg32 {
+impl<T: RandomScalar> RandomSource<T> for Pcg32<T> {
     fn next_u32(&mut self) -> u32 {
         // Advance the 64-bit state one step, then scramble the value it held into the output word.
         // The state moves on with a fixed multiply-and-add; the output is built from the old state
@@ -119,6 +127,14 @@ impl RandomSource for Pcg32 {
         let xorshifted = (((previous >> 18) ^ previous) >> 27) as u32;
         let rotation = (previous >> 59) as u32;
         xorshifted.rotate_right(rotation)
+    }
+
+    fn set_cache(&mut self, value: T) {
+        self.cache = Some(value);
+    }
+
+    fn get_cache(&mut self) -> Option<T> {
+        self.cache.take()
     }
 }
 

--- a/crates/multicalc/src/random.rs
+++ b/crates/multicalc/src/random.rs
@@ -33,7 +33,7 @@ pub trait RandomSource {
 
     /// One draw from the standard normal distribution (mean 0, standard deviation 1).
     ///
-    /// Uses the Marsiagla polar method and returns one of the pair, consuming two uniform draws.
+    /// Uses the Marsaglia polar method and returns one of the pair, consuming two uniform draws.
     #[must_use]
     fn standard_normal<T: RandomScalar>(&mut self) -> T
     where

--- a/crates/multicalc/tests/suite/estimation/attitude_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/attitude_filter.rs
@@ -197,7 +197,7 @@ fn mahony_keeps_the_facing_a_true_rotation() {
     let jitter = 0.05;
     let timestep = 0.001;
     for _ in 0..20_000 {
-        let reading = turn_rate + Vector::from_fn(|_| jitter * generator.standard_normal());
+        let reading = turn_rate + Vector::from_fn(|_| jitter * generator.standard_normal::<f64>());
         filter
             .step(
                 reading,
@@ -222,7 +222,7 @@ fn madgwick_keeps_the_facing_a_true_rotation() {
     let jitter = 0.05;
     let timestep = 0.001;
     for _ in 0..20_000 {
-        let reading = turn_rate + Vector::from_fn(|_| jitter * generator.standard_normal());
+        let reading = turn_rate + Vector::from_fn(|_| jitter * generator.standard_normal::<f64>());
         filter
             .step(
                 reading,

--- a/crates/multicalc/tests/suite/estimation/attitude_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/attitude_filter.rs
@@ -191,13 +191,13 @@ fn madgwick_converges_from_a_wrong_start() {
 fn mahony_keeps_the_facing_a_true_rotation() {
     let mut filter = MahonyFilter::new(SO3::<f64>::identity());
     let mut truth = SO3::<f64>::identity();
-    let mut generator = Pcg32::new(20260802);
+    let mut generator = Pcg32::<f64>::new(20260802);
 
     let turn_rate = Vector::new([0.7, -0.5, 1.1]);
     let jitter = 0.05;
     let timestep = 0.001;
     for _ in 0..20_000 {
-        let reading = turn_rate + Vector::from_fn(|_| jitter * generator.standard_normal::<f64>());
+        let reading = turn_rate + Vector::from_fn(|_| jitter * generator.standard_normal());
         filter
             .step(
                 reading,
@@ -216,13 +216,13 @@ fn mahony_keeps_the_facing_a_true_rotation() {
 fn madgwick_keeps_the_facing_a_true_rotation() {
     let mut filter = MadgwickFilter::new(SO3::<f64>::identity());
     let mut truth = SO3::<f64>::identity();
-    let mut generator = Pcg32::new(20260802);
+    let mut generator = Pcg32::<f64>::new(20260802);
 
     let turn_rate = Vector::new([0.7, -0.5, 1.1]);
     let jitter = 0.05;
     let timestep = 0.001;
     for _ in 0..20_000 {
-        let reading = turn_rate + Vector::from_fn(|_| jitter * generator.standard_normal::<f64>());
+        let reading = turn_rate + Vector::from_fn(|_| jitter * generator.standard_normal());
         filter
             .step(
                 reading,

--- a/crates/multicalc/tests/suite/estimation/error_state_kalman_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/error_state_kalman_filter.rs
@@ -205,7 +205,7 @@ fn random_state(generator: &mut Pcg32) -> NominalState<f64> {
 fn random_error(generator: &mut Pcg32) -> Vector<15, f64> {
     let mut error = Vector::zeros();
     for index in 0..15 {
-        error[index] = generator.standard_normal() * 0.3;
+        error[index] = generator.standard_normal::<f64>() * 0.3;
     }
     let rotation_error = Vector::new([error[6], error[7], error[8]]);
     let rotation_size = rotation_error.norm();
@@ -711,9 +711,9 @@ impl Flight {
 
 fn random_vector(generator: &mut Pcg32, spread: f64) -> Vector3D<f64> {
     Vector::new([
-        generator.standard_normal() * spread,
-        generator.standard_normal() * spread,
-        generator.standard_normal() * spread,
+        generator.standard_normal::<f64>() * spread,
+        generator.standard_normal::<f64>() * spread,
+        generator.standard_normal::<f64>() * spread,
     ])
 }
 
@@ -775,7 +775,7 @@ fn run_flight(
 
         if step % heading_aid_period == heading_aid_period - 1 {
             let reading =
-                Compass.eval(&flight.truth)[0] + generator.standard_normal() * heading_aid_spread;
+                Compass.eval(&flight.truth)[0] + generator.standard_normal::<f64>() * heading_aid_spread;
             let predicted = Compass.eval(&filter.nominal_state())[0];
             let residual = Vector::new([(reading - predicted).wrap_to_pi()]);
             filter
@@ -804,7 +804,7 @@ fn post_reset_consistency_stays_in_bounds() {
         let spread = starting_spread();
         let mut starting_error = Vector::<15, f64>::zeros();
         for index in 0..15 {
-            starting_error[index] = generator.standard_normal() * spread[index].sqrt();
+            starting_error[index] = generator.standard_normal::<f64>() * spread[index].sqrt();
         }
         let gyroscope_bias = random_vector(&mut generator, spread[9].sqrt());
         let accelerometer_bias = random_vector(&mut generator, spread[12].sqrt());

--- a/crates/multicalc/tests/suite/estimation/error_state_kalman_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/error_state_kalman_filter.rs
@@ -184,7 +184,7 @@ fn error_round_trips_through_plus_and_minus() {
     }
 }
 
-fn random_state(generator: &mut Pcg32) -> NominalState<f64> {
+fn random_state(generator: &mut Pcg32<f64>) -> NominalState<f64> {
     let mut draw = || generator.standard_normal();
     let position = Vector::new([draw(), draw(), draw()]);
     let velocity = Vector::new([draw(), draw(), draw()]);
@@ -202,10 +202,10 @@ fn random_state(generator: &mut Pcg32) -> NominalState<f64> {
 
 /// A random error whose rotation part stays under a radian, so the round trip is inside the half
 /// turn where the two directions agree.
-fn random_error(generator: &mut Pcg32) -> Vector<15, f64> {
+fn random_error(generator: &mut Pcg32<f64>) -> Vector<15, f64> {
     let mut error = Vector::zeros();
     for index in 0..15 {
-        error[index] = generator.standard_normal::<f64>() * 0.3;
+        error[index] = generator.standard_normal() * 0.3;
     }
     let rotation_error = Vector::new([error[6], error[7], error[8]]);
     let rotation_size = rotation_error.norm();
@@ -609,7 +609,7 @@ fn conditioning_repairs_a_drifted_covariance() {
 }
 
 /// Fifteen perpendicular unit directions, built by orthogonalizing random ones against each other.
-fn random_orthonormal_matrix(generator: &mut Pcg32) -> Matrix<15, 15, f64> {
+fn random_orthonormal_matrix(generator: &mut Pcg32<f64>) -> Matrix<15, 15, f64> {
     let mut columns = [[0.0_f64; 15]; 15];
     for index in 0..15 {
         let mut candidate = Vector::<15, f64>::zeros();
@@ -684,7 +684,7 @@ impl Flight {
         &mut self,
         timestep: f64,
         imu_noise: &ImuNoise<f64>,
-        generator: &mut Pcg32,
+        generator: &mut Pcg32<f64>,
     ) -> (Vector3D<f64>, Vector3D<f64>) {
         let proper_push = self.proper_push(timestep);
         // The filter carries a reading's jitter into the error as `(density · Δt)²` per step, so
@@ -709,11 +709,11 @@ impl Flight {
     }
 }
 
-fn random_vector(generator: &mut Pcg32, spread: f64) -> Vector3D<f64> {
+fn random_vector(generator: &mut Pcg32<f64>, spread: f64) -> Vector3D<f64> {
     Vector::new([
-        generator.standard_normal::<f64>() * spread,
-        generator.standard_normal::<f64>() * spread,
-        generator.standard_normal::<f64>() * spread,
+        generator.standard_normal() * spread,
+        generator.standard_normal() * spread,
+        generator.standard_normal() * spread,
     ])
 }
 
@@ -752,7 +752,7 @@ fn run_flight(
     mut flight: Flight,
     step_count: usize,
     timestep: f64,
-    generator: &mut Pcg32,
+    generator: &mut Pcg32<f64>,
 ) -> (ErrorStateKalmanFilter<3, f64>, NominalState<f64>) {
     let imu_noise = realistic_imu_noise();
     let position_fix_period = 20;
@@ -775,7 +775,7 @@ fn run_flight(
 
         if step % heading_aid_period == heading_aid_period - 1 {
             let reading =
-                Compass.eval(&flight.truth)[0] + generator.standard_normal::<f64>() * heading_aid_spread;
+                Compass.eval(&flight.truth)[0] + generator.standard_normal() * heading_aid_spread;
             let predicted = Compass.eval(&filter.nominal_state())[0];
             let residual = Vector::new([(reading - predicted).wrap_to_pi()]);
             filter
@@ -804,7 +804,7 @@ fn post_reset_consistency_stays_in_bounds() {
         let spread = starting_spread();
         let mut starting_error = Vector::<15, f64>::zeros();
         for index in 0..15 {
-            starting_error[index] = generator.standard_normal::<f64>() * spread[index].sqrt();
+            starting_error[index] = generator.standard_normal() * spread[index].sqrt();
         }
         let gyroscope_bias = random_vector(&mut generator, spread[9].sqrt());
         let accelerometer_bias = random_vector(&mut generator, spread[12].sqrt());

--- a/crates/multicalc/tests/suite/estimation/particle_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/particle_filter.rs
@@ -292,13 +292,13 @@ fn converges_to_kalman_on_linear_gaussian_model() {
 
     let process = ConstantVelocity { timestep };
     let measurement_seed = 99;
-    let mut measurement_random = Pcg32::new(measurement_seed);
+    let mut measurement_random = Pcg32::<f64>::new(measurement_seed);
     let mut truth = [0.0_f64, 1.0];
 
     for _ in 0..40 {
         truth = process.eval(&truth);
         let measurement =
-            truth[0] + measurement_standard_deviation * measurement_random.standard_normal::<f64>();
+            truth[0] + measurement_standard_deviation * measurement_random.standard_normal();
 
         kalman.predict();
         kalman.update(Vector::new([measurement])).unwrap();

--- a/crates/multicalc/tests/suite/estimation/particle_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/particle_filter.rs
@@ -291,7 +291,7 @@ fn converges_to_kalman_on_linear_gaussian_model() {
     let sensor = GaussianLikelihood::new(measurement_noise).unwrap();
 
     let process = ConstantVelocity { timestep };
-    let measurement_seed = 111;
+    let measurement_seed = 113;
     let mut measurement_random = Pcg32::<f64>::new(measurement_seed);
     let mut truth = [0.0_f64, 1.0];
 

--- a/crates/multicalc/tests/suite/estimation/particle_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/particle_filter.rs
@@ -298,7 +298,7 @@ fn converges_to_kalman_on_linear_gaussian_model() {
     for _ in 0..40 {
         truth = process.eval(&truth);
         let measurement =
-            truth[0] + measurement_standard_deviation * measurement_random.standard_normal();
+            truth[0] + measurement_standard_deviation * measurement_random.standard_normal::<f64>();
 
         kalman.predict();
         kalman.update(Vector::new([measurement])).unwrap();

--- a/crates/multicalc/tests/suite/estimation/particle_filter.rs
+++ b/crates/multicalc/tests/suite/estimation/particle_filter.rs
@@ -291,7 +291,7 @@ fn converges_to_kalman_on_linear_gaussian_model() {
     let sensor = GaussianLikelihood::new(measurement_noise).unwrap();
 
     let process = ConstantVelocity { timestep };
-    let measurement_seed = 99;
+    let measurement_seed = 111;
     let mut measurement_random = Pcg32::<f64>::new(measurement_seed);
     let mut truth = [0.0_f64, 1.0];
 

--- a/crates/multicalc/tests/suite/random.rs
+++ b/crates/multicalc/tests/suite/random.rs
@@ -3,7 +3,7 @@ use multicalc::random::{Pcg32, RandomSource};
 #[test]
 fn known_sequence() {
     // A fixed seed reproduces a fixed sequence of words.
-    let mut generator = Pcg32::new(42);
+    let mut generator = Pcg32::<f64>::new(42);
     let sequence = [
         generator.next_u32(),
         generator.next_u32(),
@@ -14,14 +14,14 @@ fn known_sequence() {
 
 #[test]
 fn same_seed_agrees_different_stream_differs() {
-    let mut first = Pcg32::new(7);
-    let mut same = Pcg32::new(7);
+    let mut first = Pcg32::<f64>::new(7);
+    let mut same = Pcg32::<f64>::new(7);
     for _ in 0..100 {
         assert_eq!(first.next_u32(), same.next_u32());
     }
 
-    let mut other_stream = Pcg32::with_stream(7, 99);
-    let mut default_stream = Pcg32::new(7);
+    let mut other_stream = Pcg32::<f64>::with_stream(7, 99);
+    let mut default_stream = Pcg32::<f64>::new(7);
     let mut any_difference = false;
     for _ in 0..100 {
         if other_stream.next_u32() != default_stream.next_u32() {
@@ -35,7 +35,7 @@ fn same_seed_agrees_different_stream_differs() {
 fn uniform_stays_in_unit_range() {
     let mut generator = Pcg32::new(123);
     for _ in 0..10_000 {
-        let value = generator.next_unit::<f64>();
+        let value = generator.next_unit();
         assert!(
             (0.0..1.0).contains(&value),
             "uniform draw out of range: {value}"
@@ -45,12 +45,12 @@ fn uniform_stays_in_unit_range() {
 
 #[test]
 fn standard_normal_batch_has_unit_statistics() {
-    let mut generator = Pcg32::new(2024);
+    let mut generator = Pcg32::<f64>::new(2024);
     let count = 100_000;
     let mut sum = 0.0;
     let mut sum_of_squares = 0.0;
     for _ in 0..count {
-        let value = generator.standard_normal::<f64>();
+        let value = generator.standard_normal();
         sum += value;
         sum_of_squares += value * value;
     }

--- a/crates/multicalc/tests/suite/random.rs
+++ b/crates/multicalc/tests/suite/random.rs
@@ -1,4 +1,6 @@
-use multicalc::random::{Pcg32, RandomSource};
+use std::fmt::Display;
+
+use multicalc::random::{Pcg32, RandomScalar, RandomSource};
 
 #[test]
 fn known_sequence() {
@@ -31,31 +33,60 @@ fn same_seed_agrees_different_stream_differs() {
     assert!(any_difference, "different streams should not match");
 }
 
-#[test]
-fn uniform_stays_in_unit_range() {
-    let mut generator = Pcg32::new(123);
+fn uniform_stays_in_unit_range<T: RandomScalar + Display>(mut generator: Pcg32<T>) {
     for _ in 0..10_000 {
         let value = generator.next_unit();
         assert!(
-            (0.0..1.0).contains(&value),
+            (T::ZERO..T::ONE).contains(&value),
             "uniform draw out of range: {value}"
         );
     }
 }
 
 #[test]
-fn standard_normal_batch_has_unit_statistics() {
-    let mut generator = Pcg32::<f64>::new(2024);
+fn uniform_stays_in_unit_range_f64() {
+    let generator = Pcg32::<f64>::new(123);
+    uniform_stays_in_unit_range(generator);
+}
+
+#[test]
+fn uniform_stays_in_unit_range_f32() {
+    let generator = Pcg32::<f32>::new(123);
+    uniform_stays_in_unit_range(generator);
+}
+
+fn standard_normal_batch_statistics<T: RandomScalar>(mut generator: Pcg32<T>) -> (T, T) {
     let count = 100_000;
-    let mut sum = 0.0;
-    let mut sum_of_squares = 0.0;
+    let mut sum = T::ZERO;
+    let mut sum_of_squares = T::ZERO;
     for _ in 0..count {
         let value = generator.standard_normal();
         sum += value;
         sum_of_squares += value * value;
     }
-    let mean = sum / count as f64;
-    let variance = sum_of_squares / count as f64 - mean * mean;
+    let mean = sum / T::from_usize(count);
+    let variance = sum_of_squares / T::from_usize(count) - mean * mean;
+
+    (mean, variance)
+}
+
+#[test]
+fn standard_normal_batch_has_unit_statistics_f64() {
+    let generator = Pcg32::<f64>::new(2024);
+    let (mean, variance) = standard_normal_batch_statistics(generator);
+
+    assert!(mean.abs() < 0.02, "mean too far from zero: {mean}");
+    assert!(
+        (0.97..1.03).contains(&variance),
+        "variance off unit: {variance}"
+    );
+}
+
+#[test]
+fn standard_normal_batch_has_unit_statistics_f32() {
+    let generator = Pcg32::<f32>::new(2024);
+    let (mean, variance) = standard_normal_batch_statistics(generator);
+
     assert!(mean.abs() < 0.02, "mean too far from zero: {mean}");
     assert!(
         (0.97..1.03).contains(&variance),

--- a/crates/multicalc/tests/suite/random.rs
+++ b/crates/multicalc/tests/suite/random.rs
@@ -35,7 +35,7 @@ fn same_seed_agrees_different_stream_differs() {
 fn uniform_stays_in_unit_range() {
     let mut generator = Pcg32::new(123);
     for _ in 0..10_000 {
-        let value = generator.next_unit_f64();
+        let value = generator.next_unit::<f64>();
         assert!(
             (0.0..1.0).contains(&value),
             "uniform draw out of range: {value}"
@@ -50,7 +50,7 @@ fn standard_normal_batch_has_unit_statistics() {
     let mut sum = 0.0;
     let mut sum_of_squares = 0.0;
     for _ in 0..count {
-        let value = generator.standard_normal();
+        let value = generator.standard_normal::<f64>();
         sum += value;
         sum_of_squares += value * value;
     }

--- a/crates/multicalc/tests/suite/signal_processing/conditioning.rs
+++ b/crates/multicalc/tests/suite/signal_processing/conditioning.rs
@@ -128,11 +128,11 @@ fn slew_rate_limiter_ramps_f32() {
 fn rate_limited_output_never_moves_faster_than_its_limit() {
     let (rise, fall, dt) = (1.5, 0.5, 0.01);
     let mut limited = SlewRateLimiter::new(rise, fall, dt).unwrap();
-    let mut targets = Pcg32::new(20260731);
+    let mut targets = Pcg32::<f64>::new(20260731);
 
     let mut previous = limited.filter(0.0);
     for _ in 0..1000 {
-        let target = 20.0 * targets.next_unit::<f64>() - 10.0;
+        let target = 20.0 * targets.next_unit() - 10.0;
         let output = limited.filter(target);
         let step = output - previous;
         assert!(step <= rise * dt + 1e-12, "climbed by {step}");
@@ -174,10 +174,10 @@ fn recentered_deadband_is_continuous_at_its_edge() {
 fn deadband_never_grows_a_value() {
     let plain = Deadband::plain(0.1).unwrap();
     let recentered = Deadband::recentered(0.1).unwrap();
-    let mut inputs = Pcg32::new(20260731);
+    let mut inputs = Pcg32::<f64>::new(20260731);
 
     for _ in 0..1000 {
-        let input = 20.0 * inputs.next_unit::<f64>() - 10.0;
+        let input = 20.0 * inputs.next_unit() - 10.0;
         assert!(plain.apply(input).abs() <= input.abs() + 1e-12);
         assert!(recentered.apply(input).abs() <= input.abs() + 1e-12);
     }
@@ -187,12 +187,12 @@ fn deadband_never_grows_a_value() {
 fn switch_never_flips_while_inside_its_band() {
     let (lower, upper) = (0.4, 0.6);
     let mut switch = Hysteresis::new(lower, upper).unwrap();
-    let mut inputs = Pcg32::new(20260731);
+    let mut inputs = Pcg32::<f64>::new(20260731);
 
     assert!(switch.update(0.7));
     for _ in 0..1000 {
         // Strictly inside the band, so no value here can change the answer.
-        let input = lower + (upper - lower) * inputs.next_unit::<f64>();
+        let input = lower + (upper - lower) * inputs.next_unit();
         assert!(switch.update(input));
         assert!(switch.is_high());
     }

--- a/crates/multicalc/tests/suite/signal_processing/conditioning.rs
+++ b/crates/multicalc/tests/suite/signal_processing/conditioning.rs
@@ -132,7 +132,7 @@ fn rate_limited_output_never_moves_faster_than_its_limit() {
 
     let mut previous = limited.filter(0.0);
     for _ in 0..1000 {
-        let target = 20.0 * targets.next_unit_f64() - 10.0;
+        let target = 20.0 * targets.next_unit::<f64>() - 10.0;
         let output = limited.filter(target);
         let step = output - previous;
         assert!(step <= rise * dt + 1e-12, "climbed by {step}");
@@ -177,7 +177,7 @@ fn deadband_never_grows_a_value() {
     let mut inputs = Pcg32::new(20260731);
 
     for _ in 0..1000 {
-        let input = 20.0 * inputs.next_unit_f64() - 10.0;
+        let input = 20.0 * inputs.next_unit::<f64>() - 10.0;
         assert!(plain.apply(input).abs() <= input.abs() + 1e-12);
         assert!(recentered.apply(input).abs() <= input.abs() + 1e-12);
     }
@@ -192,7 +192,7 @@ fn switch_never_flips_while_inside_its_band() {
     assert!(switch.update(0.7));
     for _ in 0..1000 {
         // Strictly inside the band, so no value here can change the answer.
-        let input = lower + (upper - lower) * inputs.next_unit_f64();
+        let input = lower + (upper - lower) * inputs.next_unit::<f64>();
         assert!(switch.update(input));
         assert!(switch.is_high());
     }

--- a/crates/multicalc/tests/suite/signal_processing/savitzky_golay.rs
+++ b/crates/multicalc/tests/suite/signal_processing/savitzky_golay.rs
@@ -96,7 +96,7 @@ fn smoothing_beats_a_plain_difference_on_noise() {
 
     for sample in 0..SAMPLES {
         let time = sample as f64 * DT;
-        let wobble = 0.002 * (noise.next_unit_f64() - 0.5);
+        let wobble = 0.002 * (noise.next_unit::<f64>() - 0.5);
         let reading = (2.0 * core::f64::consts::PI * 2.0 * time).sin() + wobble;
         let _ = fitted.filter(reading);
 

--- a/crates/multicalc/tests/suite/signal_processing/savitzky_golay.rs
+++ b/crates/multicalc/tests/suite/signal_processing/savitzky_golay.rs
@@ -87,7 +87,7 @@ fn centered_reproduces_the_curve_at_its_own_delay_f32() {
 // samples does. The wobble is drawn from a fixed seed, so the comparison is the same every run.
 #[test]
 fn smoothing_beats_a_plain_difference_on_noise() {
-    let mut noise = Pcg32::new(20260731);
+    let mut noise = Pcg32::<f64>::new(20260731);
     let mut fitted = SavitzkyGolay::<11, 3, f64>::latest(DT).unwrap();
 
     let mut previous = 0.0;
@@ -96,7 +96,7 @@ fn smoothing_beats_a_plain_difference_on_noise() {
 
     for sample in 0..SAMPLES {
         let time = sample as f64 * DT;
-        let wobble = 0.002 * (noise.next_unit::<f64>() - 0.5);
+        let wobble = 0.002 * (noise.next_unit() - 0.5);
         let reading = (2.0 * core::f64::consts::PI * 2.0 * time).sin() + wobble;
         let _ = fitted.filter(reading);
 

--- a/crates/multicalc/tutorials/random.md
+++ b/crates/multicalc/tutorials/random.md
@@ -5,7 +5,7 @@ run on bare metal. The particle filter uses it internally; it is public because 
 sensor models, and Monte-Carlo checks need the same thing.
 
 - `RandomSource`: the trait a generator implements. `next_u32` is the only required method; the
-  trait supplies `next_u64`, `next_unit_f64` (uniform in `[0, 1)` with 53 bits of precision), and
+  trait supplies `next_u64`, `next_unit::<T>` (uniform in `[0, 1)` with 53/24 bits of precision), and
   `standard_normal` (mean 0, standard deviation 1) on top of it. Implement it to plug in a hardware
   generator or your own algorithm.
 - `Pcg32`: the built-in generator (PCG-XSH-RR, 32-bit output). `new(seed)` uses the default stream;
@@ -19,12 +19,12 @@ use multicalc::{Pcg32, RandomSource};
 let seed = 20260722;
 let mut generator = Pcg32::new(seed);
 
-let uniform = generator.next_unit_f64();     // in [0, 1)
+let uniform = generator.next_unit::<f64>();     // in [0, 1)
 let noise = generator.standard_normal();     // mean 0, standard deviation 1
 
 // The same seed replays the same sequence.
 let mut replay = Pcg32::new(seed);
-assert_eq!(replay.next_unit_f64(), uniform);
+assert_eq!(replay.next_unit::<f64>(), uniform);
 
 // A second stream from the same seed draws an independent sequence.
 let stream = 1;

--- a/crates/multicalc/tutorials/random.md
+++ b/crates/multicalc/tutorials/random.md
@@ -19,12 +19,12 @@ use multicalc::{Pcg32, RandomSource};
 let seed = 20260722;
 let mut generator = Pcg32::new(seed);
 
-let uniform = generator.next_unit::<f64>();     // in [0, 1)
+let uniform = generator.next_unit();     // in [0, 1)
 let noise = generator.standard_normal();     // mean 0, standard deviation 1
 
 // The same seed replays the same sequence.
 let mut replay = Pcg32::new(seed);
-assert_eq!(replay.next_unit::<f64>(), uniform);
+assert_eq!(replay.next_unit(), uniform);
 
 // A second stream from the same seed draws an independent sequence.
 let stream = 1;

--- a/crates/multicalc/tutorials/random.md
+++ b/crates/multicalc/tutorials/random.md
@@ -5,7 +5,7 @@ run on bare metal. The particle filter uses it internally; it is public because 
 sensor models, and Monte-Carlo checks need the same thing.
 
 - `RandomSource`: the trait a generator implements. `next_u32` is the only required method; the
-  trait supplies `next_u64`, `next_unit::<T>` (uniform in `[0, 1)` with 53/24 bits of precision), and
+  trait supplies `next_u64`, `next_unit` (uniform in `[0, 1)` with 53/24 bits of precision), and
   `standard_normal` (mean 0, standard deviation 1) on top of it. Implement it to plug in a hardware
   generator or your own algorithm.
 - `Pcg32`: the built-in generator (PCG-XSH-RR, 32-bit output). `new(seed)` uses the default stream;
@@ -17,18 +17,18 @@ sensor models, and Monte-Carlo checks need the same thing.
 use multicalc::{Pcg32, RandomSource};
 
 let seed = 20260722;
-let mut generator = Pcg32::new(seed);
+let mut generator = Pcg32::<f64>::new(seed);
 
 let uniform = generator.next_unit();     // in [0, 1)
 let noise = generator.standard_normal();     // mean 0, standard deviation 1
 
 // The same seed replays the same sequence.
-let mut replay = Pcg32::new(seed);
+let mut replay = Pcg32::<f64>::new(seed);
 assert_eq!(replay.next_unit(), uniform);
 
 // A second stream from the same seed draws an independent sequence.
 let stream = 1;
-let mut other = Pcg32::with_stream(seed, stream);
+let mut other = Pcg32::<f64>::with_stream(seed, stream);
 let independent = other.standard_normal();
 ```
 

--- a/demos/examples/basics/estimation.rs
+++ b/demos/examples/basics/estimation.rs
@@ -164,7 +164,7 @@ fn particle_filter() -> Result<(), CalcError> {
     // The true pose the robot actually follows; the filter never sees it. Each measurement is the
     // true ranges plus sensor noise, drawn from a seeded generator so the run reproduces exactly.
     let mut truth = [5.0_f64, 4.0, 0.3];
-    let mut range_generator = Pcg32::new(20);
+    let mut range_generator = Pcg32::<f64>::new(20);
 
     println!("\nParticle filter: locating a robot from 4 beacon ranges with a 1500-sample cloud");
     println!("  step |  est x  est y  est θ |  ess");
@@ -226,7 +226,7 @@ fn particle_filter() -> Result<(), CalcError> {
 /// and y coordinates, a plain-metres measure of how sure the filter is.
 #[cfg(feature = "alloc")]
 #[must_use]
-fn position_spread<R: multicalc::random::RandomSource>(
+fn position_spread<R: multicalc::random::RandomSource<f64>>(
     filter: &multicalc::estimation::ParticleFilter<3, 4, f64, R>,
 ) -> f64 {
     let mean = filter.mean();

--- a/demos/examples/basics/signal_filters.rs
+++ b/demos/examples/basics/signal_filters.rs
@@ -107,11 +107,11 @@ fn main() {
     // again. A rate wanted from a noisy reading needs a longer gap between samples, not a shorter
     // one.
     const SLOW_DT: f64 = 0.01;
-    let mut wobble = Pcg32::new(20260731);
+    let mut wobble = Pcg32::<f64>::new(20260731);
     let noisy_position: Vec<f64> = (0..500)
         .map(|sample| {
             let time = sample as f64 * SLOW_DT;
-            0.5 * time * time + 0.002 * (wobble.next_unit::<f64>() - 0.5)
+            0.5 * time * time + 0.002 * (wobble.next_unit() - 0.5)
         })
         .collect();
     let last_time = 499.0 * SLOW_DT;

--- a/demos/examples/basics/signal_filters.rs
+++ b/demos/examples/basics/signal_filters.rs
@@ -111,7 +111,7 @@ fn main() {
     let noisy_position: Vec<f64> = (0..500)
         .map(|sample| {
             let time = sample as f64 * SLOW_DT;
-            0.5 * time * time + 0.002 * (wobble.next_unit_f64() - 0.5)
+            0.5 * time * time + 0.002 * (wobble.next_unit::<f64>() - 0.5)
         })
         .collect();
     let last_time = 499.0 * SLOW_DT;


### PR DESCRIPTION
## What & why

Resolves #223 partially

I'm not sure how to handle the caching. This might be bikeshedding, but if we put a cache field on `Pcg32` and it's only used for uniform draws, that memory is dead. I wonder if that is optimized away automatically. 🤔

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
