### PR TITLE
Install QEMU per bare-metal target in CI

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -90,11 +90,13 @@ jobs:
       # Cache the QEMU apt package + its dependencies instead of re-downloading it
       # on every run.
       - name: Install QEMU (cached)
+        if: startsWith(matrix.target, 'thumb')
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: qemu-system-arm
           version: 1.0
       - name: Install QEMU (RISC-V)
+        if: startsWith(matrix.target, 'riscv')
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-system-misc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of panicking. (#204)
 - `zoh` and `van_loan` now reject negative or non-finite timesteps before constructing their
   augmented matrices. (#203)
+- Install QEMU per bare-metal matrix target so thumb legs do not apt-upgrade shared modules under
+  a cached `qemu-system-arm` after Ubuntu QEMU bumps. rtmongold (#273)
 
 ### Changed
 


### PR DESCRIPTION
Every bare-metal leg was caching qemu-system-arm and then apt-installing qemu-system-misc, which upgrades shared modules under a stale ARM binary and aborts on build mismatch after Ubuntu QEMU bumps.

Gate installs by matrix.target: thumb* keeps the arm apt cache; riscv* keeps live apt for qemu-system-misc. Caching both together already failed in #140 (riscv32 missing from PATH).

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
