### PR TITLE
Scale the mixer rank-check tolerance to the scalar type (#301)

### DIFF
--- a/crates/multicalc/src/plant/multirotor_mixing.rs
+++ b/crates/multicalc/src/plant/multirotor_mixing.rs
@@ -163,9 +163,18 @@ impl<const ROTOR_COUNT: usize, T: Numeric> MultirotorMixer<ROTOR_COUNT, T> {
         // Going out to the rotors and back has to land where it started; when it does not, some
         // wanted push or turn is one the rotors simply cannot produce. The bar is loose enough
         // that single precision passes and tight enough that a missing direction, which is off by
-        // about one, always fails.
+        // about one, always fails. A fixed absolute bar is wrong here: the round-trip error scales
+        // with the allocation matrix's own magnitude, so the bar is scaled the same way, by the
+        // largest entry the allocation matrix holds, and by the scalar type's own epsilon so the
+        // same layout is judged the same way whether it is built at f32 or f64.
         let round_trip = allocation * distribution;
-        let bar = T::from_f64(1e-4);
+        let mut allocation_scale = T::ONE;
+        for row in 0..4 {
+            for rotor in 0..ROTOR_COUNT {
+                allocation_scale = allocation_scale.max(allocation[(row, rotor)].abs());
+            }
+        }
+        let bar = T::EPSILON_X30 * allocation_scale;
         for row in 0..4 {
             for col in 0..4 {
                 let wanted = if row == col { T::ONE } else { T::ZERO };

--- a/crates/multicalc/tests/suite/plant/multirotor_mixing.rs
+++ b/crates/multicalc/tests/suite/plant/multirotor_mixing.rs
@@ -329,8 +329,9 @@ fn accept_and_reject_agree_between_f32_and_f64() {
             Err(PlantError::RotorLayoutNotIndependent)
         );
 
-        let in_a_line_f32: [Vector3D<f32>; 4] =
-            core::array::from_fn(|rotor| Vector::new(in_a_line[rotor].into_array().map(|x| x as f32)));
+        let in_a_line_f32: [Vector3D<f32>; 4] = core::array::from_fn(|rotor| {
+            Vector::new(in_a_line[rotor].into_array().map(|x| x as f32))
+        });
         assert_eq!(
             MultirotorMixer::<4, f32>::new(
                 in_a_line_f32,

--- a/crates/multicalc/tests/suite/plant/multirotor_mixing.rs
+++ b/crates/multicalc/tests/suite/plant/multirotor_mixing.rs
@@ -273,3 +273,73 @@ fn a_mixer_drives_a_body() {
     assert!(motion.linear().norm() < 1e-12);
     assert!(motion.angular().norm() < 1e-12);
 }
+
+/// The round-trip tolerance is scaled by the allocation matrix's own magnitude and the scalar
+/// type's epsilon, so the same rotor layout is judged the same way at `f32` and `f64` - including
+/// when every position and torque ratio is scaled up by a large factor, which scales the
+/// allocation matrix's magnitude along with it.
+#[test]
+fn accept_and_reject_agree_between_f32_and_f64() {
+    // An independent layout, at its usual scale and scaled up by a large factor: accepted both
+    // ways, at both scalar types.
+    for scale in [1.0, 1.0e6] {
+        assert!(
+            MultirotorMixer::<4, f64>::quadrotor_x(
+                ARM_LENGTH * scale,
+                TORQUE_PER_THRUST * scale,
+                MINIMUM_THRUST,
+                MAXIMUM_THRUST,
+            )
+            .is_ok()
+        );
+        assert!(
+            MultirotorMixer::<4, f32>::quadrotor_x(
+                ARM_LENGTH as f32 * scale as f32,
+                TORQUE_PER_THRUST as f32 * scale as f32,
+                MINIMUM_THRUST as f32,
+                MAXIMUM_THRUST as f32,
+            )
+            .is_ok()
+        );
+    }
+
+    // Four rotors all along the x axis: nothing can tip the body about x, so this is refused at
+    // its usual scale and when scaled up, at both scalar types.
+    for scale in [1.0, 1.0e6] {
+        let in_a_line = [
+            Vector::new([0.1 * scale, 0.0, 0.0]),
+            Vector::new([0.2 * scale, 0.0, 0.0]),
+            Vector::new([-0.1 * scale, 0.0, 0.0]),
+            Vector::new([-0.2 * scale, 0.0, 0.0]),
+        ];
+        let alternating = [
+            RotorSpin::Clockwise,
+            RotorSpin::CounterClockwise,
+            RotorSpin::Clockwise,
+            RotorSpin::CounterClockwise,
+        ];
+        assert_eq!(
+            MultirotorMixer::<4, f64>::new(
+                in_a_line,
+                alternating,
+                TORQUE_PER_THRUST,
+                MINIMUM_THRUST,
+                MAXIMUM_THRUST
+            ),
+            Err(PlantError::RotorLayoutNotIndependent)
+        );
+
+        let in_a_line_f32: [Vector3D<f32>; 4] =
+            core::array::from_fn(|rotor| Vector::new(in_a_line[rotor].into_array().map(|x| x as f32)));
+        assert_eq!(
+            MultirotorMixer::<4, f32>::new(
+                in_a_line_f32,
+                alternating,
+                TORQUE_PER_THRUST as f32,
+                MINIMUM_THRUST as f32,
+                MAXIMUM_THRUST as f32
+            ),
+            Err(PlantError::RotorLayoutNotIndependent)
+        );
+    }
+}


### PR DESCRIPTION
Closes #301.

## AI-assistance disclosure

Full transparency: Hatbox's autonomous agent pipeline built this one - it triaged the issue, wrote the fix, and added the tests; a human reviewed and shipped it. Model/behavior envelope: `sonnet-5 x 0.2 x R1 + enforcing gate`. Ran green against the full suite before it left the hangar - no hand-waving, no invented APIs.

-- Hatbox
