### PR TITLE
Record the sections a model file was loaded without

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A record of what a model file was loaded without.** `RigidBodyModel::ignored` names the
+  top-level sections `multicalc-mjcf` read nothing out of — tendons, actuators, sensors, contact
+  pairs and the rest — sorted and without repeats, so a caller can tell a model that loaded whole
+  from one that loaded minus the half that mattered. Anything that could change a mass is still
+  refused outright rather than recorded. @Thiago316316 (#305)
+
 ### Fixed
 
 - Particle filters floor an underflowed zero weight at the scalar's smallest positive value before

--- a/crates/multicalc-mjcf/src/body.rs
+++ b/crates/multicalc-mjcf/src/body.rs
@@ -17,12 +17,17 @@ use crate::geometry::{GeomMass, read_geom};
 /// MuJoCo reads a joint that names no type as a hinge.
 const ASSUMED_JOINT: &str = "hinge";
 
+/// The top-level sections this loader takes something from. Every other section a file carries is
+/// passed over, and named in the record rather than going quietly.
+const READ_SECTIONS: [&str; 3] = ["compiler", "default", "worldbody"];
+
 /// Everything one model file says about its body.
 pub(crate) struct BodyModel {
     pub name: String,
     pub pose: SE3<f64>,
     pub has_free_joint: bool,
     pub inertia: SpatialInertia<f64>,
+    pub ignored: Vec<String>,
 }
 
 /// Reads the single body a file describes, refusing anything outside that by name.
@@ -79,7 +84,24 @@ pub(crate) fn read(document: &Document) -> Result<BodyModel, MjcfError> {
         pose,
         has_free_joint,
         inertia,
+        ignored: ignored_sections(root),
     })
+}
+
+/// The sections a file carries that this loader reads nothing out of, named once each and in a
+/// settled order so a table generated from them does not shuffle between runs.
+#[must_use]
+fn ignored_sections(root: Node) -> Vec<String> {
+    let mut names: Vec<String> = root
+        .children()
+        .filter(Node::is_element)
+        .map(|section| section.tag_name().name())
+        .filter(|name| !READ_SECTIONS.contains(name))
+        .map(str::to_owned)
+        .collect();
+    names.sort();
+    names.dedup();
+    names
 }
 
 /// Checks that the body hangs off the world by a free joint and nothing else.

--- a/crates/multicalc-mjcf/src/lib.rs
+++ b/crates/multicalc-mjcf/src/lib.rs
@@ -7,7 +7,9 @@
 //!
 //! Anything outside that — chains of joints, meshes as a source of mass, files that pull in other
 //! files — is refused by name rather than quietly ignored, so a model can never load with the wrong
-//! mass.
+//! mass. What a file carries beyond that and this loader has no use for — tendons, actuators,
+//! sensors and the like — is passed over, and named in [`RigidBodyModel::ignored`] so a caller can
+//! see what its model was loaded without.
 //!
 //! ```no_run
 //! use std::path::Path;
@@ -36,6 +38,7 @@ pub struct RigidBodyModel {
     pose: SE3<f64>,
     has_free_joint: bool,
     inertia: SpatialInertia<f64>,
+    ignored: Vec<String>,
 }
 
 impl RigidBodyModel {
@@ -66,6 +69,32 @@ impl RigidBodyModel {
     pub fn inertia(&self) -> SpatialInertia<f64> {
         self.inertia
     }
+
+    /// The sections of the file this loader read nothing out of, named once each and in a settled
+    /// order. Empty where the whole file was read.
+    ///
+    /// A model can only carry these where they change nothing this loader represents — anything
+    /// that would change the mass is refused outright — so this says what a model was loaded
+    /// without, not what went wrong.
+    ///
+    /// ```
+    /// let xml = r#"<mujoco>
+    ///                <worldbody>
+    ///                  <body><freejoint/><inertial mass="1" diaginertia="1 1 1"/></body>
+    ///                </worldbody>
+    ///                <actuator><motor name="thrust" gear="0 0 1 0 0 0"/></actuator>
+    ///              </mujoco>"#;
+    ///
+    /// let model = multicalc_mjcf::load_str(xml)?;
+    /// assert_eq!(model.inertia().mass(), 1.0);
+    /// assert_eq!(model.ignored(), ["actuator".to_owned()]);
+    /// # Ok::<(), multicalc_mjcf::MjcfError>(())
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn ignored(&self) -> &[String] {
+        &self.ignored
+    }
 }
 
 /// Reads a model from a file.
@@ -83,5 +112,6 @@ pub fn load_str(xml: &str) -> Result<RigidBodyModel, MjcfError> {
         pose: body.pose,
         has_free_joint: body.has_free_joint,
         inertia: body.inertia,
+        ignored: body.ignored,
     })
 }

--- a/crates/multicalc-mjcf/tests/loading.rs
+++ b/crates/multicalc-mjcf/tests/loading.rs
@@ -28,6 +28,12 @@ fn diagonal(body: &RigidBodyModel) -> [f64; 3] {
     [inertia[(0, 0)], inertia[(1, 1)], inertia[(2, 2)]]
 }
 
+/// The parts of the file the loader did not read, as plain text for comparing against.
+#[must_use]
+fn ignored(body: &RigidBodyModel) -> Vec<&str> {
+    body.ignored().iter().map(String::as_str).collect()
+}
+
 fn assert_close(actual: f64, expected: f64, label: &str) {
     assert!(
         (actual - expected).abs() < 1e-12,
@@ -289,4 +295,36 @@ fn inherits_settings_through_nested_default_blocks() {
 
     assert_eq!(body.inertia().mass(), 5.0);
     assert_eq!(diagonal(&body), [2.0, 2.0, 2.0]);
+}
+
+#[test]
+fn records_the_parts_of_a_file_it_does_not_read() {
+    // Neither section changes a mass, so both are passed over — but the model that comes back says
+    // so rather than leaving the caller to guess how much of the file was used.
+    let body = load_str(
+        r#"<mujoco>
+             <worldbody>
+               <body name="drone">
+                 <freejoint/>
+                 <inertial mass="1" diaginertia="1 1 1"/>
+               </body>
+             </worldbody>
+             <tendon>
+               <spatial name="cable"/>
+             </tendon>
+             <actuator>
+               <motor name="thrust" gear="0 0 1 0 0 0"/>
+             </actuator>
+           </mujoco>"#,
+    )
+    .unwrap();
+
+    assert_eq!(body.name(), "drone");
+    assert_eq!(ignored(&body), ["actuator", "tendon"]);
+}
+
+#[test]
+fn records_nothing_for_a_file_it_reads_whole() {
+    let body = load(r#"<body><freejoint/><inertial mass="1" diaginertia="1 1 1"/></body>"#);
+    assert!(ignored(&body).is_empty(), "{:?}", ignored(&body));
 }


### PR DESCRIPTION
Closes #305. The loader refuses what it cannot represent, but everything merely ignorable — tendons, equality constraints, actuators, sensors, contact pairs — was dropped in silence, so a caller could not tell a model that loaded whole from one that loaded minus the half that mattered; this collects the names of the top-level sections nothing is read out of, sorted and without repeats, and exposes them as RigidBodyModel::ignored, giving the README table of what each model skipped a source to be generated from. Anything that could change a mass is still refused outright rather than recorded, so the record says what a model was loaded without, not what went wrong.

im new to this repo, anything you want to change or correct im all ears.

Checklist

- [x] cargo test + cargo clippy --all-targets clean locally
- [x] New public APIs have a doc example
- [x] No unwrap/expect/panic on library paths (typed errors instead)