### PR TITLE
fix: scale finite-difference steps by scalar epsilon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Finite-difference step scaling and validation.** Default steps now follow the scalar type's
+  machine epsilon and the chosen stencil, improving `f32` accuracy. Negative and non-finite steps
+  are rejected instead of reversing the stencil or returning NaN.
+
 - **`ExponentialMap::integrate_attitude` input validation.** A non-finite timestep, a
 non-positive timestep, or a non-finite rate from the caller's `angular_rate_at` callback
 used to silently produce a NaN orientation or integrate backwards without comment.

--- a/crates/multicalc/src/error.rs
+++ b/crates/multicalc/src/error.rs
@@ -37,6 +37,8 @@ pub enum DiffError {
     OrderUnsupported,
     /// A finite-difference step size of zero was supplied.
     StepSizeZero,
+    /// A finite-difference step size was negative, infinite, or NaN.
+    InvalidStepSize,
     /// A variable index was outside the bounds of the point array.
     IndexOutOfRange,
     /// An empty set of functions was supplied where at least one was required.
@@ -553,6 +555,7 @@ impl core::fmt::Display for DiffError {
             DiffError::OrderZero => "derivative order cannot be zero",
             DiffError::OrderUnsupported => "derivative order is not supported",
             DiffError::StepSizeZero => "step size cannot be zero",
+            DiffError::InvalidStepSize => "step size must be finite and positive",
             DiffError::IndexOutOfRange => "variable index out of range",
             DiffError::EmptyFunctionSet => "function set cannot be empty",
         })

