### PR TITLE
fix(polynomial): validate range and tolerance in real_roots_in

### DIFF
--- a/crates/multicalc/src/error.rs
+++ b/crates/multicalc/src/error.rs
@@ -319,6 +319,10 @@ pub enum PolynomialError {
     TooFewSamples,
     /// A piece covers zero or a negative amount of the parameter.
     SpanNotPositive,
+    /// The bisection tolerance was zero or negative.
+    ToleranceNotPositive,
+    /// The range was given with its lower bound above its upper bound.
+    RangeReversed,
     /// Root isolation ran out of steps before separating every root.
     DidNotConverge {
         /// How many halving steps were taken.
@@ -805,6 +809,12 @@ impl core::fmt::Display for PolynomialError {
             }
             PolynomialError::TooFewSamples => f.write_str("fewer samples than coefficients to fit"),
             PolynomialError::SpanNotPositive => f.write_str("piece span was zero or negative"),
+            PolynomialError::ToleranceNotPositive => {
+                f.write_str("bisection tolerance was zero or negative")
+            }
+            PolynomialError::RangeReversed => {
+                f.write_str("range lower bound was above its upper bound")
+            }
             PolynomialError::DidNotConverge { steps } => {
                 write!(f, "root isolation stopped after {steps} steps")
             }

--- a/crates/multicalc/src/polynomial/roots.rs
+++ b/crates/multicalc/src/polynomial/roots.rs
@@ -522,6 +522,15 @@ impl<const COEFFICIENT_COUNT: usize, T: Numeric> Polynomial<COEFFICIENT_COUNT, T
         tolerance: T,
         maximum_bisections: usize,
     ) -> Result<RealRoots<COEFFICIENT_COUNT, T>, PolynomialError> {
+        if !lower.is_finite() || !upper.is_finite() || !tolerance.is_finite() {
+            return Err(PolynomialError::NonFinite);
+        }
+        if tolerance <= T::ZERO {
+            return Err(PolynomialError::ToleranceNotPositive);
+        }
+        if lower > upper {
+            return Err(PolynomialError::RangeReversed);
+        }
         let (chain, length) = self.root_counting_chain()?;
         // How many roots sit between two points.
         let count_between = |from: T, to: T| {

--- a/crates/multicalc/tests/suite/polynomial/roots.rs
+++ b/crates/multicalc/tests/suite/polynomial/roots.rs
@@ -273,3 +273,42 @@ fn real_roots_in_reports_running_out_of_steps() {
         Err(PolynomialError::DidNotConverge { .. })
     ));
 }
+
+#[test]
+fn real_roots_in_rejects_bad_arguments() {
+    let p: Polynomial<5> = Polynomial::new(QUARTIC_FOUR_ROOTS);
+    let bound = p.cauchy_root_bound().unwrap();
+
+    // A non-finite range or tolerance is reported as such.
+    assert_eq!(
+        p.real_roots_in(-bound, bound, f64::NAN, 1000).err(),
+        Some(PolynomialError::NonFinite)
+    );
+    assert_eq!(
+        p.real_roots_in(f64::INFINITY, bound, 1e-11, 1000).err(),
+        Some(PolynomialError::NonFinite)
+    );
+
+    // A zero or negative tolerance is rejected up front instead of yielding a bogus root or
+    // running the budget out.
+    assert_eq!(
+        p.real_roots_in(-bound, bound, 0.0, 1000).err(),
+        Some(PolynomialError::ToleranceNotPositive)
+    );
+    assert_eq!(
+        p.real_roots_in(-bound, bound, -1e-11, 1000).err(),
+        Some(PolynomialError::ToleranceNotPositive)
+    );
+
+    // A backwards range is an error rather than a silently empty answer.
+    assert_eq!(
+        p.real_roots_in(bound, -bound, 1e-11, 1000).err(),
+        Some(PolynomialError::RangeReversed)
+    );
+
+    // A well-formed call is unaffected.
+    assert_eq!(
+        p.real_roots_in(-bound, bound, 1e-11, 1000).unwrap().len(),
+        4
+    );
+}


### PR DESCRIPTION
## What

`Polynomial::real_roots_in` validated none of its `lower`, `upper`, and `tolerance` arguments (only the polynomial's own coefficients were checked, via `root_counting_chain`). This meant:

- A **NaN tolerance** made the `high - low > tolerance` loop guard false on the first test, so the untouched bracket's midpoint was pushed as a root and returned inside `Ok` — silent garbage.
- A **zero or negative tolerance** ran the bisection budget out and returned `DidNotConverge` (loud, but the wrong reason).
- **`lower > upper`** returned an empty set rather than signalling that the range is backwards.

## Change

Reject bad arguments up front, alongside the finiteness check the chain already does:

- non-finite `lower`, `upper`, or `tolerance` → `PolynomialError::NonFinite`
- non-positive `tolerance` → new `PolynomialError::ToleranceNotPositive`
- `lower > upper` → new `PolynomialError::RangeReversed`

`lower == upper` remains a legitimately empty range (returns `Ok` with no roots); only a strictly reversed range errors.

## Tests

Added `real_roots_in_rejects_bad_arguments` covering each rejected argument and confirming a well-formed call is unaffected. Run with `cargo test -p multicalc`.

Closes #297