### PR TITLE
Ignore unused LQR certificate in embedded-smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of panicking. (#204)
 - `zoh` and `van_loan` now reject negative or non-finite timesteps before constructing their
   augmented matrices. (#203)
+- Silence `unused_must_use` in `embedded-smoke`'s LQR identity check by discading the Lyapunov
+  certificate after `expect`. rtmongold (#272)
 
 ### Changed
 

--- a/tools/embedded-smoke/src/checks.rs
+++ b/tools/embedded-smoke/src/checks.rs
@@ -582,7 +582,7 @@ pub fn lqr_identity() -> f64 {
         Matrix::<1, 1>::identity(),
     )
     .expect("lqr design");
-    controller.certify_stability().expect("lqr certificate");
+    let _ = controller.certify_stability().expect("lqr certificate");
 
     let mut state = Vector::new([1.0, 0.0]);
     for _ in 0..400 {


### PR DESCRIPTION
certify_stability returns a #[must_use] Matrix. The smoke check only needs Ok/Err; bind with `let _ =` so release builds no longer emit unused_must_use.

Ref #258 

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