--- a/crates/multicalc/src/numerical_derivative/finite_difference.rs
+++ b/crates/multicalc/src/numerical_derivative/finite_difference.rs
@@ -24,7 +24,7 @@ fn offsets<T: Numeric>(method: FiniteDifferenceMode) -> (T, T, T) {
 /// Configuration shared by the single- and multi-variable finite-difference differentiators.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct FiniteDifferenceConfig<T = f64> {
-    /// The finite-difference step size. See [`mode::DEFAULT_STEP_SIZE`].
+    /// The finite-difference step size. See [`FiniteDifferenceMode::default_step_size`].
     pub step_size: T,
     /// Forward, Backward or Central difference.
     pub method: FiniteDifferenceMode,
@@ -36,9 +36,10 @@ pub struct FiniteDifferenceConfig<T = f64> {
 impl<T: Numeric> Default for FiniteDifferenceConfig<T> {
     /// Central difference with the default step size and multiplier; best for most cases.
     fn default() -> Self {
+        let method = FiniteDifferenceMode::Central;
         FiniteDifferenceConfig {
-            step_size: T::from_f64(mode::DEFAULT_STEP_SIZE),
-            method: FiniteDifferenceMode::Central,
+            step_size: method.default_step_size(),
+            method,
             step_size_multiplier: T::from_f64(mode::DEFAULT_STEP_SIZE_MULTIPLIER),
         }
     }
@@ -55,10 +56,13 @@ impl<T: Numeric> FiniteDifferenceConfig<T> {
         }
     }
 
-    /// Returns [`DiffError::StepSizeZero`] if the step size is zero.
+    /// Returns an error if the step size is zero, negative, infinite, or NaN.
     fn check_step_size(&self) -> Result<(), DiffError> {
         if self.step_size == T::ZERO {
             return Err(DiffError::StepSizeZero);
+        }
+        if !self.step_size.is_finite() || self.step_size < T::ZERO {
+            return Err(DiffError::InvalidStepSize);
         }
         Ok(())
     }

--- a/crates/multicalc/src/numerical_derivative/mode.rs
+++ b/crates/multicalc/src/numerical_derivative/mode.rs
@@ -1,3 +1,5 @@
+use crate::scalar::Numeric;
+
 /// The finite-difference stencil used to approximate a derivative.
 ///
 /// Central is the most accurate for most cases; start there and tweak the mode and step size
@@ -12,7 +14,40 @@ pub enum FiniteDifferenceMode {
     Central,
 }
 
-/// Default finite-difference step size.
-pub const DEFAULT_STEP_SIZE: f64 = 1.0e-5;
+impl FiniteDifferenceMode {
+    /// Returns the default step size for this stencil and scalar type.
+    ///
+    /// Central differences balance rounding and truncation error at the cube root of machine
+    /// epsilon. First-order one-sided differences use its square root.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use multicalc::numerical_derivative::FiniteDifferenceMode;
+    ///
+    /// assert_eq!(
+    ///     FiniteDifferenceMode::Central.default_step_size::<f32>(),
+    ///     f32::EPSILON.cbrt()
+    /// );
+    /// assert_eq!(
+    ///     FiniteDifferenceMode::Forward.default_step_size::<f64>(),
+    ///     f64::EPSILON.sqrt()
+    /// );
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn default_step_size<T: Numeric>(self) -> T {
+        match self {
+            FiniteDifferenceMode::Forward | FiniteDifferenceMode::Backward => T::EPSILON.sqrt(),
+            FiniteDifferenceMode::Central => T::EPSILON.cbrt(),
+        }
+    }
+}
+
+/// Default central finite-difference step size for `f64`.
+///
+/// Generic code should use [`FiniteDifferenceMode::default_step_size`] so the value follows both
+/// the scalar type and stencil.
+pub const DEFAULT_STEP_SIZE: f64 = 6.055_454_452_393_343e-6;
 /// Default factor the step is scaled by at each recursion level (third derivatives and higher).
 pub const DEFAULT_STEP_SIZE_MULTIPLIER: f64 = 10.0;

--- a/crates/multicalc/tests/suite/numerical_derivative.rs
+++ b/crates/multicalc/tests/suite/numerical_derivative.rs
@@ -333,16 +333,84 @@ fn fd_jacobian_is_column_seeded() {
 
 #[test]
 fn fd_single_derivative_modes() {
-    // x^2/2, derivative x; check all three finite-difference modes still work
+    // x^2/2, derivative x; check every mode with its type-scaled default step.
     let function = scalar_fn!(|x| constant(0.5) * x * x);
     for mode in [
         FiniteDifferenceMode::Forward,
         FiniteDifferenceMode::Backward,
         FiniteDifferenceMode::Central,
     ] {
-        let mut derivator = FiniteDifferenceSingle::default();
-        derivator.config.method = mode;
+        let derivator = FiniteDifferenceSingle::from_parameters(
+            mode.default_step_size::<f64>(),
+            mode,
+            DEFAULT_STEP_SIZE_MULTIPLIER,
+        );
         assert!(f64::abs(derivator.differentiate(1, &function, 2.0).unwrap() - 2.0) < 0.001);
+    }
+}
+
+#[test]
+fn fd_default_step_scales_with_scalar_type() {
+    assert_eq!(
+        FiniteDifferenceSingle::<f32>::default().config.step_size,
+        f32::EPSILON.cbrt()
+    );
+    assert_eq!(
+        FiniteDifferenceSingle::<f64>::default().config.step_size,
+        f64::EPSILON.cbrt()
+    );
+    for mode in [
+        FiniteDifferenceMode::Forward,
+        FiniteDifferenceMode::Backward,
+    ] {
+        assert_eq!(mode.default_step_size::<f32>(), f32::EPSILON.sqrt());
+        assert_eq!(mode.default_step_size::<f64>(), f64::EPSILON.sqrt());
+    }
+}
+
+#[test]
+fn fd_default_is_accurate_at_f32() {
+    // f(x) = x²/2, so f'(2) = 2. The error bar follows the expected rounding scale for a
+    // central difference whose step is cbrt(epsilon), rather than a fixed decimal tolerance.
+    let function = scalar_fn!(|x| constant(0.5) * x * x);
+    let derivator = FiniteDifferenceSingle::<f32>::default();
+    let derivative = derivator.differentiate(1, &function, 2.0_f32).unwrap();
+    let step = f32::EPSILON.cbrt();
+
+    assert!((derivative - 2.0).abs() < 4.0 * step * step);
+}
+
+#[test]
+fn fd_explicit_positive_step_is_preserved() {
+    // A forward difference of x²/2 at x=2 is exactly 2 + step/2.
+    let function = scalar_fn!(|x| constant(0.5) * x * x);
+    let step = 0.25_f64;
+    let derivator = FiniteDifferenceSingle::from_parameters(
+        step,
+        FiniteDifferenceMode::Forward,
+        DEFAULT_STEP_SIZE_MULTIPLIER,
+    );
+
+    assert_eq!(derivator.config.step_size, step);
+    assert_eq!(
+        derivator.differentiate(1, &function, 2.0).unwrap(),
+        2.0 + step / 2.0
+    );
+}
+
+#[test]
+fn fd_invalid_step_error() {
+    let function = scalar_fn!(|x| constant(0.5) * x * x);
+    for step in [-1.0_f64, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let derivator = FiniteDifferenceSingle::from_parameters(
+            step,
+            FiniteDifferenceMode::Central,
+            DEFAULT_STEP_SIZE_MULTIPLIER,
+        );
+        assert_eq!(
+            derivator.differentiate(1, &function, 2.0).unwrap_err(),
+            DiffError::InvalidStepSize
+        );
     }
 }
 


### PR DESCRIPTION
## What & why

Addresses the finite-difference half of #229. Default step sizes now derive from the scalar type's machine epsilon (`cbrt` for central differences and `sqrt` for one-sided stencils), which restores useful `f32` accuracy. Negative and non-finite steps return a typed error while zero retains `DiffError::StepSizeZero`; explicit positive steps are unchanged. The `Rk45` half is intentionally left for a separate PR as requested.

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)

## Validation

- `cargo test -p multicalc` on Rust 1.85 and stable
- `cargo test -p multicalc --features alloc` on Rust 1.85 and stable
- `cargo fmt --all --check`
- `cargo clippy -p multicalc --all-targets --features alloc -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p multicalc --no-deps --all-features`
- `cargo test -p multicalc --all-features --doc`
- `cargo build -p multicalc --no-default-features --target thumbv7em-none-eabi`
- `cargo publish -p multicalc --dry-run --allow-dirty`
