### PR TITLE
feat(root_finding): add Brent bracketed scalar root finder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Brent root finding.** `Brent` combines bracketed convergence with secant and inverse
+  quadratic interpolation steps for scalar equations. @snowyukitty (#323)
+
 - **Jointed robots from MuJoCo model files.** `multicalc-mjcf` reads the whole body tree a model
   file describes — hinge and sliding joints with their axes, turning points and travel, the
   settings a default block supplies to every body below it, files that pull in other files, and

--- a/crates/multicalc/src/lib.rs
+++ b/crates/multicalc/src/lib.rs
@@ -148,7 +148,9 @@ pub use random::{Pcg32, RandomSource};
 pub use optimization::{GaussNewton, LevenbergMarquardt, MinimizationReport, TerminationReason};
 
 /// Bracketed and Newton root finders for scalar equations and square systems.
-pub use root_finding::{Bisection, Newton, NewtonSystem, RootReport, RootReportN, RootTermination};
+pub use root_finding::{
+    Bisection, Brent, Newton, NewtonSystem, RootReport, RootReportN, RootTermination,
+};
 
 /// Polynomials by their coefficients, in pieces, and in several variables.
 pub use polynomial::{

--- a/crates/multicalc/src/root_finding/brent.rs
+++ b/crates/multicalc/src/root_finding/brent.rs
@@ -1,0 +1,204 @@
+//! Bracketed scalar Brent's method root solver.
+
+use crate::error::SolveError;
+use crate::root_finding::{same_sign, RootReport, RootTermination};
+use crate::scalar::{Numeric, ScalarFn};
+
+/// A bracketed scalar root solver using Brent's method (Dekker-Brent algorithm).
+///
+/// Combines root bracketing, bisection, secant method, and inverse quadratic interpolation (IQI).
+/// It guarantees convergence by retaining bracket endpoints like [`Bisection`](crate::root_finding::Bisection),
+/// but converges superlinearly on smooth functions.
+///
+/// Cost per iteration: 1 function evaluation.
+///
+/// # Examples
+/// ```
+/// use multicalc::root_finding::Brent;
+/// use multicalc::scalar::c;
+/// use multicalc::scalar_fn;
+///
+/// // f(x) = x² − 2, root at √2 ≈ 1.41421356
+/// let function = scalar_fn!(|x| c(-2.0) + x * x);
+/// let lower_bound = 0.0_f64;
+/// let upper_bound = 2.0;
+///
+/// let report = Brent::default().solve(&function, lower_bound, upper_bound).unwrap();
+/// assert!((report.root - 2.0_f64.sqrt()).abs() < 1e-9);
+/// ```
+pub struct Brent<T = f64> {
+    xtol: T,
+    ftol: T,
+    max_iterations: usize,
+}
+
+impl<T: Numeric> Default for Brent<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Numeric> Brent<T> {
+    /// Const constructor (same as [`Default::default`]).
+    ///
+    /// ```
+    /// use multicalc::root_finding::Brent;
+    ///
+    /// const B: Brent = Brent::new();
+    /// ```
+    pub const fn new() -> Self {
+        let tol = T::EPSILON_X4;
+        Brent {
+            xtol: tol,
+            ftol: tol,
+            max_iterations: 100,
+        }
+    }
+
+    /// Sets the bracket-width tolerance (relative: compared against `xtol * (1 + |b|)`).
+    #[must_use]
+    pub const fn with_xtol(mut self, xtol: T) -> Self {
+        self.xtol = xtol;
+        self
+    }
+
+    /// Sets the residual tolerance: the solver stops when `|f(b)| ≤ ftol`.
+    #[must_use]
+    pub const fn with_ftol(mut self, ftol: T) -> Self {
+        self.ftol = ftol;
+        self
+    }
+
+    /// Sets the maximum number of iterations.
+    #[must_use]
+    pub const fn with_max_iterations(mut self, max_iterations: usize) -> Self {
+        self.max_iterations = max_iterations;
+        self
+    }
+
+    /// Finds a root of `f` in the bracket `[a, b]`.
+    ///
+    /// Returns the root estimate and termination reason, or an error:
+    /// [`NonFinite`](SolveError::NonFinite) if `f` returns a non-finite value,
+    /// [`InvalidBracket`](SolveError::InvalidBracket) if `f(a)` and `f(b)` share a sign, or
+    /// [`DidNotConverge`](SolveError::DidNotConverge) if the budget is exhausted.
+    pub fn solve<F: ScalarFn>(&self, f: &F, a: T, b: T) -> Result<RootReport<T>, SolveError> {
+        let mut fa = f.eval(a);
+        let mut fb = f.eval(b);
+
+        if !fa.is_finite() || !fb.is_finite() {
+            return Err(SolveError::NonFinite);
+        }
+        if fa == T::ZERO {
+            return Ok(RootReport {
+                root: a,
+                residual: fa,
+                iterations: 0,
+                termination: RootTermination::ResidualTolerance,
+            });
+        }
+        if fb == T::ZERO {
+            return Ok(RootReport {
+                root: b,
+                residual: fb,
+                iterations: 0,
+                termination: RootTermination::ResidualTolerance,
+            });
+        }
+        if same_sign(fa, fb) {
+            return Err(SolveError::InvalidBracket);
+        }
+
+        let mut a = a;
+        let mut b = b;
+
+        if fa.abs() < fb.abs() {
+            core::mem::swap(&mut a, &mut b);
+            core::mem::swap(&mut fa, &mut fb);
+        }
+
+        let mut c = a;
+        let mut fc = fa;
+        let mut d = b - a;
+        let mut mflag = true;
+
+        for iter in 1..=self.max_iterations {
+            if fb.abs() <= self.ftol {
+                return Ok(RootReport {
+                    root: b,
+                    residual: fb,
+                    iterations: iter,
+                    termination: RootTermination::ResidualTolerance,
+                });
+            }
+
+            let tol = self.xtol * (T::ONE + b.abs());
+            let m = (a - b) * T::HALF;
+
+            if m.abs() <= tol || (b - a).abs() <= tol {
+                return Ok(RootReport {
+                    root: b,
+                    residual: fb,
+                    iterations: iter,
+                    termination: RootTermination::BracketWidth,
+                });
+            }
+
+            let mut s = if fa != fc && fb != fc {
+                let s_a = a * fb * fc / ((fa - fb) * (fa - fc));
+                let s_b = b * fa * fc / ((fb - fa) * (fb - fc));
+                let s_c = c * fa * fb / ((fc - fa) * (fc - fc));
+                s_a + s_b + s_c
+            } else {
+                b - fb * (b - a) / (fb - fa)
+            };
+
+            let bound1 = (T::THREE * a + b) * T::HALF * T::HALF;
+            let bound2 = b;
+            let (min_b, max_b) = if bound1 <= bound2 {
+                (bound1, bound2)
+            } else {
+                (bound2, bound1)
+            };
+
+            let condition1 = s < min_b || s > max_b;
+            let condition2 = mflag && (s - b).abs() >= (b - c).abs() * T::HALF;
+            let condition3 = !mflag && (s - b).abs() >= (c - d).abs() * T::HALF;
+            let condition4 = mflag && (b - c).abs() < tol;
+            let condition5 = !mflag && (c - d).abs() < tol;
+
+            if condition1 || condition2 || condition3 || condition4 || condition5 {
+                s = (a + b) * T::HALF;
+                mflag = true;
+            } else {
+                mflag = false;
+            }
+
+            let fs = f.eval(s);
+            if !fs.is_finite() {
+                return Err(SolveError::NonFinite);
+            }
+
+            d = c;
+            c = b;
+            fc = fb;
+
+            if same_sign(fa, fs) {
+                a = s;
+                fa = fs;
+            } else {
+                b = s;
+                fb = fs;
+            }
+
+            if fa.abs() < fb.abs() {
+                core::mem::swap(&mut a, &mut b);
+                core::mem::swap(&mut fa, &mut fb);
+            }
+        }
+
+        Err(SolveError::DidNotConverge {
+            iters: self.max_iterations,
+        })
+    }
+}

--- a/crates/multicalc/src/root_finding/brent.rs
+++ b/crates/multicalc/src/root_finding/brent.rs
@@ -123,32 +123,29 @@ impl<T: Numeric> Brent<T> {
         let mut mflag = true;
 
         for iter in 1..=self.max_iterations {
+            let tol = self.xtol * (T::ONE + b.abs());
+            let m = (a - b) * T::HALF;
+
             if fb.abs() <= self.ftol {
                 return Ok(RootReport {
                     root: b,
                     residual: fb,
-                    iterations: iter,
+                    iterations: iter - 1,
                     termination: RootTermination::ResidualTolerance,
                 });
             }
-
-            let tol = self.xtol * (T::ONE + b.abs());
-            let m = (a - b) * T::HALF;
 
             if m.abs() <= tol || (b - a).abs() <= tol {
                 return Ok(RootReport {
                     root: b,
                     residual: fb,
-                    iterations: iter,
+                    iterations: iter - 1,
                     termination: RootTermination::BracketWidth,
                 });
             }
 
             let mut s = if fa != fc && fb != fc {
-                let s_a = a * fb * fc / ((fa - fb) * (fa - fc));
-                let s_b = b * fa * fc / ((fb - fa) * (fb - fc));
-                let s_c = c * fa * fb / ((fc - fa) * (fc - fc));
-                s_a + s_b + s_c
+                inverse_quadratic_interpolation(a, fa, b, fb, c, fc)
             } else {
                 b - fb * (b - a) / (fb - fa)
             };
@@ -167,7 +164,7 @@ impl<T: Numeric> Brent<T> {
             let condition4 = mflag && (b - c).abs() < tol;
             let condition5 = !mflag && (c - d).abs() < tol;
 
-            if condition1 || condition2 || condition3 || condition4 || condition5 {
+            if !s.is_finite() || condition1 || condition2 || condition3 || condition4 || condition5 {
                 s = (a + b) * T::HALF;
                 mflag = true;
             } else {
@@ -195,10 +192,47 @@ impl<T: Numeric> Brent<T> {
                 core::mem::swap(&mut a, &mut b);
                 core::mem::swap(&mut fa, &mut fb);
             }
+
+            // Check convergence immediately after updating the best estimate
+            if fb.abs() <= self.ftol {
+                return Ok(RootReport {
+                    root: b,
+                    residual: fb,
+                    iterations: iter,
+                    termination: RootTermination::ResidualTolerance,
+                });
+            }
+
+            let tol_after = self.xtol * (T::ONE + b.abs());
+            let m_after = (a - b) * T::HALF;
+            if m_after.abs() <= tol_after || (b - a).abs() <= tol_after {
+                return Ok(RootReport {
+                    root: b,
+                    residual: fb,
+                    iterations: iter,
+                    termination: RootTermination::BracketWidth,
+                });
+            }
         }
 
         Err(SolveError::DidNotConverge {
             iters: self.max_iterations,
         })
     }
+}
+
+/// Evaluates inverse quadratic interpolation (IQI) through three points `(a, fa)`, `(b, fb)`, `(c, fc)`.
+#[inline]
+pub fn inverse_quadratic_interpolation<T: Numeric>(
+    a: T,
+    fa: T,
+    b: T,
+    fb: T,
+    c: T,
+    fc: T,
+) -> T {
+    let s_a = a * fb * fc / ((fa - fb) * (fa - fc));
+    let s_b = b * fa * fc / ((fb - fa) * (fb - fc));
+    let s_c = c * fa * fb / ((fc - fa) * (fc - fb));
+    s_a + s_b + s_c
 }

--- a/crates/multicalc/src/root_finding/brent.rs
+++ b/crates/multicalc/src/root_finding/brent.rs
@@ -1,7 +1,7 @@
 //! Bracketed scalar Brent's method root solver.
 
 use crate::error::SolveError;
-use crate::root_finding::{same_sign, RootReport, RootTermination};
+use crate::root_finding::{RootReport, RootTermination, same_sign};
 use crate::scalar::{Numeric, ScalarFn};
 
 /// A bracketed scalar root solver using Brent's method (Dekker-Brent algorithm).
@@ -164,7 +164,8 @@ impl<T: Numeric> Brent<T> {
             let condition4 = mflag && (b - c).abs() < tol;
             let condition5 = !mflag && (c - d).abs() < tol;
 
-            if !s.is_finite() || condition1 || condition2 || condition3 || condition4 || condition5 {
+            if !s.is_finite() || condition1 || condition2 || condition3 || condition4 || condition5
+            {
                 s = a * T::HALF + b * T::HALF;
                 mflag = true;
             } else {
@@ -223,14 +224,7 @@ impl<T: Numeric> Brent<T> {
 
 /// Evaluates inverse quadratic interpolation (IQI) through three points `(a, fa)`, `(b, fb)`, `(c, fc)`.
 #[inline]
-pub fn inverse_quadratic_interpolation<T: Numeric>(
-    a: T,
-    fa: T,
-    b: T,
-    fb: T,
-    c: T,
-    fc: T,
-) -> T {
+pub fn inverse_quadratic_interpolation<T: Numeric>(a: T, fa: T, b: T, fb: T, c: T, fc: T) -> T {
     let s_a = a * fb * fc / ((fa - fb) * (fa - fc));
     let s_b = b * fa * fc / ((fb - fa) * (fb - fc));
     let s_c = c * fa * fb / ((fc - fa) * (fc - fb));

--- a/crates/multicalc/src/root_finding/brent.rs
+++ b/crates/multicalc/src/root_finding/brent.rs
@@ -14,7 +14,7 @@ use crate::scalar::{Numeric, ScalarFn};
 ///
 /// # Examples
 /// ```
-/// use multicalc::root_finding::Brent;
+/// use multicalc::Brent;
 /// use multicalc::scalar::c;
 /// use multicalc::scalar_fn;
 ///
@@ -42,7 +42,7 @@ impl<T: Numeric> Brent<T> {
     /// Const constructor (same as [`Default::default`]).
     ///
     /// ```
-    /// use multicalc::root_finding::Brent;
+    /// use multicalc::Brent;
     ///
     /// const B: Brent = Brent::new();
     /// ```
@@ -224,9 +224,29 @@ impl<T: Numeric> Brent<T> {
 
 /// Evaluates inverse quadratic interpolation (IQI) through three points `(a, fa)`, `(b, fb)`, `(c, fc)`.
 #[inline]
-pub fn inverse_quadratic_interpolation<T: Numeric>(a: T, fa: T, b: T, fb: T, c: T, fc: T) -> T {
+#[must_use]
+pub(crate) fn inverse_quadratic_interpolation<T: Numeric>(
+    a: T,
+    fa: T,
+    b: T,
+    fb: T,
+    c: T,
+    fc: T,
+) -> T {
     let s_a = a * fb * fc / ((fa - fb) * (fa - fc));
     let s_b = b * fa * fc / ((fb - fa) * (fb - fc));
     let s_c = c * fa * fb / ((fc - fa) * (fc - fb));
     s_a + s_b + s_c
+}
+
+#[cfg(test)]
+mod tests {
+    use super::inverse_quadratic_interpolation;
+
+    #[test]
+    fn inverse_quadratic_interpolation_matches_analytical_value() {
+        let result = inverse_quadratic_interpolation(-1.0_f64, 0.75, 0.0, -0.25, -0.25, -0.1875);
+
+        assert!((result - (-0.85)).abs() < 1e-12);
+    }
 }

--- a/crates/multicalc/src/root_finding/brent.rs
+++ b/crates/multicalc/src/root_finding/brent.rs
@@ -150,7 +150,7 @@ impl<T: Numeric> Brent<T> {
                 b - fb * (b - a) / (fb - fa)
             };
 
-            let bound1 = (T::THREE * a + b) * T::HALF * T::HALF;
+            let bound1 = a * T::HALF * T::HALF * T::THREE + b * T::HALF * T::HALF;
             let bound2 = b;
             let (min_b, max_b) = if bound1 <= bound2 {
                 (bound1, bound2)
@@ -165,7 +165,7 @@ impl<T: Numeric> Brent<T> {
             let condition5 = !mflag && (c - d).abs() < tol;
 
             if !s.is_finite() || condition1 || condition2 || condition3 || condition4 || condition5 {
-                s = (a + b) * T::HALF;
+                s = a * T::HALF + b * T::HALF;
                 mflag = true;
             } else {
                 mflag = false;

--- a/crates/multicalc/src/root_finding/mod.rs
+++ b/crates/multicalc/src/root_finding/mod.rs
@@ -8,10 +8,12 @@
 //! Every solver takes an iteration budget and reports why it stopped as a [`RootTermination`].
 
 mod bisection;
+mod brent;
 mod newton;
 mod newton_system;
 
 pub use bisection::Bisection;
+pub use brent::Brent;
 pub use newton::Newton;
 pub use newton_system::NewtonSystem;
 

--- a/crates/multicalc/src/root_finding/mod.rs
+++ b/crates/multicalc/src/root_finding/mod.rs
@@ -13,7 +13,7 @@ mod newton;
 mod newton_system;
 
 pub use bisection::Bisection;
-pub use brent::Brent;
+pub use brent::{Brent, inverse_quadratic_interpolation};
 pub use newton::Newton;
 pub use newton_system::NewtonSystem;
 

--- a/crates/multicalc/src/root_finding/mod.rs
+++ b/crates/multicalc/src/root_finding/mod.rs
@@ -1,6 +1,7 @@
 //! Root finding for scalar equations and square systems.
 //!
 //! - [`Bisection`] — brackets a scalar root and halves the interval within a guaranteed budget.
+//! - [`Brent`] — preserves a bracket while accelerating with interpolation steps.
 //! - [`Newton`] / [`NewtonSystem`] — Newton steps from any
 //!   [`DerivatorSingleVariable`](crate::numerical_derivative::DerivatorSingleVariable) (exact
 //!   autodiff by default), with an optional backtracking line search.
@@ -13,7 +14,7 @@ mod newton;
 mod newton_system;
 
 pub use bisection::Bisection;
-pub use brent::{Brent, inverse_quadratic_interpolation};
+pub use brent::Brent;
 pub use newton::Newton;
 pub use newton_system::NewtonSystem;
 
@@ -27,7 +28,7 @@ pub enum RootTermination {
     ResidualTolerance,
     /// The step size fell to or below the step tolerance.
     StepTolerance,
-    /// The bracket width fell to or below the step tolerance (bisection only).
+    /// The bracket width fell to or below the step tolerance.
     BracketWidth,
 }
 

--- a/crates/multicalc/tests/suite/root_finding.rs
+++ b/crates/multicalc/tests/suite/root_finding.rs
@@ -4,7 +4,7 @@ use multicalc::error::{LinalgError, SolveError};
 use multicalc::numerical_derivative::FiniteDifferenceSingle;
 use multicalc::numerical_derivative::{AutoDiffMulti, AutoDiffSingle};
 use multicalc::root_finding::{
-    Bisection, Newton, NewtonSystem, RootReport, RootReportN, RootTermination,
+    Bisection, Brent, Newton, NewtonSystem, RootReport, RootReportN, RootTermination,
 };
 use multicalc::scalar::{Numeric, ScalarFn, VectorFn, c};
 use multicalc::scalar_fn;
@@ -16,6 +16,14 @@ fn bisect<F: ScalarFn>(
     upper_bound: f64,
 ) -> Result<RootReport<f64>, SolveError> {
     Bisection::default().solve(function, lower_bound, upper_bound)
+}
+
+fn brent<F: ScalarFn>(
+    function: &F,
+    lower_bound: f64,
+    upper_bound: f64,
+) -> Result<RootReport<f64>, SolveError> {
+    Brent::default().solve(function, lower_bound, upper_bound)
 }
 
 fn newton<F: ScalarFn>(function: &F, initial_guess: f64) -> Result<RootReport<f64>, SolveError> {
@@ -127,6 +135,80 @@ fn bisection_exact_endpoint_root() {
     // f(0) = 0 exactly; the solver returns before the first iteration.
     let line = scalar_fn!(|x| x);
     let report = bisect(&line, 0.0_f64, 1.0).unwrap();
+    assert_eq!(report.root, 0.0_f64);
+    assert!(matches!(
+        report.termination,
+        RootTermination::ResidualTolerance
+    ));
+}
+
+// ----- Brent's method -----
+
+#[test]
+fn brent_sqrt2() {
+    let sqrt_two = scalar_fn!(|x| c(-2.0) + x * x);
+    let brent_report = brent(&sqrt_two, 0.0_f64, 2.0).unwrap();
+    let bisect_report = bisect(&sqrt_two, 0.0_f64, 2.0).unwrap();
+
+    assert!((brent_report.root - 2.0_f64.sqrt()).abs() < 1e-9);
+    assert!(brent_report.iterations < bisect_report.iterations);
+    assert!(matches!(
+        brent_report.termination,
+        RootTermination::ResidualTolerance | RootTermination::BracketWidth | RootTermination::StepTolerance
+    ));
+}
+
+#[test]
+fn brent_dottie_number() {
+    let dottie = scalar_fn!(|x| x.cos() - x);
+    let brent_report = brent(&dottie, 0.0_f64, 1.0).unwrap();
+    let bisect_report = bisect(&dottie, 0.0_f64, 1.0).unwrap();
+
+    assert!((brent_report.root - 0.7390851332151607).abs() < 1e-9);
+    assert!(brent_report.iterations < bisect_report.iterations);
+}
+
+#[test]
+fn brent_wien_displacement() {
+    let wien = scalar_fn!(|x| c(-5.0) + x + c(5.0) * (-x).exp());
+    let brent_report = brent(&wien, 1.0_f64, 10.0).unwrap();
+    let bisect_report = bisect(&wien, 1.0_f64, 10.0).unwrap();
+
+    assert!((brent_report.root - 4.965114231744276).abs() < 1e-9);
+    assert!(brent_report.iterations < bisect_report.iterations);
+}
+
+#[test]
+fn brent_invalid_bracket() {
+    let sqrt_two = scalar_fn!(|x| c(-2.0) + x * x);
+    assert!(matches!(
+        brent(&sqrt_two, 2.0_f64, 3.0),
+        Err(SolveError::InvalidBracket)
+    ));
+}
+
+#[test]
+fn brent_non_finite() {
+    let reciprocal = scalar_fn!(|x| c(1.0) / x);
+    assert!(matches!(
+        brent(&reciprocal, -1.0_f64, 1.0),
+        Err(SolveError::NonFinite)
+    ));
+}
+
+#[test]
+fn brent_budget_exhausted() {
+    let sqrt_two = scalar_fn!(|x| c(-2.0) + x * x);
+    let result = Brent::default()
+        .with_max_iterations(1)
+        .solve(&sqrt_two, 0.0_f64, 2.0);
+    assert!(matches!(result, Err(SolveError::DidNotConverge { .. })));
+}
+
+#[test]
+fn brent_exact_endpoint_root() {
+    let line = scalar_fn!(|x| x);
+    let report = brent(&line, 0.0_f64, 1.0).unwrap();
     assert_eq!(report.root, 0.0_f64);
     assert!(matches!(
         report.termination,

--- a/crates/multicalc/tests/suite/root_finding.rs
+++ b/crates/multicalc/tests/suite/root_finding.rs
@@ -155,7 +155,9 @@ fn brent_sqrt2() {
     assert!(brent_report.iterations < bisect_report.iterations);
     assert!(matches!(
         brent_report.termination,
-        RootTermination::ResidualTolerance | RootTermination::BracketWidth | RootTermination::StepTolerance
+        RootTermination::ResidualTolerance
+            | RootTermination::BracketWidth
+            | RootTermination::StepTolerance
     ));
 }
 
@@ -223,7 +225,11 @@ fn brent_iqi_formula_exact_evaluation() {
     // Analytical IQI gives exactly s = -0.85
     // If the 3rd denominator regresses to (fc - fa) * (fc - fc), it divides by zero!
     let s = inverse_quadratic_interpolation(-1.0_f64, 0.75, 0.0, -0.25, -0.25, -0.1875);
-    assert!((s - (-0.85)).abs() < 1e-12, "IQI formula returned unexpected value: {}", s);
+    assert!(
+        (s - (-0.85)).abs() < 1e-12,
+        "IQI formula returned unexpected value: {}",
+        s
+    );
 }
 
 #[test]
@@ -236,7 +242,11 @@ fn brent_iqi_polynomial_regression() {
     let bisect_report = bisect(&poly, 0.0_f64, 1.0).unwrap();
 
     assert!((brent_report.root - 0.5_f64.sqrt()).abs() < 1e-9);
-    assert!(brent_report.iterations <= 8, "Expected fast IQI convergence in <= 8 iterations, got {}", brent_report.iterations);
+    assert!(
+        brent_report.iterations <= 8,
+        "Expected fast IQI convergence in <= 8 iterations, got {}",
+        brent_report.iterations
+    );
     assert!(brent_report.iterations < bisect_report.iterations);
     assert!(matches!(
         brent_report.termination,

--- a/crates/multicalc/tests/suite/root_finding.rs
+++ b/crates/multicalc/tests/suite/root_finding.rs
@@ -246,24 +246,28 @@ fn brent_iqi_polynomial_regression() {
 
 #[test]
 fn brent_non_finite_candidate_fallback_recovers() {
-    // Construct a function with extreme magnitude values near floating point limit (1e308)
-    // where secant interpolation (fb * (b - a) / (fb - fa)) overflows to NaN (inf / inf).
-    // The !s.is_finite() guard inside solve() catches the NaN candidate, falls back to bisection,
-    // and successfully recovers the root instead of evaluating f(NaN) and failing with SolveError::NonFinite.
-    struct ExtremeOverflowFn;
-    impl ScalarFn for ExtremeOverflowFn {
+    // Continuous function on large finite bracket [1e308, 1.5e308] with genuine root at 1.25e308:
+    // f(x) = ((x - 1.25e308) / 2.5e307) * 1e308.
+    // At endpoints, f(1e308) = -1e308 and f(1.5e308) = +1e308 (both finite, opposite signs).
+    // Secant numerator and denominator overflow to infinity, yielding NaN (inf/inf).
+    // The !s.is_finite() guard catches the NaN candidate, falls back to overflow-safe bisection midpoint
+    // (a * HALF + b * HALF = 1.25e308), evaluating exactly f(1.25e308) = 0.0 and converging immediately!
+    struct LargeScaleContinuousFn;
+    impl ScalarFn for LargeScaleContinuousFn {
         fn eval<S: Numeric>(&self, x: S) -> S {
-            if x <= S::ONE {
-                -S::from_f64(1e308) * (S::ONE - x) - S::from_f64(1e-10)
-            } else {
-                S::from_f64(1e308) * (x - S::ONE) + S::from_f64(1e-10)
-            }
+            ((x - S::from_f64(1.25e308)) / S::from_f64(2.5e307)) * S::from_f64(1e308)
         }
     }
 
-    let f = ExtremeOverflowFn;
-    let report = Brent::default().solve(&f, 0.0_f64, 2.5_f64).unwrap();
-    assert!((report.root - 1.0).abs() < 1e-8);
+    let f = LargeScaleContinuousFn;
+    let report = Brent::default().solve(&f, 1e308_f64, 1.5e308_f64).unwrap();
+    assert_eq!(report.root, 1.25e308_f64);
+    assert_eq!(report.residual, 0.0_f64);
+    assert_eq!(report.iterations, 1);
+    assert!(matches!(
+        report.termination,
+        RootTermination::ResidualTolerance
+    ));
 }
 
 #[test]

--- a/crates/multicalc/tests/suite/root_finding.rs
+++ b/crates/multicalc/tests/suite/root_finding.rs
@@ -5,6 +5,7 @@ use multicalc::numerical_derivative::FiniteDifferenceSingle;
 use multicalc::numerical_derivative::{AutoDiffMulti, AutoDiffSingle};
 use multicalc::root_finding::{
     Bisection, Brent, Newton, NewtonSystem, RootReport, RootReportN, RootTermination,
+    inverse_quadratic_interpolation,
 };
 use multicalc::scalar::{Numeric, ScalarFn, VectorFn, c};
 use multicalc::scalar_fn;
@@ -214,6 +215,81 @@ fn brent_exact_endpoint_root() {
         report.termination,
         RootTermination::ResidualTolerance
     ));
+}
+
+#[test]
+fn brent_iqi_formula_exact_evaluation() {
+    // Distinct points (x, y) = (-1.0, 0.75), (0.0, -0.25), (-0.25, -0.1875)
+    // Analytical IQI gives exactly s = -0.85
+    // If the 3rd denominator regresses to (fc - fa) * (fc - fc), it divides by zero!
+    let s = inverse_quadratic_interpolation(-1.0_f64, 0.75, 0.0, -0.25, -0.25, -0.1875);
+    assert!((s - (-0.85)).abs() < 1e-12, "IQI formula returned unexpected value: {}", s);
+}
+
+#[test]
+fn brent_iqi_polynomial_regression() {
+    // f(x) = x² - 0.5 on [0.0, 1.0], irrational root at 1/√2 ≈ 0.7071067811865475
+    // With IQI interpolation enabled, converges in <= 8 iterations.
+    // Pure bisection requires 30 iterations to reach 1e-9 precision on [0, 1].
+    let poly = scalar_fn!(|x| c(-0.5) + x * x);
+    let brent_report = brent(&poly, 0.0_f64, 1.0).unwrap();
+    let bisect_report = bisect(&poly, 0.0_f64, 1.0).unwrap();
+
+    assert!((brent_report.root - 0.5_f64.sqrt()).abs() < 1e-9);
+    assert!(brent_report.iterations <= 8, "Expected fast IQI convergence in <= 8 iterations, got {}", brent_report.iterations);
+    assert!(brent_report.iterations < bisect_report.iterations);
+    assert!(matches!(
+        brent_report.termination,
+        RootTermination::ResidualTolerance | RootTermination::BracketWidth
+    ));
+}
+
+#[test]
+fn brent_non_finite_candidate_fallback_recovers() {
+    // Construct a function with extreme magnitude values near floating point limit (1e308)
+    // where secant interpolation (fb * (b - a) / (fb - fa)) overflows to NaN (inf / inf).
+    // The !s.is_finite() guard inside solve() catches the NaN candidate, falls back to bisection,
+    // and successfully recovers the root instead of evaluating f(NaN) and failing with SolveError::NonFinite.
+    struct ExtremeOverflowFn;
+    impl ScalarFn for ExtremeOverflowFn {
+        fn eval<S: Numeric>(&self, x: S) -> S {
+            if x <= S::ONE {
+                -S::from_f64(1e308) * (S::ONE - x) - S::from_f64(1e-10)
+            } else {
+                S::from_f64(1e308) * (x - S::ONE) + S::from_f64(1e-10)
+            }
+        }
+    }
+
+    let f = ExtremeOverflowFn;
+    let report = Brent::default().solve(&f, 0.0_f64, 2.5_f64).unwrap();
+    assert!((report.root - 1.0).abs() < 1e-8);
+}
+
+#[test]
+fn brent_exact_root_on_final_iteration() {
+    // f(x) = x - 1 on [0.0, 2.0], root at 1.0 found on iteration 1
+    // Must converge and report success with max_iterations = 1
+    let line = scalar_fn!(|x| c(-1.0) + x);
+    let report = Brent::default()
+        .with_max_iterations(1)
+        .solve(&line, 0.0_f64, 2.0)
+        .unwrap();
+    assert!((report.root - 1.0).abs() < 1e-9);
+    assert_eq!(report.iterations, 1);
+    assert!(matches!(
+        report.termination,
+        RootTermination::ResidualTolerance | RootTermination::BracketWidth
+    ));
+}
+
+#[test]
+fn brent_f32_precision() {
+    // Generic Numeric trait compliance with f32
+    let sqrt_two = scalar_fn!(|x| c(-2.0) + x * x);
+    let solver: Brent<f32> = Brent::new();
+    let report = solver.solve(&sqrt_two, 0.0_f32, 2.0_f32).unwrap();
+    assert!((report.root - 2.0_f32.sqrt()).abs() < 1e-4);
 }
 
 // ----- Scalar Newton and damped Newton -----

--- a/crates/multicalc/tests/suite/root_finding.rs
+++ b/crates/multicalc/tests/suite/root_finding.rs
@@ -4,12 +4,11 @@ use multicalc::error::{LinalgError, SolveError};
 use multicalc::numerical_derivative::FiniteDifferenceSingle;
 use multicalc::numerical_derivative::{AutoDiffMulti, AutoDiffSingle};
 use multicalc::root_finding::{
-    Bisection, Brent, Newton, NewtonSystem, RootReport, RootReportN, RootTermination,
-    inverse_quadratic_interpolation,
+    Bisection, Newton, NewtonSystem, RootReport, RootReportN, RootTermination,
 };
 use multicalc::scalar::{Numeric, ScalarFn, VectorFn, c};
-use multicalc::scalar_fn;
 use multicalc::scalar_fn_vec;
+use multicalc::{Brent, scalar_fn};
 
 fn bisect<F: ScalarFn>(
     function: &F,
@@ -217,19 +216,6 @@ fn brent_exact_endpoint_root() {
         report.termination,
         RootTermination::ResidualTolerance
     ));
-}
-
-#[test]
-fn brent_iqi_formula_exact_evaluation() {
-    // Distinct points (x, y) = (-1.0, 0.75), (0.0, -0.25), (-0.25, -0.1875)
-    // Analytical IQI gives exactly s = -0.85
-    // If the 3rd denominator regresses to (fc - fa) * (fc - fc), it divides by zero!
-    let s = inverse_quadratic_interpolation(-1.0_f64, 0.75, 0.0, -0.25, -0.25, -0.1875);
-    assert!(
-        (s - (-0.85)).abs() < 1e-12,
-        "IQI formula returned unexpected value: {}",
-        s
-    );
 }
 
 #[test]


### PR DESCRIPTION
### Description
Adds a bracketed scalar root finder using Brent's method (the Dekker-Brent algorithm) in `crates/multicalc/src/root_finding/brent.rs`.

### Implementation Details
- Combines bracket preservation with secant method and inverse quadratic interpolation (IQI).
- Implements standard Brent fallback checks to guarantee bisection convergence while achieving superlinear convergence on smooth functions.
- Integrates seamlessly with existing `RootReport` and `RootTermination` structures.
- Added comprehensive unit tests in `crates/multicalc/tests/suite/root_finding.rs` comparing against `Bisection` fixtures (asserting equal root precision with strictly fewer iterations), invalid brackets, non-finite values, and budget exhaustion.

### Testing
- `cargo test -p multicalc`

Closes #216
