### PR TITLE
multicalc #156: make the SVD sweep budget configurable (clean reimpl; PR #235 stalled)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Configurable SVD sweep budget.** `SvdSettings` carries the one-sided Jacobi SVD's `max_sweeps`
+  (default 60, matching the previous hardcoded limit unchanged); `Matrix::svd_with_settings` takes
+  it explicitly, and `Matrix::svd` keeps calling it with the default so existing behaviour is
+  unchanged. (#156)
+
 - **Brent root finding.** `Brent` combines bracketed convergence with secant and inverse
   quadratic interpolation steps for scalar equations. @snowyukitty (#323)
 

--- a/crates/multicalc/src/linear_algebra/mod.rs
+++ b/crates/multicalc/src/linear_algebra/mod.rs
@@ -30,7 +30,7 @@ pub use lyapunov::solve_discrete_lyapunov;
 pub use matrix::Matrix;
 pub use qr::{CholeskyFactor, DampedLeastSquares, PivotedQr};
 pub use riccati::solve_discrete_riccati;
-pub use svd::Svd;
+pub use svd::{Svd, SvdSettings};
 pub use symmetric_eigendecomposition::SymmetricEigendecomposition;
 pub use vector::Vector;
 

--- a/crates/multicalc/src/linear_algebra/svd.rs
+++ b/crates/multicalc/src/linear_algebra/svd.rs
@@ -23,6 +23,20 @@ pub struct Svd<const M: usize, const N: usize, T = f64> {
     pub(crate) v: Matrix<N, N, T>,
 }
 
+/// Configuration for the one-sided Jacobi SVD.
+#[derive(Debug, Clone, Copy)]
+pub struct SvdSettings {
+    /// Maximum number of Jacobi sweeps over the column pairs before giving up on convergence.
+    pub max_sweeps: usize,
+}
+
+impl Default for SvdSettings {
+    /// 60 sweeps, matching the sweep budget [`Matrix::svd`] has always used.
+    fn default() -> Self {
+        SvdSettings { max_sweeps: 60 }
+    }
+}
+
 impl<const M: usize, const N: usize, T: Numeric> Matrix<M, N, T> {
     /// Decomposes `self` as `U · diag(σ) · Vᵀ` by one-sided Jacobi (thin form, `M ≥ N`).
     ///
@@ -69,6 +83,24 @@ impl<const M: usize, const N: usize, T: Numeric> Matrix<M, N, T> {
     /// }
     /// ```
     pub fn svd(self) -> Result<Svd<M, N, T>, LinalgError> {
+        self.svd_with_settings(&SvdSettings::default())
+    }
+
+    /// Decomposes `self` as `U · diag(σ) · Vᵀ` by one-sided Jacobi (thin form, `M ≥ N`), with an
+    /// explicit sweep budget.
+    ///
+    /// Behaves exactly like [`Matrix::svd`], except the Jacobi sweep count comes from
+    /// `settings.max_sweeps` instead of the default of 60. Returns [`LinalgError::Underdetermined`]
+    /// for a wide matrix (`M < N`) or [`LinalgError::NonFinite`] if any entry is not finite.
+    ///
+    /// ```
+    /// use multicalc::linear_algebra::{Matrix, SvdSettings};
+    /// let a = Matrix::<3, 2>::new([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]);
+    /// let settings = SvdSettings { max_sweeps: 10 };
+    /// let svd = a.svd_with_settings(&settings).unwrap();
+    /// assert!(svd.singular_values()[0] > 0.0);
+    /// ```
+    pub fn svd_with_settings(self, settings: &SvdSettings) -> Result<Svd<M, N, T>, LinalgError> {
         if M < N {
             return Err(LinalgError::Underdetermined);
         }
@@ -80,8 +112,7 @@ impl<const M: usize, const N: usize, T: Numeric> Matrix<M, N, T> {
         let mut v = Matrix::<N, N, T>::identity();
 
         // One-sided Jacobi: rotate column pairs of U until its columns are orthogonal.
-        let max_sweeps = 60;
-        for _ in 0..max_sweeps {
+        for _ in 0..settings.max_sweeps {
             let mut off_max = T::ZERO;
             for p in 0..N {
                 for q in (p + 1)..N {

--- a/crates/multicalc/tests/suite/linear_algebra/svd.rs
+++ b/crates/multicalc/tests/suite/linear_algebra/svd.rs
@@ -1,5 +1,7 @@
 use multicalc::error::LinalgError;
-use multicalc::linear_algebra::{Matrix, Matrix3D, Matrix4D, Matrix6D, Vector, Vector6D};
+use multicalc::linear_algebra::{
+    Matrix, Matrix3D, Matrix4D, Matrix6D, SvdSettings, Vector, Vector6D,
+};
 use multicalc_testkit::tol::{
     assert_identity, assert_matrix_close, svd_moore_penrose, svd_moore_penrose_f32,
     svd_reconstructs,
@@ -320,4 +322,55 @@ fn svd_overdetermined_least_squares() {
     for index in 0..3 {
         assert!((svd_solution[index] - normal_equations_solution[index]).abs() < 1e-9);
     }
+}
+
+#[test]
+fn svd_with_settings_default_matches_svd() {
+    // SvdSettings::default() (max_sweeps = 60) must reproduce today's Matrix::svd() output.
+    let a = Matrix::<12, 6>::from_fn(|row, column| {
+        if row == column {
+            10.0
+        } else {
+            1.0 / (1.0 + (row + column) as f64)
+        }
+    });
+    let default_result = a.svd().unwrap();
+    let settings_result = a.svd_with_settings(&SvdSettings::default()).unwrap();
+    for index in 0..6 {
+        assert!(
+            (default_result.singular_values()[index] - settings_result.singular_values()[index])
+                .abs()
+                < 1e-15
+        );
+    }
+}
+
+#[test]
+fn svd_with_settings_custom_max_sweeps_changes_behavior() {
+    // A matrix that needs more than one or two sweeps to converge to full accuracy, so an
+    // artificially small sweep budget leaves the columns measurably less orthogonal than the
+    // default budget does.
+    let a = Matrix::<20, 6>::from_fn(|row, column| {
+        if row == column {
+            8.0
+        } else {
+            (row as f64 - column as f64) / (5.0 + (row + column) as f64)
+        }
+    });
+
+    let converged = a
+        .svd_with_settings(&SvdSettings { max_sweeps: 60 })
+        .unwrap();
+    let starved = a.svd_with_settings(&SvdSettings { max_sweeps: 1 }).unwrap();
+
+    // The starved run's singular values differ measurably from the converged run's.
+    let mut max_difference: f64 = 0.0;
+    for index in 0..6 {
+        let difference =
+            (converged.singular_values()[index] - starved.singular_values()[index]).abs();
+        if difference > max_difference {
+            max_difference = difference;
+        }
+    }
+    assert!(max_difference > 1e-6);
 }


### PR DESCRIPTION
Closes #156.

## Summary

- Introduces a new public struct `SvdSettings` with a configurable `max_sweeps` field defaulting to 60 for the one-sided Jacobi SVD.
- Adds a new method `Matrix::svd_with_settings()` that takes `SvdSettings` to control the sweep budget, preserving existing behavior via `Matrix::svd()`.
- Adds tests verifying that the default sweep budget matches current behavior and that custom sweep budgets affect convergence as expected.
- Updates CHANGELOG.md with an entry describing the new configurable sweep budget feature.

## AI-assistance disclosure

Full transparency: Hatbox's autonomous agent pipeline built this one - it triaged the issue, wrote the fix, and added the tests; a human reviewed and shipped it. Model/behavior envelope: `sonnet-5 x 0.2 x R1 + enforcing gate`. Ran green against the full suite before it left the hangar - no hand-waving, no invented APIs.

-- Hatbox
