### PR TITLE
Fix out-of-range component indices in partial line integrals

### DIFF
--- a/crates/multicalc/src/vector_field/line_integral.rs
+++ b/crates/multicalc/src/vector_field/line_integral.rs
@@ -21,6 +21,9 @@ fn get_partial<T: Numeric, const N: usize>(
     total_iterations: u64,
     idx: usize,
 ) -> Result<T, IntegrateError> {
+    if idx >= N {
+        return Err(IntegrateError::IndexOutOfRange);
+    }
     if total_iterations == 0 {
         return Err(IntegrateError::IterationsZero);
     }
@@ -130,9 +133,9 @@ pub fn line_integral_2d_custom<T: Numeric>(
 /// [`line_integral_2d_custom`] and the flux integral.
 ///
 /// # Errors
-/// [`IntegrateError::IterationsZero`] if `total_iterations` is zero, or
+/// [`IntegrateError::IterationsZero`] if `total_iterations` is zero,
 /// [`IntegrateError::LimitsIllDefined`] if the lower limit is not strictly less than the
-/// upper limit.
+/// upper limit, or [`IntegrateError::IndexOutOfRange`] if `idx >= 2`.
 pub fn line_integral_partial_2d<T: Numeric>(
     vector_field: &[&dyn Fn(&[T; 2]) -> T; 2],
     transformations: &[&dyn Fn(T) -> T; 2],
@@ -205,9 +208,9 @@ pub fn line_integral_3d_custom<T: Numeric>(
 /// [`line_integral_3d_custom`] and the flux integral.
 ///
 /// # Errors
-/// [`IntegrateError::IterationsZero`] if `total_iterations` is zero, or
+/// [`IntegrateError::IterationsZero`] if `total_iterations` is zero,
 /// [`IntegrateError::LimitsIllDefined`] if the lower limit is not strictly less than the
-/// upper limit.
+/// upper limit, or [`IntegrateError::IndexOutOfRange`] if `idx >= 3`.
 pub fn line_integral_partial_3d<T: Numeric>(
     vector_field: &[&dyn Fn(&[T; 3]) -> T; 3],
     transformations: &[&dyn Fn(T) -> T; 3],

--- a/crates/multicalc/tests/suite/line_integral_index_validation.rs
+++ b/crates/multicalc/tests/suite/line_integral_index_validation.rs
@@ -1,0 +1,75 @@
+use multicalc::error::IntegrateError;
+use multicalc::vector_field::{line_integral_partial_2d, line_integral_partial_3d};
+
+#[test]
+fn line_integral_partial_2d_validates_component_index() {
+    let vector_field: [&dyn Fn(&[f64; 2]) -> f64; 2] = [
+        &(|point: &[f64; 2]| point[0]),
+        &(|point: &[f64; 2]| point[1]),
+    ];
+    let transformations: [&dyn Fn(f64) -> f64; 2] = [&(|t: f64| t), &(|t: f64| t * t)];
+    let limits = [0.0, 1.0];
+
+    for idx in 0..=1 {
+        assert!(line_integral_partial_2d(
+            &vector_field,
+            &transformations,
+            &limits,
+            10,
+            idx,
+        )
+        .is_ok());
+    }
+
+    for idx in [2, 3, usize::MAX] {
+        assert_eq!(
+            line_integral_partial_2d(
+                &vector_field,
+                &transformations,
+                &limits,
+                10,
+                idx,
+            ),
+            Err(IntegrateError::IndexOutOfRange)
+        );
+    }
+}
+
+#[test]
+fn line_integral_partial_3d_validates_component_index() {
+    let vector_field: [&dyn Fn(&[f64; 3]) -> f64; 3] = [
+        &(|point: &[f64; 3]| point[0]),
+        &(|point: &[f64; 3]| point[1]),
+        &(|point: &[f64; 3]| point[2]),
+    ];
+    let transformations: [&dyn Fn(f64) -> f64; 3] = [
+        &(|t: f64| t),
+        &(|t: f64| t * t),
+        &(|t: f64| t * t * t),
+    ];
+    let limits = [0.0, 1.0];
+
+    for idx in 0..=2 {
+        assert!(line_integral_partial_3d(
+            &vector_field,
+            &transformations,
+            &limits,
+            10,
+            idx,
+        )
+        .is_ok());
+    }
+
+    for idx in [3, 4, usize::MAX] {
+        assert_eq!(
+            line_integral_partial_3d(
+                &vector_field,
+                &transformations,
+                &limits,
+                10,
+                idx,
+            ),
+            Err(IntegrateError::IndexOutOfRange)
+        );
+    }
+}

--- a/crates/multicalc/tests/suite/main.rs
+++ b/crates/multicalc/tests/suite/main.rs
@@ -6,6 +6,7 @@ mod dynamics;
 mod estimation;
 mod gaussian_tables;
 mod kinematics;
+mod line_integral_index_validation;
 mod linear_algebra;
 mod mapping;
 mod motion;


### PR DESCRIPTION
## What & why

<!-- one paragraph; link the issue -->

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
