### PR TITLE
fix(IterativeConfig): Align iteration count with composite rule weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Particle filters floor an underflowed zero weight at the scalar's smallest positive value before
   the next update, allowing that particle to recover when later measurements favor it.
 
+- **Iterative Config Total Iterations** Auto-align iteration counts to the composite rules below
+  12k. 
+
 ## [0.10.0] - 2026-08-09
 
 A feature release adding signal processing, polynomials and minimum-snap trajectories, LQR and

--- a/crates/multicalc/src/numerical_integration/iterative_integration.rs
+++ b/crates/multicalc/src/numerical_integration/iterative_integration.rs
@@ -34,8 +34,22 @@ impl Default for IterativeConfig {
 
 impl IterativeConfig {
     /// Builds a config with an explicit iteration count and rule.
+    ///
+    /// For counts up to 12,000, `total_iterations` is automatically rounded up
+    /// to the nearest valid step multiple required by the chosen integration rule
+    /// (e.g., multiples of 4 for Boole's rule, 3 for Simpson's 3/8 rule).
+    /// Above 12,000, the count is left untouched.
     #[must_use]
     pub fn from_parameters(total_iterations: u64, integration_method: IterativeMethod) -> Self {
+        let total_iterations = if total_iterations <= 12000 {
+            match integration_method {
+                IterativeMethod::Booles => total_iterations.next_multiple_of(4),
+                IterativeMethod::Simpsons => total_iterations.next_multiple_of(3),
+                IterativeMethod::Trapezoidal => total_iterations,
+            }
+        } else {
+            total_iterations
+        };
         IterativeConfig {
             total_iterations,
             integration_method,

--- a/crates/multicalc/tests/suite/numerical_integration.rs
+++ b/crates/multicalc/tests/suite/numerical_integration.rs
@@ -6,6 +6,28 @@ use multicalc::numerical_integration::*;
 use proptest::prelude::*;
 
 #[test]
+fn booles_round_up_total_iterations() {
+    let config_120 = IterativeConfig::from_parameters(120, IterativeMethod::Booles);
+    let config_121 = IterativeConfig::from_parameters(121, IterativeMethod::Booles);
+    let config_122 = IterativeConfig::from_parameters(122, IterativeMethod::Booles);
+    let config_123 = IterativeConfig::from_parameters(123, IterativeMethod::Booles);
+    assert!(config_120.total_iterations == 120);
+    assert!(config_121.total_iterations == 124);
+    assert!(config_122.total_iterations == 124);
+    assert!(config_123.total_iterations == 124);
+}
+
+#[test]
+fn simpson_round_up_total_iterations() {
+    let config_120 = IterativeConfig::from_parameters(120, IterativeMethod::Simpsons);
+    let config_121 = IterativeConfig::from_parameters(121, IterativeMethod::Simpsons);
+    let config_122 = IterativeConfig::from_parameters(122, IterativeMethod::Simpsons);
+    assert!(config_120.total_iterations == 120);
+    assert!(config_121.total_iterations == 123);
+    assert!(config_122.total_iterations == 123);
+}
+
+#[test]
 fn booles_rule_integrates_a_line_to_its_closed_form() {
     // closed form of 2x is x*x
     let line = |x: f64| -> f64 { 2.0 * x };


### PR DESCRIPTION
## What & why

It ensures that `from_parameters` automatically aligns `total_iterations` up to the nearest valid step multiple required by the selected composite integration rule (e.g. multiples of 4 for Boole's rule, 3 for Simpson's 3/8 rule) when `total_iterations <= 12,000`.

Counts greater than 12,000 are left untouched.

<!-- one paragraph; link the issue -->

Be reminded that `total_iterations` remains a public field. If a user modifies `config.total_iterations` directly after construction, no alignment check or rounding will be performed. Alignment is only guaranteed when using `from_parameters` function.

It is for issue #155 

## Checklist
- [X] `cargo test` + `cargo clippy --all-targets` clean locally
- [ ] New public APIs have a doc example (No new public API)
- [X] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
