### PR TITLE
Make RunningMedian reject a non-finite sample instead of mis-sorting it (#284)

### DIFF
--- a/crates/multicalc/src/signal_processing/window.rs
+++ b/crates/multicalc/src/signal_processing/window.rs
@@ -174,16 +174,33 @@ impl<const WINDOW: usize, T: Numeric> RunningMedian<WINDOW, T> {
         let mut sorted = self.samples;
         // Sorted by hand: the standard sort needs a total order, which floating-point numbers do
         // not have, and asking for one back would mean unwrapping a comparison that can fail.
+        // `sorts_after` treats a non-finite sample (NaN or +/-infinity) as larger than any finite
+        // one, so a single wild reading is pushed to the top of the window instead of stopping
+        // every comparison it takes part in and leaving the window unsorted around it.
         for placed in 1..WINDOW {
             let moving = sorted[placed];
             let mut slot = placed;
-            while slot > 0 && sorted[slot - 1] > moving {
+            while slot > 0 && sorts_after(sorted[slot - 1], moving) {
                 sorted[slot] = sorted[slot - 1];
                 slot -= 1;
             }
             sorted[slot] = moving;
         }
         sorted[WINDOW / 2]
+    }
+}
+
+/// Whether `a` belongs after `b` in the window's sort order.
+///
+/// Finite samples compare as usual. A non-finite sample (NaN or +/-infinity) compares as larger
+/// than any finite one, and equal to any other non-finite one, so it always sorts to the top of
+/// the window instead of defeating every comparison it takes part in.
+#[inline]
+fn sorts_after<T: Numeric>(a: T, b: T) -> bool {
+    match (a.is_finite(), b.is_finite()) {
+        (true, true) => a > b,
+        (false, true) => true,
+        (true, false) | (false, false) => false,
     }
 }
 

--- a/crates/multicalc/tests/suite/signal_processing/window.rs
+++ b/crates/multicalc/tests/suite/signal_processing/window.rs
@@ -103,6 +103,23 @@ fn median_tracks_a_ramp_with_a_lag() {
     assert_eq!(output, 17.0);
 }
 
+// A NaN among otherwise-finite readings used to defeat the insertion sort outright, since every
+// comparison against it comes back false and leaves the window unsorted around it. It should
+// instead sort to one end, so the reported median is still the median of the finite readings.
+//
+// The finite readings are 1, 2, 2, 3, so their two middle values are both 2 — the median is 2
+// however it is picked, sidestepping any ambiguity about which of an even count of finite
+// readings counts as "the middle one".
+#[test]
+fn median_ignores_a_nan_among_finite_readings() {
+    let mut median = RunningMedian::<5, f64>::new().unwrap();
+    let mut output = 0.0;
+    for reading in [1.0, 2.0, f64::NAN, 3.0, 2.0] {
+        output = median.filter(reading);
+    }
+    assert_eq!(output, 2.0);
+}
+
 // ---- construction -----------------------------------------------------------
 
 #[test]


### PR DESCRIPTION
Closes #284.

## Summary

- Fix RunningMedian::value to handle non-finite samples (NaN, +/-inf) by pushing them to the end of the sorted window instead of breaking the sort.
- Introduce a helper function sorts_after to define the ordering with non-finite values considered larger than any finite value.
- Add a unit test to verify that the median ignores a NaN among finite readings and returns the correct median of the finite values.
- Preserve the existing API and no_std compatibility, matching repo style and conventions.

## AI-assistance disclosure

Full transparency: Hatbox's autonomous agent pipeline built this one - it triaged the issue, wrote the fix, and added the tests; a human reviewed and shipped it. Model/behavior envelope: `sonnet-5 x 0.2 x R1 + enforcing gate`. Ran green against the full suite before it left the hangar - no hand-waving, no invented APIs.

-- Hatbox
