### PR TITLE
Add small-angles thresholds for different trig functions

### DIFF
--- a/crates/multicalc/src/spatial/lie/mod.rs
+++ b/crates/multicalc/src/spatial/lie/mod.rs
@@ -22,7 +22,7 @@ pub use so3::SO3;
 
 use crate::linear_algebra::{Matrix, Matrix3D, Matrix6D, Vector, Vector3D, Vector6D};
 use crate::scalar::Numeric;
-use crate::spatial::small_angle_sq;
+use crate::spatial::{small_angle_inverse_so3_sq, small_angle_se3_sq, small_angle_so3_sq};
 
 /// The 3×3 skew-symmetric matrix `[v]×`, so that `[v]× · p = v × p`.
 #[inline]
@@ -38,18 +38,21 @@ pub(crate) fn left_jacobian_so3<T: Numeric>(phi: Vector3D<T>) -> Matrix3D<T> {
     let theta_sq = phi.dot(phi);
     let s = skew3(phi);
     let s2 = s * s;
-    let (c1, c2) = if theta_sq < small_angle_sq::<T>() {
-        (
-            T::HALF - theta_sq / T::from_f64(24.0),
-            T::ONE / T::from_f64(6.0) - theta_sq / T::from_f64(120.0),
-        )
+    let (t1, t2) = small_angle_so3_sq::<T>();
+    let theta = theta_sq.sqrt();
+
+    let c1 = if theta_sq < t1 {
+        T::HALF - theta_sq / T::from_f64(24.0)
     } else {
-        let theta = theta_sq.sqrt();
-        (
-            (T::ONE - theta.cos()) / theta_sq,
-            (theta - theta.sin()) / (theta_sq * theta),
-        )
+        (T::ONE - theta.cos()) / theta_sq
     };
+
+    let c2 = if theta_sq < t2 {
+        T::ONE / T::from_f64(6.0) - theta_sq / T::from_f64(120.0)
+    } else {
+        (theta - theta.sin()) / (theta_sq * theta)
+    };
+
     Matrix::identity() + s.scale(c1) + s2.scale(c2)
 }
 
@@ -60,7 +63,7 @@ pub(crate) fn inverse_left_jacobian_so3<T: Numeric>(phi: Vector3D<T>) -> Matrix3
     let theta_sq = phi.dot(phi);
     let s = skew3(phi);
     let s2 = s * s;
-    let c3 = if theta_sq < small_angle_sq::<T>() {
+    let c3 = if theta_sq < small_angle_inverse_so3_sq::<T>() {
         T::ONE / T::from_f64(12.0) + theta_sq / T::from_f64(720.0)
     } else {
         let theta = theta_sq.sqrt();
@@ -77,23 +80,33 @@ pub(crate) fn q_matrix_se3<T: Numeric>(rho: Vector3D<T>, phi: Vector3D<T>) -> Ma
     let theta_sq = phi.dot(phi);
     let p = skew3(rho);
     let ph = skew3(phi);
-    let (c2, c3, c5) = if theta_sq < small_angle_sq::<T>() {
-        (
-            T::ONE / T::from_f64(6.0) - theta_sq / T::from_f64(120.0),
-            T::ONE / T::from_f64(24.0) - theta_sq / T::from_f64(720.0),
-            -T::ONE / T::from_f64(120.0) + theta_sq / T::from_f64(5040.0),
-        )
+    // Each ratio cancels at its own angle, so each gets its own cutoff. Sharing one would force
+    // the earliest-switching ratio onto its series far past its crossover, and truncation grows
+    // as θ⁴.
+    let (t_c2, t_c3, t_c5) = small_angle_se3_sq::<T>();
+    let theta = theta_sq.sqrt();
+    let theta3 = theta_sq * theta;
+    let theta4 = theta_sq * theta_sq;
+    let theta5 = theta4 * theta;
+
+    let c2 = if theta_sq < t_c2 {
+        T::ONE / T::from_f64(6.0) - theta_sq / T::from_f64(120.0)
     } else {
-        let theta = theta_sq.sqrt();
-        let theta3 = theta_sq * theta;
-        let theta4 = theta_sq * theta_sq;
-        let theta5 = theta4 * theta;
-        (
-            (theta - theta.sin()) / theta3,
-            (T::ONE - theta_sq * T::HALF - theta.cos()) / theta4,
-            (theta - theta.sin() - theta3 / T::from_f64(6.0)) / theta5,
-        )
+        (theta - theta.sin()) / theta3
     };
+
+    let c3 = if theta_sq < t_c3 {
+        -T::ONE / T::from_f64(24.0) + theta_sq / T::from_f64(720.0)
+    } else {
+        (T::ONE - theta_sq * T::HALF - theta.cos()) / theta4
+    };
+
+    let c5 = if theta_sq < t_c5 {
+        -T::ONE / T::from_f64(120.0) + theta_sq / T::from_f64(5040.0)
+    } else {
+        (theta - theta.sin() - theta3 / T::from_f64(6.0)) / theta5
+    };
+
     let c4 = (c3 - T::from_f64(3.0) * c5) * T::HALF;
     let phph = ph * p * ph; // Φ P Φ, reused in two terms
     let t2 = ph * p + p * ph + phph; // ΦP + PΦ + ΦPΦ

--- a/crates/multicalc/src/spatial/mod.rs
+++ b/crates/multicalc/src/spatial/mod.rs
@@ -38,3 +38,36 @@ pub(crate) fn small_angle<T: Numeric>() -> T {
 pub(crate) fn small_angle_sq<T: Numeric>() -> T {
     small_angle::<T>() * small_angle::<T>()
 }
+
+/// Small-angle thresholds for left jacobian so3
+/// t1 = (360*epsilon)^(1/6)
+/// t2 = (2520*epsilon)^(1/6)
+#[inline]
+#[must_use]
+pub(crate) fn small_angle_so3_sq<T: Numeric>() -> (T, T) {
+    let t1 = (T::from_f64(360.0) * T::EPSILON).cbrt();
+    let t2 = (T::from_f64(2520.0) * T::EPSILON).cbrt();
+    (t1, t2)
+}
+
+/// Small-angle threshold for inverse left jacobian so3
+/// t = (16*945*epsilon)^(1/6)
+#[inline]
+#[must_use]
+pub(crate) fn small_angle_inverse_so3_sq<T: Numeric>() -> T {
+    (T::from_f64(15_120.0) * T::EPSILON).cbrt()
+}
+
+/// Small-angle threshold for q matrix se3
+/// The function has two thresholds, take the largest
+/// t2 = (2520*espilon)^(1/6)
+/// t3 = (12*1680*espilon)^(1/8)
+/// t5 = (0.5*9!*epsilon)^(1/8)
+#[inline]
+#[must_use]
+pub(crate) fn small_angle_se3_sq<T: Numeric>() -> (T, T, T) {
+    let t2 = (T::from_f64(2520.0) * T::EPSILON).cbrt();
+    let t3 = (T::from_f64(20_160.0) * T::EPSILON).sqrt().sqrt();
+    let t5 = (T::from_f64(181_440.0) * T::EPSILON).sqrt().sqrt();
+    (t2, t3, t5)
+}

--- a/crates/multicalc/tests/suite/spatial/lie.rs
+++ b/crates/multicalc/tests/suite/spatial/lie.rs
@@ -4,7 +4,7 @@
 
 use std::f64::consts::PI;
 
-use multicalc::linear_algebra::{Matrix, Vector, Vector2D, Vector3D, Vector6D};
+use multicalc::linear_algebra::{Matrix, Matrix3D, Vector, Vector2D, Vector3D, Vector6D};
 use multicalc::scalar::{Dual, Numeric};
 use multicalc::spatial::{SE2, SE3, SO2, SO3};
 use rand::rngs::StdRng;
@@ -67,6 +67,19 @@ fn random_se2(rng: &mut StdRng) -> SE2<f64> {
         random_so2(rng),
         Vector::new([rng.gen_range(-2.0..2.0), rng.gen_range(-2.0..2.0)]),
     )
+}
+
+/// Translation part of every `Q(ρ, φ)` reference below. Must match `RHO` in
+/// `tools/qa/src/bin/spatial_small_angle.py`, which generated those matrices.
+const RHO: Vector3D = Vector::new([0.5, 0.25, -0.75]);
+
+/// Barfoot's `Q(ρ, φ)`: the top-right 3×3 block of the SE(3) left Jacobian. `q_matrix_se3` is
+/// `pub(crate)`, so assembling the twist and slicing the block out is the only route to it from
+/// the test crate. The tangent ordering is `[ρ; φ]`, linear part first.
+fn q_block(rho: Vector3D, phi: Vector3D) -> Matrix3D {
+    let xi = Vector::new([rho[0], rho[1], rho[2], phi[0], phi[1], phi[2]]);
+    let jacobian = SE3::left_jacobian(xi);
+    Matrix::from_fn(|row, column| jacobian[(row, column + 3)])
 }
 
 fn assert_entries_close<const R: usize, const C: usize>(
@@ -1121,4 +1134,397 @@ fn two_direction_pairs_f32_round_trip() {
             }
         }
     }
+}
+
+#[test]
+fn jacobian_branches_agree_across_small_angle_thresholds() {
+    let mut rng = StdRng::seed_from_u64(2);
+    let axis = random_unit_vector3(&mut rng);
+
+    let thresholds = [
+        (360.0_f64 * f64::EPSILON).powf(1.0 / 6.0),     // so3 c1
+        (2520.0_f64 * f64::EPSILON).powf(1.0 / 6.0),    // so3 c2, q c2
+        (15_120.0_f64 * f64::EPSILON).powf(1.0 / 6.0),  // inv so3 c3
+        (20_160.0_f64 * f64::EPSILON).powf(1.0 / 8.0),  // q c3
+        (181_440.0_f64 * f64::EPSILON).powf(1.0 / 8.0), // q c5
+    ];
+
+    // Translation part of the twist. `Q` is linear in ρ, so any fixed non-degenerate
+    // value works; it only has to be nonzero for the ρ-carrying terms to show up.
+    let rho = random_unit_vector3(&mut rng);
+
+    // Straddles each seam. δ·θ ≈ 5e-12 of genuine variation, well under TOL, while a
+    // sign-flipped or mispaired series shows up around 1e-4.
+    let delta: f64 = 1e-10;
+    const TOL: f64 = 1e-9;
+
+    let twist = |theta: f64| {
+        let phi = axis.scale(theta);
+        Vector::new([rho[0], rho[1], rho[2], phi[0], phi[1], phi[2]])
+    };
+
+    for t in thresholds {
+        let (lo, hi) = (t * (1.0 - delta), t * (1.0 + delta));
+
+        // c1, c2
+        let d = SO3::left_jacobian(axis.scale(hi)) - SO3::left_jacobian(axis.scale(lo));
+        for r in 0..3 {
+            for c in 0..3 {
+                assert!(
+                    d[(r, c)].abs() < TOL,
+                    "SO3::left_jacobian θ={t:e} row={r} col={c} jump={:e}",
+                    d[(r, c)]
+                );
+            }
+        }
+
+        // inv c3
+        let d =
+            SO3::left_jacobian_inverse(axis.scale(hi)) - SO3::left_jacobian_inverse(axis.scale(lo));
+        for r in 0..3 {
+            for c in 0..3 {
+                assert!(
+                    d[(r, c)].abs() < TOL,
+                    "SO3::left_jacobian_inverse θ={t:e} row={r} col={c} jump={:e}",
+                    d[(r, c)]
+                );
+            }
+        }
+
+        // q c2, c3, c5 in the top-right block, alongside c1/c2 on the diagonal
+        let d = SE3::left_jacobian(twist(hi)) - SE3::left_jacobian(twist(lo));
+        for r in 0..6 {
+            for c in 0..6 {
+                assert!(
+                    d[(r, c)].abs() < TOL,
+                    "SE3::left_jacobian θ={t:e} row={r} col={c} jump={:e}",
+                    d[(r, c)]
+                );
+            }
+        }
+    }
+}
+
+/// Left Jacobian SO3
+/// Threshold for theta_sq 360e^1/3
+/// 0.0065633231517825491692449761238662810296049408728717656257768315763825522720280114 +/- 1e-09
+/// Computed using mpmath at 80 digits.
+#[test]
+fn left_jacobian_so3_c1_threshold() {
+    let t_hi: Vector<3, f64> = Vector::new([
+        0.0018752354719378712,
+        -0.002812853207906807,
+        0.005625706415813614,
+    ]);
+    let matrix_hi = Matrix::new([
+        [
+            0.9999934065615603,
+            -0.0028137222355543025,
+            -0.0014046633049639315,
+        ],
+        [
+            0.002811963985303727,
+            0.9999941391658315,
+            -0.0009402517455188686,
+        ],
+        [
+            0.0014081798054650832,
+            0.0009349769947671412,
+            0.9999980952288952,
+        ],
+    ]);
+
+    let t_lo: Vector<3, f64> = Vector::new([
+        0.0018752349005092999,
+        -0.00281285235076395,
+        0.0056257047015279,
+    ]);
+    let matrix_lo = Matrix::new([
+        [
+            0.9999934065655787,
+            -0.002813721377884897,
+            -0.0014046628774686768,
+        ],
+        [
+            0.0028119631287058795,
+            0.9999941391694033,
+            -0.0009402514582003222,
+        ],
+        [
+            0.0014081793758267116,
+            0.00093497671066327,
+            0.9999980952300561,
+        ],
+    ]);
+
+    assert_entries_close(SO3::left_jacobian(t_hi), matrix_hi, 1e-13);
+
+    assert_entries_close(SO3::left_jacobian(t_lo), matrix_lo, 1e-13);
+}
+
+/// Left Jacobian SO3
+/// Threshold for theta_sq 2,025e^1/3
+/// 0.0090776505658726734101113986465827468133032549568677515285705797365192293938527642 +/- 1e-09
+/// Computed using mpmath at 80 digits.
+#[test]
+fn left_jacobian_so3_c2_threshold() {
+    let t_hi: Vector<3, f64> = Vector::new([
+        0.002593614733106478,
+        -0.0038904220996597173,
+        0.0077808441993194345,
+    ]);
+    let matrix_hi = Matrix::new([
+        [
+            0.9999873872318725,
+            -0.003892077086700015,
+            -0.0019418342873075028,
+        ],
+        [
+            0.0038887136818660114,
+            0.9999887886505533,
+            -0.0013018435686786764,
+        ],
+        [
+            0.0019485610969755102,
+            0.0012917533541766655,
+            0.9999963563114298,
+        ],
+    ]);
+    let t_lo: Vector<3, f64> = Vector::new([
+        0.002593614161677907,
+        -0.00389042124251686,
+        0.00778084248503372,
+    ]);
+    let matrix_lo = Matrix::new([
+        [
+            0.9999873872374302,
+            -0.003892076228833789,
+            -0.0019418338602269565,
+        ],
+        [
+            0.0038887128254818386,
+            0.9999887886554935,
+            -0.0013018432807471972,
+        ],
+        [
+            0.0019485606669308576,
+            0.0012917530706913457,
+            0.9999963563130354,
+        ],
+    ]);
+
+    assert_entries_close(SO3::left_jacobian(t_hi), matrix_hi, 1e-13);
+
+    assert_entries_close(SO3::left_jacobian(t_lo), matrix_lo, 1e-13);
+}
+
+/// Inverse Left Jacobian SO3
+/// Threshold for theta_sq 15,120e^1/3
+/// 0.01223672883207982409248517788125746974275923799237944986778430043546338826342771 +/- 1e-09
+/// Computed using mpmath at 80 digits.
+#[test]
+fn inverse_left_jacobian_so3_c3_threshold() {
+    let t_hi: Vector<3, f64> = Vector::new([
+        0.0034962085234513784,
+        -0.005244312785177068,
+        0.010488625570354135,
+    ]);
+    let matrix_hi = Matrix::new([
+        [
+            0.9999885404644893,
+            0.00524278484710897,
+            0.002625212268724729,
+        ],
+        [
+            -0.005245840723245165,
+            0.9999898137462127,
+            0.001743520447521396,
+        ],
+        [
+            -0.0026191005164523384,
+            -0.0017526880759299824,
+            0.9999966894675191,
+        ],
+    ]);
+    let t_lo: Vector<3, f64> = Vector::new([
+        0.003496207952022807,
+        -0.00524431192803421,
+        0.01048862385606842,
+    ]);
+    let matrix_lo = Matrix::new([
+        [
+            0.9999885404682353,
+            0.005242783990465573,
+            0.002625211839154379,
+        ],
+        [
+            -0.005245839865602847,
+            0.9999898137495424,
+            0.0017435201633054927,
+        ],
+        [
+            -0.002619100088879831,
+            -0.001752687788717314,
+            0.9999966894686013,
+        ],
+    ]);
+
+    assert_entries_close(SO3::left_jacobian_inverse(t_hi), matrix_hi, 1e-13);
+
+    assert_entries_close(SO3::left_jacobian_inverse(t_lo), matrix_lo, 1e-13);
+}
+
+/// Matrix Q SE3
+/// Threshold for theta_sq 2,025e^1/3
+/// 0.0090776505658726734101113986465827468133032549568677515285705797365192293938527642 +/- 1e-09
+/// Computed using mpmath at 80 digits.
+#[test]
+fn q_matrix_se3_c2_threshold() {
+    let t_hi: Vector<3, f64> = Vector::new([
+        0.002593614733106478,
+        -0.0038904220996597173,
+        0.0077808441993194345,
+    ]);
+    let matrix_hi = Matrix::new([
+        [
+            0.0022693965896371064,
+            0.3747777166794713,
+            0.1253215571831013,
+        ],
+        [
+            -0.37520998587434706,
+            0.0015129295149932092,
+            -0.2491889759799066,
+        ],
+        [
+            -0.12467315246392878,
+            0.25080997294809526,
+            -0.00010806884348379557,
+        ],
+    ]);
+    let t_lo: Vector<3, f64> = Vector::new([
+        0.002593614161677907,
+        -0.00389042124251686,
+        0.00778084248503372,
+    ]);
+    let matrix_lo = Matrix::new([
+        [
+            0.002269396089647881,
+            0.37477771672979976,
+            0.12532155711283796,
+        ],
+        [
+            -0.3752099858294374,
+            0.0015129291816680802,
+            -0.24918897615870556,
+        ],
+        [
+            -0.12467315253652327,
+            0.2508099727697594,
+            -0.00010806881967323877,
+        ],
+    ]);
+
+    assert_entries_close(q_block(RHO, t_hi), matrix_hi, 1e-13);
+    assert_entries_close(q_block(RHO, t_lo), matrix_lo, 1e-13);
+}
+
+/// Matrix Q SE3
+/// Threshold for theta_sq 20,160e^1/4
+/// 0.038138740273514832356063423923705899849787335895792428065353256457527059271825147 +/- 1e-09
+/// Computed using mpmath at 80 digits.
+#[test]
+fn q_matrix_se3_c3_threshold() {
+    let t_hi: Vector<3, f64> = Vector::new([
+        0.010896783221004238,
+        -0.016345174831506357,
+        0.032690349663012715,
+    ]);
+    let matrix_hi = Matrix::new([
+        [
+            0.009533476406376695,
+            0.37398340468332747,
+            0.1263154481158103,
+        ],
+        [
+            -0.37579954060639215,
+            0.0063555363829814185,
+            -0.24658593196723697,
+        ],
+        [
+            -0.12359117549845144,
+            0.25339551378644487,
+            -0.0004541485353692165,
+        ],
+    ]);
+    let t_lo: Vector<3, f64> =
+        Vector::new([0.010896782649575667, -0.0163451739743635, 0.032690347948727]);
+    let matrix_lo = Matrix::new([
+        [
+            0.009533475906566877,
+            0.37398340474232844,
+            0.12631544804927197,
+        ],
+        [
+            -0.3757995405701542,
+            0.006355536049792893,
+            -0.24658593214671007,
+        ],
+        [
+            -0.12359117557478233,
+            0.2533955136089179,
+            -0.00045414851154146005,
+        ],
+    ]);
+
+    assert_entries_close(q_block(RHO, t_hi), matrix_hi, 1e-13);
+    assert_entries_close(q_block(RHO, t_lo), matrix_lo, 1e-13);
+}
+
+#[test]
+/// Matrix Q SE3
+/// Threshold for theta_sq 181,440e^1/4
+/// 0.050193404960717505336016995289832652425413397500753684377067048913466264320148131 +/- 1e-09
+/// Computed using mpmath at 80 digits.
+fn q_matrix_se3_c5_threshold() {
+    let t_hi: Vector<3, f64> = Vector::new([
+        0.014340973131633574,
+        -0.021511459697450358,
+        0.043022919394900716,
+    ]);
+    let matrix_hi = Matrix::new([
+        [0.012545595866446456, 0.3736169484295461, 0.1267118476660283],
+        [
+            -0.37600712288784666,
+            0.008363469462850288,
+            -0.24550341123485972,
+        ],
+        [
+            -0.12312642930970909,
+            0.2544644504237632,
+            -0.0005978047293558165,
+        ],
+    ]);
+    let t_lo: Vector<3, f64> =
+        Vector::new([0.014340972560205001, -0.0215114588403075, 0.043022917680615]);
+    let matrix_lo = Matrix::new([
+        [
+            0.012545595366775837,
+            0.3736169484921431,
+            0.12671184760103235,
+        ],
+        [
+            -0.37600712285520405,
+            0.008363469129767754,
+            -0.2455034114145882,
+        ],
+        [
+            -0.1231264293875912,
+            0.25446445024659614,
+            -0.0005978047055147155,
+        ],
+    ]);
+
+    assert_entries_close(q_block(RHO, t_hi), matrix_hi, 1e-13);
+    assert_entries_close(q_block(RHO, t_lo), matrix_lo, 1e-13);
 }

--- a/tools/qa/src/bin/bootstrap_thresholds.rs
+++ b/tools/qa/src/bin/bootstrap_thresholds.rs
@@ -1,0 +1,249 @@
+//! Bootstraps the small-angle threshold for each trig ratio in `spatial::lie`.
+//!
+//! **Theory**
+//! Given a trig function `f(θ)` with `θ` is the angle. There are two types of error
+//! related to the value of `f`:
+//! - Representation error of `θ`: as `f64` only have 52 bits in the mantissa part,
+//!   the absolute error magnitue of 1 ULP is around 2^-52 = 2.22e-16;
+//! - Calculation error: this accumulates as the representation error of input `θ`
+//!   flows through the calculation chain;
+//!
+//! One solution is to use a Taylor series to approximate that represented value, instead of
+//! calculating from `f(θ)`. This does not mitigate the error, but makes the calculation error
+//! less severe compared to closed form trig function,
+//! as Taylor form is much simpler (just polynormial).
+//!
+//! **Method**
+//! Let's call:
+//! - `f(θ)`: the trig function under scrutiny;
+//! - `t(θ)`: the Taylor function of `f`;
+//! - `d(θ)`: the discrepancy between `f` and `t`;
+//! - `E`: the exact floating point value
+//! - `B`: a target value that `θ` approaches;
+//!
+//! We have `d(θ)` the discrepancy between `f` and `t`. This already incorporate errors.
+//!
+//! ```tex
+//! d(θ) = |f(θ) − t(θ)| = |(f − E) − (t − E)| = |Err(f) − Err(t)|
+//! ```
+//! Given a small enough threshold `T` of `θ` at which the calculation error of `f` jumps.
+//! When `θ` decreases towards `T`, the error of both `f` and `g` got smaller, `d(0)` got smaller.
+//! At `T`, the error of `f` jumps, `d(0)` jumps up.
+//!
+//! `Err(f)` is cancellation error, which grows as θ → 0; `Err(t)` is truncation error, which
+//! grows as θ → ∞. `d(0)` has a V shape whose vertex is the crossover.
+//! That locates the threshold without ever needing a high-precision reference:
+//! the two f64 branches are compared against each other.
+//!
+//! Run with `cargo run -p multicalc-qa --bin bootstrap_thresholds`.
+
+use core::f64;
+use std::cmp::Ordering;
+
+use multicalc::Numeric;
+
+trait Scalar: Numeric + std::fmt::LowerExp + std::fmt::Display {}
+impl<T: Numeric + std::fmt::LowerExp + std::fmt::Display> Scalar for T {}
+
+/// One sweep point, just for f32 and f64, no need for monomorphism
+struct Sample<T: Numeric> {
+    theta: T,
+    discrepancy: T,
+}
+
+/// Sweeps θ over `[lo, hi]` and returns the samples, highest θ first.
+fn sweep<T, F, G>(f: F, g: G, lo: T, hi: T, steps_per_octave: u64) -> Vec<Sample<T>>
+where
+    T: Numeric,
+    F: Fn(T) -> T,
+    G: Fn(T) -> T,
+{
+    // theta decreases at diminishing step size
+    let ratio = T::HALF.powf(T::ONE / T::from_u64(steps_per_octave));
+    let mut samples = Vec::new();
+    let mut theta = hi;
+    while theta >= lo {
+        samples.push(Sample {
+            theta,
+            discrepancy: (f(theta) - g(theta)).abs(),
+        });
+        theta *= ratio;
+    }
+    samples
+}
+
+/// The vertex of the V, i.e. the crossover.
+///
+/// |d| is not continous at threashold `T`, so cannot find derivative of |d| at `T`.
+///
+/// |d| jitters by up to a decade between adjacent θ because the cancellation error is rounding
+/// luck, so a raw `argmin` lands in whichever dip happened to be lucky. Taking the max over a
+/// small window first builds an upper envelope, and the envelope's minimum is stable.
+/// Pre-condition: samples are all positive and produced by a convex function
+///
+/// **Method:**
+/// - Scan over +/- window size around index i, search for max discrepancy as upper envelope
+/// - Slide i forwards, continue the process, saving i when new upper < previous upper envelope
+/// - From a certain threshold of samples, discrepancy stops decreasing
+fn crossover<T: Numeric>(samples: &[Sample<T>], window: usize) -> T {
+    // Max discrepancy, i, hi, lo
+    let mut best = (T::INFINITY, T::NAN);
+    for i in 0..samples.len() {
+        let lo = i.saturating_sub(window);
+        let hi = (i + window + 1).min(samples.len());
+        let envelope = samples[lo..hi]
+            .iter()
+            .fold(T::ZERO, |acc, s| acc.max(s.discrepancy));
+        if envelope < best.0 {
+            best = (envelope, samples[i].theta);
+        }
+    }
+    best.1
+}
+
+/// Run bootstrapping and print out result:
+/// - `name`: of the run
+/// - `close_form`: function closed-form
+/// - `samples`: bootstrapping results
+/// - `theta_modeled_name`: theta according to closed form of error model
+/// - `theta_modeled`: value of modeled theta
+fn report<T: Numeric + std::fmt::LowerExp + std::fmt::Display>(
+    name: &str,
+    closed_form: &str,
+    samples: &[Sample<T>],
+    theta_modeled_form: &str,
+    theta_modeled: T,
+) {
+    let theta = crossover(samples, 2);
+    // Error at the changeover: |d| there is the sum of two errors of similar size, so either
+    // branch carries about half of it.
+    // `partial_cmp` is `None` only for NaN; treating that as `Equal` just means it never wins.
+    let Some(threshold) = samples.iter().min_by(|a, b| {
+        (a.theta - theta)
+            .abs()
+            .partial_cmp(&(b.theta - theta).abs())
+            .unwrap_or(Ordering::Equal)
+    }) else {
+        println!("{name:8}  {closed_form:25}  no samples");
+        return;
+    };
+
+    let vs_bootstrap = theta_modeled / theta;
+
+    println!(
+        "{name:8}  {closed_form:25}  bootstrapped ≈ {theta:.3e}    \
+        EPS form = {theta_modeled_form:16}    EPS value ≈ {theta_modeled:.3e}  \
+        {vs_bootstrap:.2} x bootstrapped    \
+        error there ≈ {:.1e}",
+        threshold.discrepancy / T::from_f64(2.0)
+    );
+}
+
+fn run_all<T: Scalar>(label: &str) {
+    let lo = T::from_f64(1.0e-9);
+    let hi = T::PI;
+    const PER_OCTAVE: u64 = 8;
+
+    println!("==={label}=== crossover of |closed form − Taylor|, swept θ ∈ [{lo:.0e}, {hi:.0e}]\n");
+
+    let thalf = T::from_f64(0.5);
+    let t1 = T::from_f64(1.0);
+    let t6 = T::from_f64(6.0);
+    let t8 = T::from_f64(8.0);
+
+    // --- left_jacobian_so3 ------------------------------------------------
+    report(
+        "so3 c1",
+        "(1 − cos θ)/θ²",
+        &sweep(
+            |x| (t1 - x.cos()) / (x * x),
+            |x| thalf - x * x / T::from_f64(24.0),
+            lo,
+            hi,
+            PER_OCTAVE,
+        ),
+        "(360ϵ)^(1/6)",
+        (T::from_f64(360.0) * T::EPSILON).powf(t1 / t6),
+    );
+    report(
+        "so3 c2",
+        "(θ − sin θ)/θ³",
+        &sweep(
+            |x| (x - x.sin()) / (x * x * x),
+            |x| t1 / t6 - x * x / T::from_f64(120.0),
+            lo,
+            hi,
+            PER_OCTAVE,
+        ),
+        "(2520ϵ)^(1/6)",
+        (T::from_f64(2520.0) * T::EPSILON).powf(t1 / t6),
+    );
+
+    // --- inverse_left_jacobian_so3 ----------------------------------------
+    report(
+        "inv c3",
+        "(1 − (θ/2)·cot(θ/2))/θ²",
+        &sweep(
+            |x| {
+                let h = x * thalf;
+                (t1 - h * (h.cos() / h.sin())) / (x * x)
+            },
+            |x| t1 / T::from_f64(12.0) + x * x / T::from_f64(720.0),
+            lo,
+            hi,
+            PER_OCTAVE,
+        ),
+        "(16*945ϵ)^(1/6)",
+        (T::from_f64(16.0) * T::from_f64(945.0) * T::EPSILON).powf(t1 / t6),
+    );
+
+    // --- q_matrix_se3 -----------------------------------------------------
+    report(
+        "q c2",
+        "(θ − sin θ)/θ³",
+        &sweep(
+            |x| (x - x.sin()) / (x * x * x),
+            |x| t1 / t6 - x * x / T::from_f64(120.0),
+            lo,
+            hi,
+            PER_OCTAVE,
+        ),
+        "(2520ϵ)^(1/6)",
+        (T::from_f64(2520.0) * T::EPSILON).powf(t1 / t6),
+    );
+    // NOTE: the series below is NOT the one in the source. The closed form
+    // (1 − θ²/2 − cos θ)/θ⁴ expands to −1/24 + θ²/720, but `q_matrix_se3` codes
+    // +1/24 − θ²/720. Sign flipped. Swap the sign back to see the V fail to form.
+    report(
+        "q c3",
+        "(1 − θ²/2 − cos θ)/θ⁴",
+        &sweep(
+            |x| (t1 - x * x * thalf - x.cos()) / (x * x * x * x),
+            |x| -t1 / T::from_f64(24.0) + x * x / T::from_f64(720.0),
+            lo,
+            hi,
+            PER_OCTAVE,
+        ),
+        "(12*1680ϵ)^(1/8)",
+        (T::from_f64(12.0) * T::from_f64(1690.0) * T::EPSILON).powf(t1 / t8),
+    );
+    report(
+        "q c5",
+        "(θ − sin θ − θ³/6)/θ⁵",
+        &sweep(
+            |x| (x - x.sin() - x * x * x / t6) / (x * x * x * x * x),
+            |x| -t1 / T::from_f64(120.0) + x * x / T::from_f64(5040.0),
+            lo,
+            hi,
+            PER_OCTAVE,
+        ),
+        "(0.5*9!ϵ)^(1/8)",
+        (T::from_f64(181_440.0) * T::EPSILON).powf(t1 / t8),
+    );
+}
+
+fn main() {
+    run_all::<f64>("f64");
+    println!();
+    run_all::<f32>("f32");
+}

--- a/tools/qa/src/bin/spatial_small_angle.py
+++ b/tools/qa/src/bin/spatial_small_angle.py
@@ -1,0 +1,290 @@
+# Generate high-precision reference values for the `spatial::lie` small-angle branches.
+#
+# The Rust code switches each trig ratio to a Taylor series below its own threshold. Neither
+# branch is exact, so the tests need a reference computed well outside f64 to say which one is
+# closer. mpmath at 80 digits provides that.
+#
+# Two tables come out of this, and they test different things:
+#
+# - The *coefficient* tables are the threshold test. A coefficient's error is undiluted there,
+#   so a wrong cutoff or a wrong series term shows up directly.
+# - The *matrix* tables are the assembly test: a coefficient plugged into the wrong term, a
+#   sign slip in c4, a transposed product. They cannot see coefficient precision, because a
+#   1e-13 relative error in c3 moves Q by only 1.5e-19 relative at c3's own threshold -- three
+#   orders below an f64 ulp. Do not try to test thresholds through the matrices.
+#
+# Exactness discipline: every number handed to Rust must round-trip, and both sides must
+# evaluate at *identical bits*. Grid points are chosen as f64, and rotation vectors are built
+# at high precision then rounded to f64 once before being fed back in. The comparison then
+# measures the branch, not a mismatched input.
+#
+# Run with `python3 tools/qa/src/bin/spatial_small_angle.py`.
+import sys
+
+from mpmath import eye, mp, mpf, sin, cos, matrix, fdot, sqrt
+
+# 80 digits. c5's numerator `theta - sin(theta) - theta^3/6` cancels to a relative size of
+# theta^4/120, so at theta = 1e-9 it loses 38 digits outright. 50 would leave too little.
+mp.dps = 80
+
+HALF = mpf(1) / 2
+EPS_F64 = mpf(2) ** -52  # f64 machine epsilon, as an exact power of two
+EPS_F32 = mpf(2) ** -32  # f32 machine epsilon
+
+
+# --- coefficients -----------------------------------------------------------------------
+#
+# Each takes theta^2, matching the Rust functions, which branch on `theta_sq` to avoid a sqrt
+# they may not need. Every one is even in theta, hence expressible in theta^2 alone.
+
+def c1_so3(theta_sq):
+    """`(1 - cos t)/t^2`, the [phi]x coefficient of the SO(3) left Jacobian. Limit 1/2."""
+    if theta_sq == 0:
+        return HALF
+    return (1 - cos(sqrt(theta_sq))) / theta_sq
+
+
+def c2_so3(theta_sq):
+    """`(t - sin t)/t^3`, the [phi]x^2 coefficient of the SO(3) left Jacobian. Limit 1/6.
+
+    Also the c2 of the Barfoot Q block -- same ratio, same threshold.
+    """
+    if theta_sq == 0:
+        return mpf(1) / 6
+    theta = sqrt(theta_sq)
+    return (theta - sin(theta)) / (theta_sq * theta)
+
+
+def c3_inverse_so3(theta_sq):
+    """`(1 - (t/2)*cot(t/2))/t^2`, the [phi]x^2 coefficient of the inverse. Limit 1/12.
+
+    Finite on (0, pi], so only theta = 0 needs the limit.
+    """
+    if theta_sq == 0:
+        return mpf(1) / 12
+    half = sqrt(theta_sq) * HALF
+    return (1 - half * (cos(half) / sin(half))) / theta_sq
+
+
+def c3_q(theta_sq):
+    """`(1 - t^2/2 - cos t)/t^4`, from the Barfoot Q block. Limit -1/24.
+
+    The numerator cancels to a relative size of t^4/24, which is why this one needs a much
+    later cutoff than the c1/c2 family.
+    """
+    if theta_sq == 0:
+        return -mpf(1) / 24
+    return (1 - theta_sq * HALF - cos(sqrt(theta_sq))) / (theta_sq * theta_sq)
+
+
+def c5_q(theta_sq):
+    """`(t - sin t - t^3/6)/t^5`, from the Barfoot Q block. Limit -1/120.
+
+    Worst cancellation of the five: the numerator survives at a relative t^4/120.
+    """
+    if theta_sq == 0:
+        return -mpf(1) / 120
+    theta = sqrt(theta_sq)
+    theta3 = theta_sq * theta
+    return (theta - sin(theta) - theta3 / 6) / (theta_sq * theta3)
+
+
+# --- matrices ---------------------------------------------------------------------------
+
+def skew3(v):
+    """The 3x3 skew-symmetric matrix S(v), so that S(v) * p = cross(v, p).
+
+    v: mpmath column vector, e.g. `matrix([1, 2, 3])`.
+    """
+    return matrix([
+        [0, -v[2], v[1]],
+        [v[2], 0, -v[0]],
+        [-v[1], v[0], 0]
+        ])
+
+
+def left_jacobian_so3(v):
+    """The SO(3) left Jacobian `J = I + c1*S + c2*S^2`.
+
+    v: rotation vector phi = theta * axis, as an mpmath column vector.
+    """
+    theta_sq = fdot(v, v)
+    s = skew3(v)
+    return eye(3) + s * c1_so3(theta_sq) + (s * s) * c2_so3(theta_sq)
+
+
+def inverse_left_jacobian_so3(v):
+    """The inverse SO(3) left Jacobian `J^-1 = I - S/2 + c3*S^2`.
+
+    v: rotation vector phi = theta * axis, as an mpmath column vector.
+    """
+    theta_sq = fdot(v, v)
+    s = skew3(v)
+    return eye(3) - s * HALF + (s * s) * c3_inverse_so3(theta_sq)
+
+
+def q_matrix_se3(rho, phi):
+    """The Barfoot SE(3) `Q(rho, phi)` block (Eq. 7.86), the top-right of the 6x6 Jacobian.
+
+    rho: translation part of the twist, as an mpmath column vector.
+    phi: rotation vector theta * axis, as an mpmath column vector.
+    """
+    theta_sq = fdot(phi, phi)
+    p = skew3(rho)
+    ph = skew3(phi)
+
+    c2 = c2_so3(theta_sq)
+    c3 = c3_q(theta_sq)
+    c5 = c5_q(theta_sq)
+    c4 = (c3 - 3 * c5) * HALF
+
+    phph = ph * p * ph                                  # Phi P Phi, reused in two terms
+    t2 = ph * p + p * ph + phph                         # PhiP + PPhi + PhiPPhi
+    t3 = ph * ph * p + p * ph * ph - phph * 3           # Phi^2 P + P Phi^2 - 3 PhiPPhi
+    t4 = ph * p * ph * ph + ph * ph * p * ph            # PhiPPhi^2 + Phi^2 PPhi
+    return p * HALF + t2 * c2 - t3 * c3 - t4 * c4
+
+
+# --- inputs -----------------------------------------------------------------------------
+#
+# AXIS is [2, -3, 6]/7. That triple is a Pythagorean quadruple (4 + 9 + 36 = 49), so the axis
+# is a *rational* unit vector: |AXIS| is exactly 1 in exact arithmetic, which makes
+# |AXIS * theta| exactly theta. No component is zero and no two share a magnitude, so every
+# entry of S and S^2 is populated and no term drops out by symmetry.
+AXIS = matrix([mpf(2) / 7, mpf(-3) / 7, mpf(6) / 7])
+
+# RHO is [2, 1, -3]/4. Dyadic, so all three components are exact in f64 as well as in mpmath.
+# It is neither parallel nor perpendicular to AXIS (cross = [3, 18, 8], dot = -17/28), so the
+# Q terms stay generic. Q is linear in rho, so only its scale and orientation matter.
+RHO = matrix([mpf(1) / 2, mpf(1) / 4, mpf(-3) / 4])
+
+
+def phi_at(theta):
+    """Rotation vector at angle `theta`, rounded to f64 componentwise.
+
+    Rounding here is the whole point: the returned values are what the Rust literals will
+    hold, so the reference is evaluated at the same bits Rust sees.
+    """
+    t = mpf(theta)
+    return matrix([mpf(float(AXIS[i] * t)) for i in range(3)])
+
+def thresholds_sq():
+    """The five f64 branch cutoffs in theta^2, mirroring `spatial::small_angle_*_sq`."""
+    e = EPS_F64
+    return {
+        "so3 c1": ("360e^1/3", (360 * e) ** (mpf(1) / 3)),
+        "so3 c2": ("2,025e^1/3", (2520 * e) ** (mpf(1) / 3)),
+        "inv c3": ("15,120e^1/3", (15120 * e) ** (mpf(1) / 3)),
+        "q c2": ("2,025e^1/3", (2520 * e) ** (mpf(1) / 3)),
+        "q c3": ("20,160e^1/4", (20160 * e) ** (mpf(1) / 4)),
+        "q c5": ("181,440e^1/4", (181440 * e) ** (mpf(1) / 4)),
+    }
+
+# --- emitters ---------------------------------------------------------------------------
+
+def lit(x):
+    """Shortest f64 literal that round-trips. Rust's parser is correctly rounded, so it
+    recovers the identical bits."""
+    return repr(float(x))
+
+def emit_matrix_table(name, threshold, dst, fn, rho = None):
+    """Emit `(phi, matrix)` pairs.
+    """
+    (form, threshold) = threshold
+    theta = sqrt(threshold)
+    print("=======================================================================")
+    print("==============Hard-coded high-precision value for testing==============")
+    print(f"/// {name}")
+    print(f"/// Threshold for theta_sq {form}")
+    print(f"/// {theta} +/- {dst}")
+    print(f"/// Computed using mpmath at 80 digits.")
+
+    suffixes = ["hi", "lo"]
+    signs = [1, -1]
+
+    for sign, suffix in zip(signs, suffixes):
+        phi = phi_at(theta + sign*dst)
+        if rho is None:
+            m = fn(phi)
+        else:
+            m = fn(rho, phi)
+
+        print(f"let t_{suffix}: Vector<3, f64> = Vector::new([{', '.join([lit(phi[i]) for i in range(3)])}]);")
+        print(f"let matrix_{suffix} = Matrix::new([")
+        for r in range(3):
+            entries = ", ".join(lit(m[r, c]) for c in range(3))
+            print(f"    [{entries}],")
+        print("]);")
+        # key = ", ".join(lit(phi[i]) for i in range(3))
+        # entries = ", ".join(lit(m[r, c]) for r in range(3) for c in range(3))
+        # print(f"const theta_{} = {lit(theta)}")
+        # print(f"    ([{key}], [{entries}]),")
+        # print("];\n")
+
+    print("")
+
+
+BANNER = """// @generated by tools/qa/src/bin/spatial_small_angle.py -- do not edit by hand.
+//
+// High-precision reference values for the small-angle branches in `spatial::lie`, computed
+// with mpmath at 80 decimal digits and rounded to f64 exactly once. Regenerate with:
+//
+//     python3 tools/qa/src/bin/spatial_small_angle.py matrices > <this file>
+"""
+
+def emit_matrices():
+    # The assembly test. Blind to coefficient precision, see the header.
+    print(f"// axis = {[lit(AXIS[i]) for i in range(3)]}")
+    print(f"// rho  = {[lit(RHO[i]) for i in range(3)]}\n")
+    # print(f"pub const RHO_REF: [f64; 3] = [{', '.join(lit(RHO[i]) for i in range(3))}];\n")
+
+    thresholds = thresholds_sq()
+
+    emit_matrix_table(
+        "Left Jacobian SO3",
+        thresholds["so3 c1"],
+        1e-9,
+        left_jacobian_so3)
+
+    emit_matrix_table(
+        "Left Jacobian SO3",
+        thresholds["so3 c2"],
+        1e-9,
+        left_jacobian_so3)
+
+    emit_matrix_table(
+        "Inverse Left Jacobian SO3",
+        thresholds["inv c3"],
+        1e-9,
+        inverse_left_jacobian_so3)
+
+    emit_matrix_table(
+        "Matrix Q SE3",
+        thresholds["q c2"],
+        1e-9,
+        q_matrix_se3,
+        RHO)
+
+    emit_matrix_table(
+        "Matrix Q SE3",
+        thresholds["q c3"],
+        1e-9,
+        q_matrix_se3,
+        RHO)
+
+    emit_matrix_table(
+        "Matrix Q SE3",
+        thresholds["q c5"],
+        1e-9,
+        q_matrix_se3,
+        RHO)
+
+def main():
+    section = sys.argv[1] if len(sys.argv) > 1 else "all"
+    print(BANNER)
+    if section in ("all", "matrices"):
+        emit_matrices()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What & why
Issue #230.

Different trig functions have different error models, so different thresholds for small angles.

What have been done:
- Establish error model for each trig functions;
- Add a bootstrap run at `tools/qa/src/bin`, sweeping angle from 1e-9 to PI, compute error and compare with threshold from error models;
- Add different small-angle thresholds at `crates/multicalc/src/spatial/mods.rs`, represented on EPSILON-base;
- Split small-angle switch at  `crates/multicalc/src/spatial/lie/mod.rs` for each small-angle thresholds;



## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
