### PR TITLE
Add host-only Python bindings crate multicalc-py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,24 @@ jobs:
           cargo run -p multicalc-qa --bin gen_accuracy_tables
           git diff --exit-code benchmarks/*.md
 
+  python-bindings:
+    name: python bindings (host-only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Develop + smoke test
+        working-directory: crates/multicalc-py
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install -U pip maturin pytest
+          maturin develop
+          python -m pytest tests/ -v
+
   lint:
     name: fmt + clippy
     runs-on: ubuntu-latest
@@ -89,6 +107,8 @@ jobs:
         run: cargo clippy -p multicalc-robot-model --all-targets -- -D warnings
       - name: No Rerun without the viewer feature
         run: "! cargo tree -p multicalc-robot-model -i rerun"
+      - name: Clippy (python bindings)
+        run: cargo clippy -p multicalc-py --all-targets -- -D warnings
       - name: No nightly features
         run: |
           if grep -rnE '#!\[feature\(|generic_const_exprs' crates/*/src; then
@@ -158,7 +178,7 @@ jobs:
   ci-success:
     name: CI success
     if: always()
-    needs: [matrix, test, qa, lint, docs, no_std, package]
+    needs: [matrix, test, qa, python-bindings, lint, docs, no_std, package]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any dependency failed or was cancelled

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -89,6 +89,24 @@ jobs:
           cargo run -p multicalc-qa --bin gen_accuracy_tables
           git diff --exit-code benchmarks/*.md
 
+  python-bindings:
+    name: python bindings (host-only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Develop + smoke test
+        working-directory: crates/multicalc-py
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install -U pip maturin pytest
+          maturin develop
+          python -m pytest tests/ -v
+
   lint:
     name: fmt + clippy
     runs-on: ubuntu-latest
@@ -105,6 +123,8 @@ jobs:
         run: cargo clippy -p multicalc-robot-model --all-targets -- -D warnings
       - name: No Rerun without the viewer feature
         run: "! cargo tree -p multicalc-robot-model -i rerun"
+      - name: Clippy (python bindings)
+        run: cargo clippy -p multicalc-py --all-targets -- -D warnings
       - name: No nightly features
         run: |
           if grep -rnE '#!\[feature\(|generic_const_exprs' crates/*/src; then

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 *.pyc
 smoke-*.txt
 tools/qa/gen/.venv/
+.venv/
+.pytest_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pairs and the rest — sorted and without repeats, so a caller can tell a model that loaded whole
   from one that loaded minus the half that mattered. Anything that could change a mass is still
   refused outright rather than recorded. @Thiago316316 (#305)
+- **Host-only Python bindings.** `multicalc-py` is a workspace crate (`publish = false`) with a
+  thin PyO3/maturin surface over a slice of crate-root `multicalc` (`f64` only, sizes fixed in
+  the type name). Import `multicalc_py`. Not published to crates.io or PyPI. @rtmongold (#330)
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/multicalc",
+    "crates/multicalc-py",
     "crates/multicalc-robot-model",
     "tools/embedded-smoke",
     "tools/qa",

--- a/crates/multicalc-py/Cargo.toml
+++ b/crates/multicalc-py/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "multicalc-py"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Python bindings for multicalc (host-only)"
+repository.workspace = true
+publish = false
+
+[lib]
+name = "multicalc_py"
+crate-type = ["cdylib"]
+
+[dependencies]
+multicalc = { path = "../multicalc", features = ["alloc"] }
+pyo3 = { version = "0.27", features = ["extension-module"] }
+
+[lints.rust]
+unsafe_code = "allow"
+
+[lints.clippy]
+type_complexity = "allow"
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+min_ident_chars = "warn"

--- a/crates/multicalc-py/README.md
+++ b/crates/multicalc-py/README.md
@@ -1,0 +1,75 @@
+# multicalc-py
+
+Python bindings for [`multicalc`](../multicalc), built with PyO3 and maturin.
+
+This is a workspace-internal crate (`publish = false`): host-only development bindings,
+not published to crates.io or PyPI on their own. Import name is `multicalc_py`.
+
+Requires CPython **3.10+**. On **3.14**, the crate needs PyO3 **0.27+** (already pinned
+in `Cargo.toml`).
+
+## Develop
+
+From this directory:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -U pip maturin pytest
+maturin develop
+```
+
+`maturin develop` needs an active venv (or a `.venv` in this directory / a parent). Prefer
+`python -m pytest` so you do not pick up a system `pytest`.
+
+## Test
+
+```bash
+python -m pytest tests/ -v
+cargo clippy -p multicalc-py --all-targets -- -D warnings
+```
+
+PR CI runs the same path on Python 3.12 (`maturin develop` + `pytest`) and
+`cargo clippy -p multicalc-py --all-targets -- -D warnings`.
+
+## What is exposed
+
+Host `f64` only. Const-generic sizes are fixed in the class name. This is a slice of
+the crate-root API, not every `multicalc` type or method.
+
+| Area | Python names |
+| --- | --- |
+| Basics | `version()` |
+| Errors | `CalcError`, `LinalgError`, `DiffError`, `IntegrateError`, `SolveError`, `KinematicsError`, `SpatialError`, `EstimateError`, `SignalError`, `ControlError`, `DynamicsError`, `PlantError`, `MappingError`, `MotionError`, `PolynomialError` |
+| Linear algebra | `Vector2`/`3`/`4`/`6`, `Matrix2`/`3`/`4`/`6` (solve, Cholesky, LU, SVD) |
+| Spatial | `Quaternion`, `SO2`, `SO3`, `SE2`, `SE3`, `Twist`, `Wrench`, `SpatialInertia`, `FreeJointState` |
+| Control | `Pid`, `Lqr2x1`, `GeometricAttitudeController`, `FollowTheGap5`, `FollowTheGapOutput`, `ThrustCommand`, `pure_pursuit_curvature`, `thrust_command_from_acceleration` |
+| Polynomials | `Polynomial2`…`Polynomial8`, `PiecewisePolynomial2`, `MultivariatePolynomial2` |
+| Calculus | `derivative`, `second_derivative`, `partial`, `integral` |
+| Roots | `bisection`, `brent`, `newton` |
+| ODE | `rk4_step`, `rk45_solve`, `exponential_map_attitude_step` (2-state) |
+| Discretization | `zoh`, `van_loan`, `q_discrete_white_noise` |
+| Signal | `OnePoleLowPass`, `Biquad`, `Deadband`, `SlewRateLimiter`, `MovingAverage4`, `RunningMedian5` |
+| Random | `Pcg32` |
+| Estimation | `KalmanFilter2x1`, `MadgwickFilter`, `MahonyFilter`, `ParticleFilter2x2` |
+| Kinematics / motion / dynamics | `DifferentialDrive`, `KinematicTree2`, `PolylinePath8x2`, `RigidBody` |
+| Plant / mapping | `MultirotorMixer4`, `RotorLag4`, `ScanGeometry5`, `DynamicOccupancyGrid` |
+| Autodiff / optimization | `Dual`, `HyperDual`, `Jet7`, `GaussNewton2x2`, `LevenbergMarquardt2x2` |
+
+Python residuals and ODE right-hand sides are evaluated as `f64` (finite differences).
+`Dual` / `HyperDual` / `Jet7` are separate types; they are not passed through those callbacks.
+
+## Example
+
+```python
+import multicalc_py
+
+print(multicalc_py.version())
+
+a = multicalc_py.Vector4([1.0, 2.0, 3.0, 4.0])
+b = multicalc_py.Vector4([4.0, 3.0, 2.0, 1.0])
+assert a.dot(b) == 20.0
+
+pid = multicalc_py.Pid(2.0, 1.0, 0.0, 0.01)
+assert abs(pid.update(1.0, 0.0) - 2.01) < 1e-12
+```

--- a/crates/multicalc-py/pyproject.toml
+++ b/crates/multicalc-py/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["maturin>=1.4,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "multicalc_py"
+dynamic = ["version"]
+description = "Python bindings for multicalc"
+requires-python = ">=3.10"
+classifiers = [
+  "Programming Language :: Rust",
+  "Programming Language :: Python :: Implementation :: CPython",
+]
+
+[tool.maturin]
+module-name = "multicalc_py"
+manifest-path = "Cargo.toml"

--- a/crates/multicalc-py/src/autodiff.rs
+++ b/crates/multicalc-py/src/autodiff.rs
@@ -1,0 +1,160 @@
+use multicalc::scalar::{Dual, HyperDual, Jet};
+use pyo3::prelude::*;
+
+/// First-order dual number (`value + deriv ε`).
+#[pyclass(name = "Dual")]
+pub struct PyDual {
+    inner: Dual,
+}
+
+#[pymethods]
+impl PyDual {
+    /// Real part and first derivative.
+    #[new]
+    fn new(value: f64, deriv: f64) -> Self {
+        Self {
+            inner: Dual::new(value, deriv),
+        }
+    }
+
+    /// Independent variable (`deriv = 1`).
+    #[staticmethod]
+    fn variable(value: f64) -> Self {
+        Self {
+            inner: Dual::variable(value),
+        }
+    }
+
+    /// Constant (`deriv = 0`).
+    #[staticmethod]
+    fn constant(value: f64) -> Self {
+        Self {
+            inner: Dual::constant(value),
+        }
+    }
+
+    #[getter]
+    fn value(&self) -> f64 {
+        self.inner.value
+    }
+
+    /// First derivative (ε coefficient).
+    #[getter]
+    fn deriv(&self) -> f64 {
+        self.inner.deriv
+    }
+
+    fn __add__(&self, other: &Self) -> Self {
+        Self {
+            inner: self.inner + other.inner,
+        }
+    }
+
+    fn __sub__(&self, other: &Self) -> Self {
+        Self {
+            inner: self.inner - other.inner,
+        }
+    }
+
+    fn __mul__(&self, other: &Self) -> Self {
+        Self {
+            inner: self.inner * other.inner,
+        }
+    }
+
+    fn __truediv__(&self, other: &Self) -> Self {
+        Self {
+            inner: self.inner / other.inner,
+        }
+    }
+}
+
+/// Hyper-dual number for mixed second derivatives.
+#[pyclass(name = "HyperDual")]
+pub struct PyHyperDual {
+    inner: HyperDual,
+}
+
+#[pymethods]
+impl PyHyperDual {
+    /// Real part and `ε1`, `ε2`, `ε1ε2` coefficients.
+    #[new]
+    fn new(real: f64, eps1: f64, eps2: f64, eps1eps2: f64) -> Self {
+        Self {
+            inner: HyperDual::new(real, eps1, eps2, eps1eps2),
+        }
+    }
+
+    /// Independent variable (`eps1 = 1`).
+    #[staticmethod]
+    fn variable(real: f64) -> Self {
+        Self {
+            inner: HyperDual::variable(real),
+        }
+    }
+
+    #[getter]
+    fn real(&self) -> f64 {
+        self.inner.real
+    }
+
+    #[getter]
+    fn eps1(&self) -> f64 {
+        self.inner.eps1
+    }
+
+    #[getter]
+    fn eps2(&self) -> f64 {
+        self.inner.eps2
+    }
+
+    #[getter]
+    fn eps1eps2(&self) -> f64 {
+        self.inner.eps1eps2
+    }
+
+    fn __mul__(&self, other: &Self) -> Self {
+        Self {
+            inner: self.inner * other.inner,
+        }
+    }
+}
+
+/// Truncated Taylor jet of length 7.
+#[pyclass(name = "Jet7")]
+pub struct PyJet7 {
+    inner: Jet<f64, 7>,
+}
+
+#[pymethods]
+impl PyJet7 {
+    /// Independent variable.
+    #[staticmethod]
+    fn variable(value: f64) -> Self {
+        Self {
+            inner: Jet::<f64, 7>::variable(value),
+        }
+    }
+
+    fn value(&self) -> f64 {
+        self.inner.value()
+    }
+
+    /// Derivative of the given order (`0` is the value).
+    fn derivative(&self, order: usize) -> f64 {
+        self.inner.derivative(order)
+    }
+
+    fn __mul__(&self, other: &Self) -> Self {
+        Self {
+            inner: self.inner * other.inner,
+        }
+    }
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_class::<PyDual>()?;
+    module.add_class::<PyHyperDual>()?;
+    module.add_class::<PyJet7>()?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/calculus.rs
+++ b/crates/multicalc-py/src/calculus.rs
@@ -1,0 +1,66 @@
+use multicalc::numerical_derivative::{
+    DerivatorMultiVariable, DerivatorSingleVariable, FiniteDifferenceMulti, FiniteDifferenceSingle,
+};
+use multicalc::numerical_integration::integral;
+use multicalc::scalar::ScalarFn;
+use pyo3::prelude::*;
+
+use crate::callables::{PythonScalarFn, PythonScalarFn2};
+use crate::errors;
+
+/// First derivative of a scalar callable at `point` (finite difference).
+#[pyfunction(name = "derivative")]
+fn bind_derivative(callback: Py<PyAny>, point: f64) -> PyResult<f64> {
+    let function = PythonScalarFn::new(callback);
+    function.finish(
+        FiniteDifferenceSingle::default()
+            .first_derivative(&function, point)
+            .map_err(errors::diff_error),
+    )
+}
+
+/// Second derivative of a scalar callable at `point` (finite difference).
+#[pyfunction(name = "second_derivative")]
+fn bind_second_derivative(callback: Py<PyAny>, point: f64) -> PyResult<f64> {
+    let function = PythonScalarFn::new(callback);
+    function.finish(
+        FiniteDifferenceSingle::default()
+            .second_derivative(&function, point)
+            .map_err(errors::diff_error),
+    )
+}
+
+/// Partial derivative of a 2-argument `callback` at a length-2 `point`.
+#[pyfunction(name = "partial")]
+fn bind_partial(callback: Py<PyAny>, variable_index: usize, point: Vec<f64>) -> PyResult<f64> {
+    if point.len() != 2 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "partial currently needs a 2-vector",
+        ));
+    }
+    let function = PythonScalarFn2::new(callback);
+    let coordinates = [point[0], point[1]];
+    function.finish(
+        FiniteDifferenceMulti::default()
+            .first_partial_derivative(&function, variable_index, &coordinates)
+            .map_err(errors::diff_error),
+    )
+}
+
+/// Definite integral of a scalar callable from `lower` to `upper`.
+#[pyfunction(name = "integral")]
+fn bind_integral(callback: Py<PyAny>, lower: f64, upper: f64) -> PyResult<f64> {
+    let function = PythonScalarFn::new(callback);
+    function.finish(
+        integral(&|argument| function.eval(argument), [lower, upper])
+            .map_err(errors::integrate_error),
+    )
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_function(wrap_pyfunction!(bind_derivative, module)?)?;
+    module.add_function(wrap_pyfunction!(bind_second_derivative, module)?)?;
+    module.add_function(wrap_pyfunction!(bind_partial, module)?)?;
+    module.add_function(wrap_pyfunction!(bind_integral, module)?)?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/callables.rs
+++ b/crates/multicalc-py/src/callables.rs
@@ -1,0 +1,214 @@
+use multicalc::scalar::{Numeric, ScalarFn, ScalarFnN};
+use pyo3::prelude::*;
+
+use std::cell::RefCell;
+
+#[allow(clippy::min_ident_chars)]
+mod shared {
+    pub(super) use std::rc::Rc as ReferenceCounter;
+}
+use shared::ReferenceCounter;
+
+use multicalc::linear_algebra::Vector;
+
+/// First Python callback failure during a multicalc call; re-raised at the pyfunction boundary.
+#[derive(Clone, Default)]
+pub(crate) struct CallbackError(ReferenceCounter<RefCell<Option<PyErr>>>);
+
+impl CallbackError {
+    fn stash(&self, err: PyErr) {
+        let mut slot = self.0.borrow_mut();
+        if slot.is_none() {
+            *slot = Some(err);
+        }
+    }
+
+    pub(crate) fn take(&self) -> Option<PyErr> {
+        self.0.borrow_mut().take()
+    }
+
+    pub(crate) fn finish<T>(&self, result: PyResult<T>) -> PyResult<T> {
+        if let Some(err) = self.take() {
+            return Err(err);
+        }
+        result
+    }
+}
+
+fn stash_scalar_err(error: &CallbackError, err: PyErr) -> f64 {
+    error.stash(err);
+    f64::NAN
+}
+
+fn stash_vector_err<S: Numeric>(_error: &CallbackError) -> [S; 2] {
+    [S::from_f64(f64::NAN), S::from_f64(f64::NAN)]
+}
+
+/// Reinterpret a `Numeric` scalar as `f64` for a Python callback.
+///
+/// Python only speaks `f64`. The finite-difference and explicit-`f64` paths in this crate
+/// evaluate `ScalarFn` / `VectorFn` at `f64`. Autodiff types (`Dual`, `HyperDual`, `Jet`)
+/// are wider than eight bytes and must not be passed through here.
+fn read_as_f64<S: Numeric>(scalar: &S) -> f64 {
+    debug_assert_eq!(core::mem::size_of::<S>(), core::mem::size_of::<f64>());
+    // SAFETY: the scalar is `Copy`. These `eval` impls are only reached with `f64`, so the
+    // object is a valid `f64` and the sizes match. The debug_assert above fails if an
+    // autodiff scalar (larger than `f64`) is ever used.
+    unsafe { core::ptr::read((scalar as *const S).cast::<f64>()) }
+}
+
+pub(crate) struct PythonScalarFn {
+    callback: Py<PyAny>,
+    error: CallbackError,
+}
+
+impl PythonScalarFn {
+    pub(crate) fn new(callback: Py<PyAny>) -> Self {
+        Self {
+            callback,
+            error: CallbackError::default(),
+        }
+    }
+
+    pub(crate) fn finish<T>(&self, result: PyResult<T>) -> PyResult<T> {
+        self.error.finish(result)
+    }
+}
+
+impl ScalarFn for PythonScalarFn {
+    fn eval<S: Numeric>(&self, argument: S) -> S {
+        let value = read_as_f64(&argument);
+        let result = Python::attach(|python| {
+            self.callback
+                .bind(python)
+                .call1((value,))
+                .and_then(|object| object.extract::<f64>())
+        });
+        match result {
+            Ok(output) => S::from_f64(output),
+            Err(err) => S::from_f64(stash_scalar_err(&self.error, err)),
+        }
+    }
+}
+
+pub(crate) struct PythonScalarFn2 {
+    callback: Py<PyAny>,
+    error: CallbackError,
+}
+
+impl PythonScalarFn2 {
+    pub(crate) fn new(callback: Py<PyAny>) -> Self {
+        Self {
+            callback,
+            error: CallbackError::default(),
+        }
+    }
+
+    pub(crate) fn finish<T>(&self, result: PyResult<T>) -> PyResult<T> {
+        self.error.finish(result)
+    }
+}
+
+impl ScalarFnN<2> for PythonScalarFn2 {
+    fn eval<S: Numeric>(&self, point: &[S; 2]) -> S {
+        let first = read_as_f64(&point[0]);
+        let second = read_as_f64(&point[1]);
+        let result = Python::attach(|python| {
+            self.callback
+                .bind(python)
+                .call1((first, second))
+                .and_then(|object| object.extract::<f64>())
+        });
+        match result {
+            Ok(output) => S::from_f64(output),
+            Err(err) => S::from_f64(stash_scalar_err(&self.error, err)),
+        }
+    }
+}
+
+pub(crate) fn call_ode2(callback: &Py<PyAny>, time: f64, state: [f64; 2]) -> PyResult<[f64; 2]> {
+    Python::attach(|python| {
+        let output: Vec<f64> = callback
+            .bind(python)
+            .call1((time, state.to_vec()))?
+            .extract()?;
+        if output.len() != 2 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "ode callback must return 2 values",
+            ));
+        }
+        Ok([output[0], output[1]])
+    })
+}
+
+pub(crate) struct PythonOdeRate2 {
+    callback: Py<PyAny>,
+    error: CallbackError,
+}
+
+impl PythonOdeRate2 {
+    pub(crate) fn new(callback: Py<PyAny>) -> Self {
+        Self {
+            callback,
+            error: CallbackError::default(),
+        }
+    }
+
+    pub(crate) fn rate(&self) -> impl Fn(f64, &Vector<2>) -> Vector<2> + '_ {
+        move |clock, current| match call_ode2(&self.callback, clock, current.into_array()) {
+            Ok(output) => Vector::new(output),
+            Err(err) => {
+                self.error.stash(err);
+                Vector::new(stash_vector_err::<f64>(&self.error))
+            }
+        }
+    }
+
+    pub(crate) fn finish<T>(&self, result: PyResult<T>) -> PyResult<T> {
+        self.error.finish(result)
+    }
+}
+
+pub(crate) struct PythonVectorFn2x2 {
+    callback: Py<PyAny>,
+    error: CallbackError,
+}
+
+impl PythonVectorFn2x2 {
+    pub(crate) fn new(callback: Py<PyAny>) -> Self {
+        Self {
+            callback,
+            error: CallbackError::default(),
+        }
+    }
+
+    pub(crate) fn finish<T>(&self, result: PyResult<T>) -> PyResult<T> {
+        self.error.finish(result)
+    }
+}
+
+impl multicalc::scalar::VectorFn<2, 2> for PythonVectorFn2x2 {
+    fn eval<S: Numeric>(&self, point: &[S; 2]) -> [S; 2] {
+        let first = read_as_f64(&point[0]);
+        let second = read_as_f64(&point[1]);
+        let result = Python::attach(|python| {
+            self.callback
+                .bind(python)
+                .call1((first, second))
+                .and_then(|object| object.extract::<[f64; 2]>())
+        });
+        match result {
+            Ok(output) if output.len() == 2 => [S::from_f64(output[0]), S::from_f64(output[1])],
+            Ok(_) => {
+                self.error.stash(pyo3::exceptions::PyValueError::new_err(
+                    "vector callback must return 2 values",
+                ));
+                stash_vector_err(&self.error)
+            }
+            Err(err) => {
+                self.error.stash(err);
+                stash_vector_err(&self.error)
+            }
+        }
+    }
+}

--- a/crates/multicalc-py/src/control.rs
+++ b/crates/multicalc-py/src/control.rs
@@ -1,0 +1,251 @@
+use multicalc::control::{
+    FollowTheGap, FollowTheGapOutput, GeometricAttitudeController, Lqr, Pid, ThrustCommand,
+    pure_pursuit_curvature, thrust_command_from_acceleration,
+};
+use pyo3::prelude::*;
+
+use crate::convert::{matrix_from_rows, vector_from_list, vector_to_list};
+use crate::errors;
+use crate::spatial::{PySE2, PySO3};
+
+/// Discrete PID controller.
+#[pyclass(name = "Pid")]
+pub struct PyPid {
+    inner: Pid,
+}
+
+#[pymethods]
+impl PyPid {
+    /// Gains and sample period. Raises `ControlError` if the timestep is invalid.
+    #[new]
+    fn new(
+        proportional_gain: f64,
+        integral_gain: f64,
+        derivative_gain: f64,
+        timestep: f64,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            inner: Pid::new(proportional_gain, integral_gain, derivative_gain, timestep)
+                .map_err(errors::control_error)?,
+        })
+    }
+
+    fn update(&mut self, setpoint: f64, measurement: f64) -> f64 {
+        self.inner.update(setpoint, measurement)
+    }
+}
+
+/// Discrete LQR for 2 states and 1 input.
+#[pyclass(name = "Lqr2x1")]
+pub struct PyLqr2x1 {
+    inner: Lqr<2, 1>,
+}
+
+#[pymethods]
+impl PyLqr2x1 {
+    /// Discrete `state_transition`, `input_model`, `state_cost`, `input_cost` as nested lists.
+    #[new]
+    fn new(
+        state_transition: Vec<Vec<f64>>,
+        input_model: Vec<Vec<f64>>,
+        state_cost: Vec<Vec<f64>>,
+        input_cost: Vec<Vec<f64>>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            inner: Lqr::new(
+                matrix_from_rows::<2, 2>(state_transition)?,
+                matrix_from_rows::<2, 1>(input_model)?,
+                matrix_from_rows::<2, 2>(state_cost)?,
+                matrix_from_rows::<1, 1>(input_cost)?,
+            )
+            .map_err(errors::control_error)?,
+        })
+    }
+
+    fn control(&self, state: Vec<f64>) -> PyResult<Vec<f64>> {
+        Ok(vector_to_list(
+            self.inner.control(vector_from_list::<2>(state)?),
+        ))
+    }
+
+    /// Raise `ControlError` if the closed-loop discrete system is not stable.
+    fn certify_stability(&self) -> PyResult<()> {
+        self.inner
+            .certify_stability()
+            .map(|_| ())
+            .map_err(errors::control_error)
+    }
+}
+
+/// Geometric SO(3) attitude controller.
+#[pyclass(name = "GeometricAttitudeController")]
+pub struct PyGeometricAttitudeController {
+    inner: GeometricAttitudeController,
+}
+
+#[pymethods]
+impl PyGeometricAttitudeController {
+    /// Attitude/rate gains and 3×3 inertia.
+    #[new]
+    fn new(attitude_gain: f64, rate_gain: f64, inertia: Vec<Vec<f64>>) -> PyResult<Self> {
+        Ok(Self {
+            inner: GeometricAttitudeController::new(
+                attitude_gain,
+                rate_gain,
+                matrix_from_rows::<3, 3>(inertia)?,
+            )
+            .map_err(errors::control_error)?,
+        })
+    }
+
+    fn torque(
+        &self,
+        attitude: &PySO3,
+        body_rate: Vec<f64>,
+        desired_attitude: &PySO3,
+        desired_body_rate: Vec<f64>,
+        desired_body_rate_derivative: Vec<f64>,
+    ) -> PyResult<Vec<f64>> {
+        Ok(vector_to_list(self.inner.torque(
+            attitude.inner,
+            vector_from_list::<3>(body_rate)?,
+            desired_attitude.inner,
+            vector_from_list::<3>(desired_body_rate)?,
+            vector_from_list::<3>(desired_body_rate_derivative)?,
+        )))
+    }
+}
+
+/// Result of a five-beam follow-the-gap query.
+#[pyclass(name = "FollowTheGapOutput")]
+pub struct PyFollowTheGapOutput {
+    inner: FollowTheGapOutput,
+}
+
+#[pymethods]
+impl PyFollowTheGapOutput {
+    fn heading(&self) -> f64 {
+        self.inner.heading()
+    }
+
+    fn is_blocked(&self) -> bool {
+        self.inner.is_blocked()
+    }
+
+    fn minimum_clearance(&self) -> f64 {
+        self.inner.minimum_clearance()
+    }
+
+    fn body_twist(&self) -> (f64, f64) {
+        let twist = self.inner.body_twist();
+        (twist.linear(), twist.angular())
+    }
+}
+
+/// Follow-the-gap on a 5-beam scan.
+#[pyclass(name = "FollowTheGap5")]
+pub struct PyFollowTheGap5 {
+    inner: FollowTheGap<5>,
+}
+
+#[pymethods]
+impl PyFollowTheGap5 {
+    /// Sensor and chassis parameters.
+    #[staticmethod]
+    fn try_new(
+        field_of_view: f64,
+        maximum_range: f64,
+        chassis_width: f64,
+        free_range_threshold: f64,
+        cruise_speed: f64,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            inner: FollowTheGap::try_new(
+                field_of_view,
+                maximum_range,
+                chassis_width,
+                free_range_threshold,
+                cruise_speed,
+            )
+            .map_err(errors::control_error)?,
+        })
+    }
+
+    /// Heading from five ranges and a goal angle.
+    fn compute(&self, beam_range: Vec<f64>, goal_angle: f64) -> PyResult<PyFollowTheGapOutput> {
+        let ranges = vector_from_list::<5>(beam_range)?;
+        Ok(PyFollowTheGapOutput {
+            inner: self
+                .inner
+                .compute(ranges.as_array(), goal_angle)
+                .map_err(errors::control_error)?,
+        })
+    }
+}
+
+/// Collective thrust plus desired attitude.
+#[pyclass(name = "ThrustCommand")]
+pub struct PyThrustCommand {
+    inner: ThrustCommand,
+}
+
+#[pymethods]
+impl PyThrustCommand {
+    fn attitude(&self) -> PySO3 {
+        PySO3 {
+            inner: self.inner.attitude(),
+        }
+    }
+
+    fn thrust_acceleration(&self) -> f64 {
+        self.inner.thrust_acceleration()
+    }
+}
+
+/// Pure-pursuit curvature for an SE(2) pose and lookahead point.
+#[pyfunction(name = "pure_pursuit_curvature")]
+fn bind_pure_pursuit_curvature(
+    pose: &PySE2,
+    lookahead_point: Vec<f64>,
+    lookahead_distance: f64,
+) -> PyResult<f64> {
+    let curvature = pure_pursuit_curvature(
+        pose.inner,
+        vector_from_list::<2>(lookahead_point)?,
+        lookahead_distance,
+    )
+    .map_err(errors::control_error)?;
+    Ok(curvature.value())
+}
+
+/// Thrust plus attitude from a 3-vector acceleration command.
+#[pyfunction(name = "thrust_command_from_acceleration")]
+fn bind_thrust_command_from_acceleration(
+    acceleration_command: Vec<f64>,
+    desired_heading: f64,
+    gravity: f64,
+) -> PyResult<PyThrustCommand> {
+    Ok(PyThrustCommand {
+        inner: thrust_command_from_acceleration(
+            vector_from_list::<3>(acceleration_command)?,
+            desired_heading,
+            gravity,
+        )
+        .map_err(errors::control_error)?,
+    })
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_class::<PyPid>()?;
+    module.add_class::<PyLqr2x1>()?;
+    module.add_class::<PyGeometricAttitudeController>()?;
+    module.add_class::<PyFollowTheGapOutput>()?;
+    module.add_class::<PyFollowTheGap5>()?;
+    module.add_class::<PyThrustCommand>()?;
+    module.add_function(wrap_pyfunction!(bind_pure_pursuit_curvature, module)?)?;
+    module.add_function(wrap_pyfunction!(
+        bind_thrust_command_from_acceleration,
+        module
+    )?)?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/convert.rs
+++ b/crates/multicalc-py/src/convert.rs
@@ -1,0 +1,54 @@
+use multicalc::linear_algebra::{Matrix, Vector};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+pub(crate) fn vector_from_list<const COUNT: usize>(values: Vec<f64>) -> PyResult<Vector<COUNT>> {
+    if values.len() != COUNT {
+        return Err(PyValueError::new_err(format!(
+            "expected {COUNT} values, got {}",
+            values.len()
+        )));
+    }
+    let array: [f64; COUNT] = values
+        .try_into()
+        .map_err(|_| PyValueError::new_err("invalid vector length"))?;
+    Ok(Vector::new(array))
+}
+
+pub(crate) fn vector_to_list<const COUNT: usize>(vector: Vector<COUNT>) -> Vec<f64> {
+    vector.into_array().to_vec()
+}
+
+pub(crate) fn matrix_from_rows<const ROWS: usize, const COLS: usize>(
+    rows: Vec<Vec<f64>>,
+) -> PyResult<Matrix<ROWS, COLS>> {
+    if rows.len() != ROWS {
+        return Err(PyValueError::new_err(format!(
+            "expected {ROWS} rows, got {}",
+            rows.len()
+        )));
+    }
+    let mut data = [[0.0; COLS]; ROWS];
+    for (row_index, row) in rows.into_iter().enumerate() {
+        if row.len() != COLS {
+            return Err(PyValueError::new_err(format!(
+                "row {row_index} expected {COLS} values, got {}",
+                row.len()
+            )));
+        }
+        for (col_index, value) in row.into_iter().enumerate() {
+            data[row_index][col_index] = value;
+        }
+    }
+    Ok(Matrix::new(data))
+}
+
+pub(crate) fn matrix_to_rows<const ROWS: usize, const COLS: usize>(
+    matrix: Matrix<ROWS, COLS>,
+) -> Vec<Vec<f64>> {
+    matrix
+        .as_slice_rows()
+        .iter()
+        .map(|row| row.to_vec())
+        .collect()
+}

--- a/crates/multicalc-py/src/discretization.rs
+++ b/crates/multicalc-py/src/discretization.rs
@@ -1,0 +1,56 @@
+use multicalc::discretization::{q_discrete_white_noise, van_loan, zoh};
+use pyo3::prelude::*;
+
+use crate::convert::{matrix_from_rows, matrix_to_rows};
+use crate::errors;
+
+/// Zero-order hold of a 2-state, 1-input continuous linear system.
+#[pyfunction(name = "zoh")]
+fn bind_zoh(
+    state_matrix: Vec<Vec<f64>>,
+    input_matrix: Vec<Vec<f64>>,
+    timestep: f64,
+) -> PyResult<(Vec<Vec<f64>>, Vec<Vec<f64>>)> {
+    let (discrete_state, discrete_input) = zoh::<2, 1, 3, f64>(
+        matrix_from_rows::<2, 2>(state_matrix)?,
+        matrix_from_rows::<2, 1>(input_matrix)?,
+        timestep,
+    )
+    .map_err(errors::linalg_error)?;
+    Ok((
+        matrix_to_rows(discrete_state),
+        matrix_to_rows(discrete_input),
+    ))
+}
+
+/// Van Loan discretisation of a 2-state linear process (`state_matrix`, `process_noise`).
+#[pyfunction(name = "van_loan")]
+fn bind_van_loan(
+    state_matrix: Vec<Vec<f64>>,
+    process_noise: Vec<Vec<f64>>,
+    timestep: f64,
+) -> PyResult<(Vec<Vec<f64>>, Vec<Vec<f64>>)> {
+    let (discrete_state, discrete_noise) = van_loan::<2, 4, f64>(
+        matrix_from_rows::<2, 2>(state_matrix)?,
+        matrix_from_rows::<2, 2>(process_noise)?,
+        timestep,
+    )
+    .map_err(errors::linalg_error)?;
+    Ok((
+        matrix_to_rows(discrete_state),
+        matrix_to_rows(discrete_noise),
+    ))
+}
+
+/// Discrete white-noise process covariance for a 2-state integrator.
+#[pyfunction(name = "q_discrete_white_noise")]
+fn bind_q_discrete_white_noise(timestep: f64, variance: f64) -> Vec<Vec<f64>> {
+    matrix_to_rows(q_discrete_white_noise::<2, f64>(timestep, variance))
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_function(wrap_pyfunction!(bind_zoh, module)?)?;
+    module.add_function(wrap_pyfunction!(bind_van_loan, module)?)?;
+    module.add_function(wrap_pyfunction!(bind_q_discrete_white_noise, module)?)?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/dynamics.rs
+++ b/crates/multicalc-py/src/dynamics.rs
@@ -1,0 +1,49 @@
+use pyo3::prelude::*;
+
+use crate::convert::{vector_from_list, vector_to_list};
+use crate::errors;
+use crate::spatial::{PySO3, PySpatialInertia, PyWrench};
+
+/// Single rigid body with gravity.
+#[pyclass(name = "RigidBody")]
+pub struct PyRigidBody {
+    inner: multicalc::dynamics::RigidBody,
+}
+
+#[pymethods]
+impl PyRigidBody {
+    /// Inertia and gravity 3-vector.
+    #[new]
+    fn new(inertia: &PySpatialInertia, gravity: Vec<f64>) -> PyResult<Self> {
+        Ok(Self {
+            inner: multicalc::dynamics::RigidBody::new(
+                inertia.inner,
+                vector_from_list::<3>(gravity)?,
+            )
+            .map_err(errors::dynamics_error)?,
+        })
+    }
+
+    /// Linear and angular accelerations given orientation, rate, and applied wrench.
+    fn accelerations(
+        &self,
+        orientation: &PySO3,
+        angular_rate: Vec<f64>,
+        applied_wrench: &PyWrench,
+    ) -> PyResult<(Vec<f64>, Vec<f64>)> {
+        let accelerations = self.inner.accelerations(
+            orientation.inner,
+            vector_from_list::<3>(angular_rate)?,
+            applied_wrench.inner,
+        );
+        Ok((
+            vector_to_list(accelerations.linear()),
+            vector_to_list(accelerations.angular()),
+        ))
+    }
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_class::<PyRigidBody>()?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/errors.rs
+++ b/crates/multicalc-py/src/errors.rs
@@ -1,0 +1,104 @@
+use pyo3::create_exception;
+use pyo3::exceptions::PyException;
+use pyo3::prelude::*;
+
+create_exception!(_errors, CalcErrorException, PyException);
+create_exception!(_errors, LinalgErrorException, PyException);
+create_exception!(_errors, DiffErrorException, PyException);
+create_exception!(_errors, IntegrateErrorException, PyException);
+create_exception!(_errors, SolveErrorException, PyException);
+create_exception!(_errors, KinematicsErrorException, PyException);
+create_exception!(_errors, SpatialErrorException, PyException);
+create_exception!(_errors, EstimateErrorException, PyException);
+create_exception!(_errors, SignalErrorException, PyException);
+create_exception!(_errors, ControlErrorException, PyException);
+create_exception!(_errors, DynamicsErrorException, PyException);
+create_exception!(_errors, PlantErrorException, PyException);
+create_exception!(_errors, MappingErrorException, PyException);
+create_exception!(_errors, MotionErrorException, PyException);
+create_exception!(_errors, PolynomialErrorException, PyException);
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    let python = module.py();
+    module.add("CalcError", python.get_type::<CalcErrorException>())?;
+    module.add("LinalgError", python.get_type::<LinalgErrorException>())?;
+    module.add("DiffError", python.get_type::<DiffErrorException>())?;
+    module.add(
+        "IntegrateError",
+        python.get_type::<IntegrateErrorException>(),
+    )?;
+    module.add("SolveError", python.get_type::<SolveErrorException>())?;
+    module.add(
+        "KinematicsError",
+        python.get_type::<KinematicsErrorException>(),
+    )?;
+    module.add("SpatialError", python.get_type::<SpatialErrorException>())?;
+    module.add("EstimateError", python.get_type::<EstimateErrorException>())?;
+    module.add("SignalError", python.get_type::<SignalErrorException>())?;
+    module.add("ControlError", python.get_type::<ControlErrorException>())?;
+    module.add("DynamicsError", python.get_type::<DynamicsErrorException>())?;
+    module.add("PlantError", python.get_type::<PlantErrorException>())?;
+    module.add("MappingError", python.get_type::<MappingErrorException>())?;
+    module.add("MotionError", python.get_type::<MotionErrorException>())?;
+    module.add(
+        "PolynomialError",
+        python.get_type::<PolynomialErrorException>(),
+    )?;
+    Ok(())
+}
+
+pub(crate) fn linalg_error(error: multicalc::error::LinalgError) -> PyErr {
+    LinalgErrorException::new_err(format!("{error:?}"))
+}
+
+pub(crate) fn spatial_error(error: multicalc::error::SpatialError) -> PyErr {
+    SpatialErrorException::new_err(format!("{error:?}"))
+}
+
+pub(crate) fn control_error(error: multicalc::error::ControlError) -> PyErr {
+    ControlErrorException::new_err(format!("{error:?}"))
+}
+
+pub(crate) fn diff_error(error: multicalc::error::DiffError) -> PyErr {
+    DiffErrorException::new_err(format!("{error:?}"))
+}
+
+pub(crate) fn integrate_error(error: multicalc::error::IntegrateError) -> PyErr {
+    IntegrateErrorException::new_err(format!("{error:?}"))
+}
+
+pub(crate) fn solve_error(error: multicalc::error::SolveError) -> PyErr {
+    SolveErrorException::new_err(format!("{error:?}"))
+}
+
+pub(crate) fn polynomial_error(error: multicalc::error::PolynomialError) -> PyErr {
+    PolynomialErrorException::new_err(format!("{error:?}"))
+}
+
+pub(crate) fn estimation_error(error: multicalc::error::EstimationError) -> PyErr {
+    EstimateErrorException::new_err(format!("{error:?}"))
+}
+
+pub(crate) fn signal_error(error: multicalc::error::SignalError) -> PyErr {
+    SignalErrorException::new_err(format!("{error:?}"))
+}
+
+pub(crate) fn kinematics_error(error: multicalc::error::KinematicsError) -> PyErr {
+    KinematicsErrorException::new_err(format!("{error:?}"))
+}
+
+pub(crate) fn motion_error(error: multicalc::error::MotionError) -> PyErr {
+    MotionErrorException::new_err(format!("{error:?}"))
+}
+
+pub(crate) fn dynamics_error(error: multicalc::error::DynamicsError) -> PyErr {
+    DynamicsErrorException::new_err(format!("{error:?}"))
+}
+
+pub(crate) fn plant_error(error: multicalc::error::PlantError) -> PyErr {
+    PlantErrorException::new_err(format!("{error:?}"))
+}
+
+pub(crate) fn mapping_error(error: multicalc::error::MappingError) -> PyErr {
+    MappingErrorException::new_err(format!("{error:?}"))
+}

--- a/crates/multicalc-py/src/estimation.rs
+++ b/crates/multicalc-py/src/estimation.rs
@@ -1,0 +1,214 @@
+use multicalc::estimation::{
+    GaussianLikelihood, KalmanFilter, KalmanModel, MadgwickFilter, MahonyFilter, ParticleFilter,
+};
+use multicalc::linear_algebra::Matrix;
+use pyo3::prelude::*;
+
+use crate::callables::PythonVectorFn2x2;
+use crate::convert::{matrix_from_rows, matrix_to_rows, vector_from_list, vector_to_list};
+use crate::errors;
+use crate::spatial::PySO3;
+
+/// Linear Kalman filter with 2 states and 1 measurement.
+#[pyclass(name = "KalmanFilter2x1")]
+pub struct PyKalmanFilter2x1 {
+    inner: KalmanFilter<2, 1>,
+}
+
+#[pymethods]
+impl PyKalmanFilter2x1 {
+    /// Initial state/covariance and the discrete Kalman model matrices.
+    #[new]
+    fn new(
+        initial_state: Vec<f64>,
+        initial_covariance: Vec<Vec<f64>>,
+        state_transition: Vec<Vec<f64>>,
+        measurement_model: Vec<Vec<f64>>,
+        process_noise: Vec<Vec<f64>>,
+        measurement_noise: Vec<Vec<f64>>,
+    ) -> PyResult<Self> {
+        let model = KalmanModel {
+            state_transition: matrix_from_rows::<2, 2>(state_transition)?,
+            measurement_model: matrix_from_rows::<1, 2>(measurement_model)?,
+            process_noise: matrix_from_rows::<2, 2>(process_noise)?,
+            measurement_noise: matrix_from_rows::<1, 1>(measurement_noise)?,
+        };
+        Ok(Self {
+            inner: KalmanFilter::new(
+                vector_from_list(initial_state)?,
+                matrix_from_rows::<2, 2>(initial_covariance)?,
+                model,
+            ),
+        })
+    }
+
+    fn predict(&mut self) {
+        self.inner.predict();
+    }
+
+    /// Measurement update. `measurement` is length 1.
+    fn update(&mut self, measurement: Vec<f64>) -> PyResult<()> {
+        self.inner
+            .update(vector_from_list::<1>(measurement)?)
+            .map_err(errors::estimation_error)
+    }
+
+    fn state(&self) -> Vec<f64> {
+        vector_to_list(self.inner.state())
+    }
+
+    fn covariance(&self) -> Vec<Vec<f64>> {
+        matrix_to_rows(self.inner.covariance())
+    }
+}
+
+/// Madgwick IMU/AHRS filter.
+#[pyclass(name = "MadgwickFilter")]
+pub struct PyMadgwickFilter {
+    inner: MadgwickFilter,
+}
+
+#[pymethods]
+impl PyMadgwickFilter {
+    #[new]
+    fn new(orientation: &PySO3) -> Self {
+        Self {
+            inner: MadgwickFilter::new(orientation.inner),
+        }
+    }
+
+    /// Gyro, accelerometer, optional magnetometer (each length 3), and timestep.
+    fn step(
+        &mut self,
+        gyroscope: Vec<f64>,
+        accelerometer: Vec<f64>,
+        magnetometer: Option<Vec<f64>>,
+        timestep: f64,
+    ) -> PyResult<()> {
+        let field = match magnetometer {
+            Some(values) => Some(vector_from_list::<3>(values)?),
+            None => None,
+        };
+        self.inner
+            .step(
+                vector_from_list::<3>(gyroscope)?,
+                vector_from_list::<3>(accelerometer)?,
+                field,
+                timestep,
+            )
+            .map_err(errors::estimation_error)
+    }
+
+    fn orientation(&self) -> PySO3 {
+        PySO3 {
+            inner: self.inner.orientation(),
+        }
+    }
+}
+
+/// Mahony IMU/AHRS filter.
+#[pyclass(name = "MahonyFilter")]
+pub struct PyMahonyFilter {
+    inner: MahonyFilter,
+}
+
+#[pymethods]
+impl PyMahonyFilter {
+    #[new]
+    fn new(orientation: &PySO3) -> Self {
+        Self {
+            inner: MahonyFilter::new(orientation.inner),
+        }
+    }
+
+    /// Gyro, accelerometer, optional magnetometer (each length 3), and timestep.
+    fn step(
+        &mut self,
+        gyroscope: Vec<f64>,
+        accelerometer: Vec<f64>,
+        magnetometer: Option<Vec<f64>>,
+        timestep: f64,
+    ) -> PyResult<()> {
+        let field = match magnetometer {
+            Some(values) => Some(vector_from_list::<3>(values)?),
+            None => None,
+        };
+        self.inner
+            .step(
+                vector_from_list::<3>(gyroscope)?,
+                vector_from_list::<3>(accelerometer)?,
+                field,
+                timestep,
+            )
+            .map_err(errors::estimation_error)
+    }
+
+    fn orientation(&self) -> PySO3 {
+        PySO3 {
+            inner: self.inner.orientation(),
+        }
+    }
+}
+
+/// Particle filter with 2-D state and 2-D measurement.
+#[pyclass(name = "ParticleFilter2x2")]
+pub struct PyParticleFilter2x2 {
+    inner: ParticleFilter<2, 2>,
+    measurement_noise: Matrix<2, 2>,
+}
+
+#[pymethods]
+impl PyParticleFilter2x2 {
+    /// Particle count, prior mean/covariance, process noise, measurement noise, and RNG seed.
+    #[new]
+    fn new(
+        particle_count: usize,
+        initial_mean: Vec<f64>,
+        initial_covariance: Vec<Vec<f64>>,
+        process_noise: Vec<Vec<f64>>,
+        measurement_noise: Vec<Vec<f64>>,
+        seed: u64,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            inner: ParticleFilter::new(
+                particle_count,
+                vector_from_list::<2>(initial_mean)?,
+                matrix_from_rows::<2, 2>(initial_covariance)?,
+                matrix_from_rows::<2, 2>(process_noise)?,
+                seed,
+            )
+            .map_err(errors::estimation_error)?,
+            measurement_noise: matrix_from_rows::<2, 2>(measurement_noise)?,
+        })
+    }
+
+    /// Propagate particles with `process_model` (two state components in, two out).
+    fn predict(&mut self, process_model: Py<PyAny>) -> PyResult<()> {
+        let model = PythonVectorFn2x2::new(process_model);
+        model.finish(self.inner.predict(&model).map_err(errors::estimation_error))
+    }
+
+    /// Weight particles with `measurement_model` (two state components to a 2-vector prediction) and a 2-vector measurement.
+    fn update(&mut self, measurement_model: Py<PyAny>, measurement: Vec<f64>) -> PyResult<()> {
+        let likelihood = GaussianLikelihood::<2>::new(self.measurement_noise)
+            .map_err(errors::estimation_error)?;
+        let model = PythonVectorFn2x2::new(measurement_model);
+        model.finish(
+            self.inner
+                .update(&model, &likelihood, vector_from_list::<2>(measurement)?)
+                .map_err(errors::estimation_error),
+        )
+    }
+
+    fn mean(&self) -> Vec<f64> {
+        vector_to_list(self.inner.mean())
+    }
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_class::<PyKalmanFilter2x1>()?;
+    module.add_class::<PyMadgwickFilter>()?;
+    module.add_class::<PyMahonyFilter>()?;
+    module.add_class::<PyParticleFilter2x2>()?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/kinematics.rs
+++ b/crates/multicalc-py/src/kinematics.rs
@@ -1,0 +1,92 @@
+use multicalc::kinematics::{
+    BodyTwist, DifferentialDrive, Joint, JointParent, KinematicTree, WheelVelocities,
+};
+use multicalc::linear_algebra::Vector;
+use multicalc::spatial::{SE3, SO3};
+use pyo3::prelude::*;
+
+use crate::convert::{vector_from_list, vector_to_list};
+use crate::errors;
+
+/// Differential-drive kinematics.
+#[pyclass(name = "DifferentialDrive")]
+pub struct PyDifferentialDrive {
+    inner: DifferentialDrive,
+}
+
+#[pymethods]
+impl PyDifferentialDrive {
+    /// Wheel radius and wheelbase.
+    #[new]
+    fn new(wheel_radius: f64, wheelbase: f64) -> PyResult<Self> {
+        Ok(Self {
+            inner: DifferentialDrive::new(wheel_radius, wheelbase)
+                .map_err(errors::kinematics_error)?,
+        })
+    }
+
+    /// Body twist `(linear, angular)` from left and right wheel speeds.
+    fn forward(&self, left: f64, right: f64) -> (f64, f64) {
+        let twist = self.inner.forward(WheelVelocities::new(left, right));
+        (twist.linear(), twist.angular())
+    }
+
+    /// Left and right wheel speeds from a body twist.
+    fn inverse(&self, linear: f64, angular: f64) -> (f64, f64) {
+        let wheels = self.inner.inverse(BodyTwist::new(linear, angular));
+        (wheels.left(), wheels.right())
+    }
+}
+
+/// Two-joint planar kinematic tree.
+#[pyclass(name = "KinematicTree2")]
+pub struct PyKinematicTree2 {
+    inner: KinematicTree<2, 2>,
+}
+
+#[pymethods]
+impl PyKinematicTree2 {
+    /// Equal-length two-link planar arm.
+    #[staticmethod]
+    fn planar_two_link(link_length: f64) -> PyResult<Self> {
+        let axis_z = Vector::new([0.0, 0.0, 1.0]);
+        let link = SE3::from_parts(SO3::identity(), Vector::new([link_length, 0.0, 0.0]));
+        Ok(Self {
+            inner: KinematicTree::<2, 2>::try_from_joints(
+                &[
+                    Joint::revolute(axis_z, SE3::identity()),
+                    Joint::revolute(axis_z, link),
+                ],
+                &[JointParent::World, JointParent::Joint(0)],
+            )
+            .map_err(errors::kinematics_error)?,
+        })
+    }
+
+    fn __len__(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("KinematicTree2(joints={})", self.inner.len())
+    }
+
+    /// Translation of the last link for a 2-vector configuration.
+    fn forward_kinematics(&self, configuration: Vec<f64>) -> PyResult<Vec<f64>> {
+        let configuration = vector_from_list::<2>(configuration)?;
+        let state = self
+            .inner
+            .forward_kinematics(&configuration)
+            .map_err(errors::kinematics_error)?;
+        let pose = state.pose(1).ok_or_else(|| {
+            errors::kinematics_error(multicalc::error::KinematicsError::CapacityExceeded)
+        })?;
+        Ok(vector_to_list(pose.translation()))
+    }
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_class::<PyDifferentialDrive>()?;
+    module.add_class::<PyKinematicTree2>()?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/lib.rs
+++ b/crates/multicalc-py/src/lib.rs
@@ -1,0 +1,64 @@
+//! Host-only Python bindings for [`multicalc`](multicalc).
+//!
+//! Import name `multicalc_py`. Workspace crate (`publish = false`), `f64` only. Const-generic
+//! sizes are fixed at bind time (`Vector3`, `KalmanFilter2x1`, `ScanGeometry5`), not chosen at
+//! runtime. A slice of the crate-root API, not a 1:1 dump.
+//!
+//! Python callables used as residuals or ODE right-hand sides are evaluated as `f64`. Autodiff
+//! numbers (`Dual`, `HyperDual`, `Jet7`) are separate Python types and are not passed through
+//! those callbacks.
+
+mod autodiff;
+mod calculus;
+mod callables;
+mod control;
+mod convert;
+mod discretization;
+mod dynamics;
+mod errors;
+mod estimation;
+mod kinematics;
+mod linalg;
+mod mapping;
+mod motion;
+mod ode;
+mod optimization;
+mod plant;
+mod polynomial;
+mod random;
+mod roots;
+mod signal;
+mod spatial;
+
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+#[pymodule]
+fn multicalc_py<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    errors::register(module)?;
+    linalg::register(module)?;
+    control::register(module)?;
+    polynomial::register(module)?;
+    spatial::register(module)?;
+    calculus::register(module)?;
+    discretization::register(module)?;
+    ode::register(module)?;
+    roots::register(module)?;
+    random::register(module)?;
+    signal::register(module)?;
+    estimation::register(module)?;
+    kinematics::register(module)?;
+    motion::register(module)?;
+    dynamics::register(module)?;
+    plant::register(module)?;
+    mapping::register(module)?;
+    autodiff::register(module)?;
+    optimization::register(module)?;
+    module.add_function(wrap_pyfunction!(version, module)?)?;
+    module.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/linalg.rs
+++ b/crates/multicalc-py/src/linalg.rs
@@ -1,0 +1,172 @@
+use multicalc::linear_algebra::{Matrix, Vector};
+use pyo3::prelude::*;
+use pyo3::types::PyList;
+
+use crate::convert::{matrix_from_rows, matrix_to_rows, vector_from_list, vector_to_list};
+use crate::errors;
+
+macro_rules! bind_vector {
+    ($py_name:ident, $count:expr) => {
+        /// Fixed-length `f64` column vector. Length is in the type name (`Vector2`, `Vector3`, …).
+        #[pyclass]
+        pub struct $py_name {
+            pub(crate) inner: Vector<$count>,
+        }
+
+        #[pymethods]
+        impl $py_name {
+            /// Build from as many values as this vector's length.
+            #[new]
+            fn new(values: Vec<f64>) -> PyResult<Self> {
+                Ok(Self {
+                    inner: vector_from_list::<$count>(values)?,
+                })
+            }
+
+            #[staticmethod]
+            fn zeros() -> Self {
+                Self {
+                    inner: Vector::zeros(),
+                }
+            }
+
+            fn dot(&self, other: &$py_name) -> f64 {
+                self.inner.dot(other.inner)
+            }
+
+            fn to_list(&self) -> Vec<f64> {
+                vector_to_list(self.inner)
+            }
+
+            fn __len__(&self) -> usize {
+                $count
+            }
+
+            fn __repr__(&self) -> String {
+                format!("{}({:?})", stringify!($py_name), self.to_list())
+            }
+        }
+    };
+}
+
+macro_rules! bind_square_matrix {
+    ($py_name:ident, $vector_name:ident, $size:expr) => {
+        /// Square `f64` matrix. Side length is in the type name (`Matrix2`, `Matrix3`, …).
+        #[pyclass]
+        pub struct $py_name {
+            inner: Matrix<$size, $size>,
+        }
+
+        #[pymethods]
+        impl $py_name {
+            /// Build from a list of rows.
+            #[new]
+            fn new(rows: Vec<Vec<f64>>) -> PyResult<Self> {
+                Ok(Self {
+                    inner: matrix_from_rows(rows)?,
+                })
+            }
+
+            #[staticmethod]
+            fn zeros() -> Self {
+                Self {
+                    inner: Matrix::zeros(),
+                }
+            }
+
+            #[staticmethod]
+            fn identity() -> Self {
+                Self {
+                    inner: Matrix::identity(),
+                }
+            }
+
+            fn to_list(&self) -> Vec<Vec<f64>> {
+                matrix_to_rows(self.inner)
+            }
+
+            fn __len__(&self) -> usize {
+                $size
+            }
+
+            fn __repr__(&self) -> String {
+                format!("{}({:?})", stringify!($py_name), self.to_list())
+            }
+
+            fn transpose(&self) -> Self {
+                Self {
+                    inner: self.inner.transpose(),
+                }
+            }
+
+            /// Solve against `right_hand_side`. Raises `LinalgError` if this matrix is singular.
+            fn solve(&self, right_hand_side: &$vector_name) -> PyResult<$vector_name> {
+                Ok($vector_name {
+                    inner: self
+                        .inner
+                        .solve(right_hand_side.inner)
+                        .map_err(errors::linalg_error)?,
+                })
+            }
+
+            /// Lower-triangular Cholesky factor. Raises `LinalgError` if the matrix is not SPD.
+            fn cholesky(&self) -> PyResult<Self> {
+                let factor = self.inner.cholesky().map_err(errors::linalg_error)?;
+                Ok(Self {
+                    inner: factor.lower(),
+                })
+            }
+
+            /// LU factorisation as `(lower, upper, permutation)`.
+            fn lu_decompose<'python>(
+                &self,
+                python: Python<'python>,
+            ) -> PyResult<(Self, Self, Py<PyList>)> {
+                let factor = self.inner.lu_decompose().map_err(errors::linalg_error)?;
+                let lower = Self {
+                    inner: factor.lower(),
+                };
+                let upper = Self {
+                    inner: factor.upper(),
+                };
+                let perm: Vec<usize> = factor.permutation().to_vec();
+                Ok((lower, upper, PyList::new(python, perm)?.unbind()))
+            }
+
+            /// SVD as `(left, singular_values, right)`.
+            fn svd<'python>(&self, python: Python<'python>) -> PyResult<(Self, Py<PyList>, Self)> {
+                let decomposition = self.inner.svd().map_err(errors::linalg_error)?;
+                let left = Self {
+                    inner: decomposition.left(),
+                };
+                let values = vector_to_list(decomposition.singular_values());
+                let right = Self {
+                    inner: decomposition.right(),
+                };
+                Ok((left, PyList::new(python, values)?.unbind(), right))
+            }
+        }
+    };
+}
+
+bind_vector!(Vector2, 2);
+bind_vector!(Vector3, 3);
+bind_vector!(Vector4, 4);
+bind_vector!(Vector6, 6);
+
+bind_square_matrix!(Matrix2, Vector2, 2);
+bind_square_matrix!(Matrix3, Vector3, 3);
+bind_square_matrix!(Matrix4, Vector4, 4);
+bind_square_matrix!(Matrix6, Vector6, 6);
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_class::<Vector2>()?;
+    module.add_class::<Vector3>()?;
+    module.add_class::<Vector4>()?;
+    module.add_class::<Vector6>()?;
+    module.add_class::<Matrix2>()?;
+    module.add_class::<Matrix3>()?;
+    module.add_class::<Matrix4>()?;
+    module.add_class::<Matrix6>()?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/mapping.rs
+++ b/crates/multicalc-py/src/mapping.rs
@@ -1,0 +1,101 @@
+use multicalc::mapping::{DynamicOccupancyGrid, MutableOccupancyMap, OccupancyMap, ScanGeometry};
+use pyo3::prelude::*;
+
+use crate::errors;
+
+/// Five-beam planar lidar geometry.
+#[pyclass(name = "ScanGeometry5")]
+pub struct PyScanGeometry5 {
+    inner: ScanGeometry<5>,
+}
+
+#[pymethods]
+impl PyScanGeometry5 {
+    /// Field of view (radians) and maximum range.
+    #[new]
+    fn new(field_of_view: f64, maximum_range: f64) -> PyResult<Self> {
+        Ok(Self {
+            inner: ScanGeometry::<5>::try_new(field_of_view, maximum_range)
+                .map_err(errors::mapping_error)?,
+        })
+    }
+
+    /// Bearing of beam `index`. Raises `IndexError` if out of range.
+    fn beam_angle(&self, index: usize) -> PyResult<f64> {
+        self.inner.beam_angle(index).ok_or_else(|| {
+            pyo3::exceptions::PyIndexError::new_err(format!("beam index {index} out of range"))
+        })
+    }
+
+    fn __len__(&self) -> usize {
+        self.inner.num_beams()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "ScanGeometry5(beams={}, field_of_view={}, maximum_range={})",
+            self.inner.num_beams(),
+            self.inner.field_of_view(),
+            self.inner.maximum_range()
+        )
+    }
+}
+
+/// Occupancy grid with a 2D origin and uniform resolution.
+#[pyclass(name = "DynamicOccupancyGrid")]
+pub struct PyDynamicOccupancyGrid {
+    inner: DynamicOccupancyGrid,
+}
+
+#[pymethods]
+impl PyDynamicOccupancyGrid {
+    /// `columns`, `rows`, cell size, and world origin as a length-2 list.
+    #[new]
+    fn new(columns: usize, rows: usize, resolution: f64, origin: Vec<f64>) -> PyResult<Self> {
+        if origin.len() != 2 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "origin must have 2 values",
+            ));
+        }
+        Ok(Self {
+            inner: DynamicOccupancyGrid::try_new(columns, rows, resolution, [origin[0], origin[1]])
+                .map_err(errors::mapping_error)?,
+        })
+    }
+
+    /// Mark the cell containing a 2D world point as occupied.
+    fn occupy_point(&mut self, point: Vec<f64>) -> PyResult<()> {
+        if point.len() != 2 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "point must have 2 values",
+            ));
+        }
+        MutableOccupancyMap::occupy_point(&mut self.inner, [point[0], point[1]]);
+        Ok(())
+    }
+
+    fn is_occupied(&self, row: usize, column: usize) -> bool {
+        OccupancyMap::is_occupied(&self.inner, row, column)
+    }
+
+    /// Range to the first occupied cell along a ray, or `None`.
+    fn cast_ray(&self, start: Vec<f64>, bearing: f64, maximum_range: f64) -> PyResult<Option<f64>> {
+        if start.len() != 2 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "start must have 2 values",
+            ));
+        }
+        Ok(OccupancyMap::cast_ray(
+            &self.inner,
+            [start[0], start[1]],
+            bearing,
+            maximum_range,
+        ))
+    }
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_class::<PyScanGeometry5>()?;
+    module.add_class::<PyDynamicOccupancyGrid>()?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/motion.rs
+++ b/crates/multicalc-py/src/motion.rs
@@ -1,0 +1,60 @@
+use multicalc::motion::PolylinePath;
+use pyo3::prelude::*;
+
+use crate::convert::vector_from_list;
+use crate::convert::vector_to_list;
+use crate::errors;
+
+/// Planar polyline with at most 8 waypoints.
+#[pyclass(name = "PolylinePath8x2")]
+pub struct PyPolylinePath8x2 {
+    inner: PolylinePath<8, 2>,
+}
+
+#[pymethods]
+impl PyPolylinePath8x2 {
+    /// Build from 2D waypoints.
+    #[staticmethod]
+    fn try_from_points(points: Vec<Vec<f64>>) -> PyResult<Self> {
+        let mut waypoints = Vec::with_capacity(points.len());
+        for point in points {
+            waypoints.push(vector_from_list::<2>(point)?);
+        }
+        Ok(Self {
+            inner: PolylinePath::<8, 2>::try_from_points(&waypoints)
+                .map_err(errors::motion_error)?,
+        })
+    }
+
+    fn total_arc_length(&self) -> f64 {
+        self.inner.total_arc_length()
+    }
+
+    /// Point a lookahead distance along the path from `from_arc_length`.
+    fn lookahead_point(&self, from_arc_length: f64, lookahead: f64) -> PyResult<[f64; 2]> {
+        Ok(self
+            .inner
+            .lookahead_point(from_arc_length, lookahead)
+            .map_err(errors::motion_error)?
+            .into_array())
+    }
+
+    fn __len__(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn __repr__(&self) -> String {
+        let points: Vec<Vec<f64>> = self
+            .inner
+            .waypoints()
+            .iter()
+            .map(|point| vector_to_list(*point))
+            .collect();
+        format!("PolylinePath8x2({points:?})")
+    }
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_class::<PyPolylinePath8x2>()?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/ode.rs
+++ b/crates/multicalc-py/src/ode.rs
@@ -1,0 +1,61 @@
+use multicalc::ode::{ExponentialMap, Rk4, Rk45};
+use pyo3::prelude::*;
+
+use crate::callables::PythonOdeRate2;
+use crate::convert::{vector_from_list, vector_to_list};
+use crate::errors;
+use crate::spatial::PySO3;
+
+/// One RK4 step. `callback(time, state)` must return a length-2 derivative.
+#[pyfunction]
+fn rk4_step(callback: Py<PyAny>, time: f64, state: Vec<f64>, timestep: f64) -> PyResult<Vec<f64>> {
+    let state_vector = vector_from_list(state)?;
+    let rate = PythonOdeRate2::new(callback);
+    rate.finish(Ok(vector_to_list(Rk4::step(
+        &rate.rate(),
+        time,
+        &state_vector,
+        timestep,
+    ))))
+}
+
+/// Integrate a 2-state ODE from `time_start` to `time_final` with RK45.
+#[pyfunction]
+fn rk45_solve(
+    callback: Py<PyAny>,
+    time_start: f64,
+    state: Vec<f64>,
+    time_final: f64,
+) -> PyResult<Vec<f64>> {
+    let state_vector = vector_from_list(state)?;
+    let rate = PythonOdeRate2::new(callback);
+    rate.finish(
+        Rk45::default()
+            .solve(&rate.rate(), time_start, &state_vector, time_final)
+            .map(vector_to_list)
+            .map_err(errors::integrate_error),
+    )
+}
+
+/// Integrate an SO(3) attitude by exponential map over `timestep`.
+#[pyfunction]
+fn exponential_map_attitude_step(
+    orientation: &PySO3,
+    angular_rate: Vec<f64>,
+    timestep: f64,
+) -> PyResult<PySO3> {
+    Ok(PySO3 {
+        inner: ExponentialMap::attitude_step(
+            orientation.inner,
+            vector_from_list::<3>(angular_rate)?,
+            timestep,
+        ),
+    })
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_function(wrap_pyfunction!(rk4_step, module)?)?;
+    module.add_function(wrap_pyfunction!(rk45_solve, module)?)?;
+    module.add_function(wrap_pyfunction!(exponential_map_attitude_step, module)?)?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/optimization.rs
+++ b/crates/multicalc-py/src/optimization.rs
@@ -1,0 +1,96 @@
+use multicalc::numerical_derivative::FiniteDifferenceMulti;
+use multicalc::optimization::{GaussNewton, LevenbergMarquardt};
+use pyo3::prelude::*;
+
+use crate::callables::PythonVectorFn2x2;
+use crate::errors;
+
+/// Gauss–Newton for a 2-residual, 2-parameter problem (finite-difference Jacobian).
+#[pyclass(name = "GaussNewton2x2")]
+pub struct PyGaussNewton2x2 {
+    inner: GaussNewton<FiniteDifferenceMulti>,
+}
+
+#[pymethods]
+impl PyGaussNewton2x2 {
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: GaussNewton::from_derivator(FiniteDifferenceMulti::default()),
+        }
+    }
+
+    /// Minimize a two-argument `residual` from a 2-vector `initial_guess`.
+    ///
+    /// Returns `(solution, objective, evaluations)`.
+    fn minimize(
+        &self,
+        residual: Py<PyAny>,
+        initial_guess: Vec<f64>,
+    ) -> PyResult<(Vec<f64>, f64, usize)> {
+        if initial_guess.len() != 2 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "initial_guess must have 2 values",
+            ));
+        }
+        let residual_fn = PythonVectorFn2x2::new(residual);
+        let report = residual_fn.finish(
+            self.inner
+                .minimize(&residual_fn, &[initial_guess[0], initial_guess[1]])
+                .map_err(errors::solve_error),
+        )?;
+        Ok((
+            report.solution.to_vec(),
+            report.objective_function,
+            report.evaluations,
+        ))
+    }
+}
+
+/// Levenberg–Marquardt for a 2-residual, 2-parameter problem (finite-difference Jacobian).
+#[pyclass(name = "LevenbergMarquardt2x2")]
+pub struct PyLevenbergMarquardt2x2 {
+    inner: LevenbergMarquardt<FiniteDifferenceMulti>,
+}
+
+#[pymethods]
+impl PyLevenbergMarquardt2x2 {
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: LevenbergMarquardt::from_derivator(FiniteDifferenceMulti::default()),
+        }
+    }
+
+    /// Minimize a two-argument `residual` from a 2-vector `initial_guess`.
+    ///
+    /// Returns `(solution, objective, evaluations)`.
+    fn minimize(
+        &self,
+        residual: Py<PyAny>,
+        initial_guess: Vec<f64>,
+    ) -> PyResult<(Vec<f64>, f64, usize)> {
+        if initial_guess.len() != 2 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "initial_guess must have 2 values",
+            ));
+        }
+        let residual_fn = PythonVectorFn2x2::new(residual);
+        let report = residual_fn.finish(
+            self.inner
+                .minimize(&residual_fn, &[initial_guess[0], initial_guess[1]])
+                .map_err(errors::solve_error),
+        )?;
+        Ok((
+            report.solution.to_vec(),
+            report.objective_function,
+            report.evaluations,
+        ))
+    }
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_class::<PyGaussNewton2x2>()?;
+    module.add_class::<PyLevenbergMarquardt2x2>()?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/plant.rs
+++ b/crates/multicalc-py/src/plant.rs
@@ -1,0 +1,87 @@
+use multicalc::plant::{MultirotorMixer, RotorLag};
+use pyo3::prelude::*;
+
+use crate::convert::{vector_from_list, vector_to_list};
+use crate::errors;
+use crate::spatial::PyWrench;
+
+/// Four-rotor mixer (quadrotor X).
+#[pyclass(name = "MultirotorMixer4")]
+pub struct PyMultirotorMixer4 {
+    inner: MultirotorMixer<4>,
+}
+
+#[pymethods]
+impl PyMultirotorMixer4 {
+    /// Quadrotor-X mixer with thrust limits.
+    #[staticmethod]
+    fn quadrotor_x(
+        arm_length: f64,
+        torque_per_thrust: f64,
+        minimum_thrust: f64,
+        maximum_thrust: f64,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            inner: MultirotorMixer::<4>::quadrotor_x(
+                arm_length,
+                torque_per_thrust,
+                minimum_thrust,
+                maximum_thrust,
+            )
+            .map_err(errors::plant_error)?,
+        })
+    }
+
+    /// Rotor thrusts and whether any axis saturated. Returns `(thrusts, saturated)`.
+    fn rotor_thrusts(
+        &self,
+        collective_thrust: f64,
+        torque: Vec<f64>,
+    ) -> PyResult<(Vec<f64>, bool)> {
+        let commands = self
+            .inner
+            .rotor_thrusts(collective_thrust, vector_from_list::<3>(torque)?);
+        Ok((vector_to_list(commands.thrusts()), commands.saturated()))
+    }
+
+    /// Wrench from four rotor thrusts.
+    fn wrench(&self, thrusts: Vec<f64>) -> PyResult<PyWrench> {
+        Ok(PyWrench {
+            inner: self.inner.wrench(vector_from_list::<4>(thrusts)?),
+        })
+    }
+}
+
+/// First-order lag on four rotor commands.
+#[pyclass(name = "RotorLag4")]
+pub struct PyRotorLag4 {
+    inner: RotorLag<4>,
+}
+
+#[pymethods]
+impl PyRotorLag4 {
+    /// Time constant and sample period.
+    #[new]
+    fn new(lag_time: f64, tick: f64) -> PyResult<Self> {
+        Ok(Self {
+            inner: RotorLag::<4>::new(lag_time, tick).map_err(errors::plant_error)?,
+        })
+    }
+
+    /// Advance one tick toward `commanded` thrusts.
+    fn stepped(&mut self, commanded: Vec<f64>) -> PyResult<Vec<f64>> {
+        Ok(vector_to_list(
+            self.inner.stepped(vector_from_list::<4>(commanded)?),
+        ))
+    }
+
+    fn thrusts(&self) -> Vec<f64> {
+        vector_to_list(self.inner.thrusts())
+    }
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_class::<PyMultirotorMixer4>()?;
+    module.add_class::<PyRotorLag4>()?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/polynomial.rs
+++ b/crates/multicalc-py/src/polynomial.rs
@@ -1,0 +1,220 @@
+use multicalc::{MultivariatePolynomial, MultivariateTerm, PiecewisePolynomial, Polynomial};
+use pyo3::prelude::*;
+use pyo3::types::PyList;
+
+use crate::errors;
+
+fn polynomial_coefficients<const COUNT: usize>(coefficients: Vec<f64>) -> PyResult<[f64; COUNT]> {
+    if coefficients.len() != COUNT {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "expected {COUNT} coefficients, got {}",
+            coefficients.len()
+        )));
+    }
+    coefficients
+        .try_into()
+        .map_err(|_| pyo3::exceptions::PyValueError::new_err("invalid coefficient count"))
+}
+
+macro_rules! bind_polynomial {
+    ($py_name:ident, $count:expr) => {
+        /// Univariate polynomial. Coefficient count is in the type name (`Polynomial2`, …).
+        #[pyclass]
+        pub struct $py_name {
+            inner: Polynomial<$count>,
+        }
+
+        #[pymethods]
+        impl $py_name {
+            /// Coefficients, lowest degree first, matching the type length.
+            #[new]
+            fn new(coefficients: Vec<f64>) -> PyResult<Self> {
+                Ok(Self {
+                    inner: Polynomial::new(polynomial_coefficients::<$count>(coefficients)?),
+                })
+            }
+
+            fn evaluate(&self, argument: f64) -> f64 {
+                self.inner.evaluate(argument)
+            }
+
+            /// Value and first two derivatives at `argument`.
+            fn evaluate_with_derivatives(&self, argument: f64) -> [f64; 3] {
+                self.inner.evaluate_with_derivatives::<3>(argument)
+            }
+
+            fn __len__(&self) -> usize {
+                $count
+            }
+
+            fn __repr__(&self) -> String {
+                format!(
+                    "{}({:?})",
+                    stringify!($py_name),
+                    self.inner.coefficients().as_slice()
+                )
+            }
+        }
+    };
+}
+
+macro_rules! bind_polynomial_with_roots {
+    ($py_name:ident, $count:expr) => {
+        /// Univariate polynomial with real-root finding. Coefficient count is in the type name.
+        #[pyclass]
+        pub struct $py_name {
+            inner: Polynomial<$count>,
+        }
+
+        #[pymethods]
+        impl $py_name {
+            /// Coefficients, lowest degree first, matching the type length.
+            #[new]
+            fn new(coefficients: Vec<f64>) -> PyResult<Self> {
+                Ok(Self {
+                    inner: Polynomial::new(polynomial_coefficients::<$count>(coefficients)?),
+                })
+            }
+
+            fn evaluate(&self, argument: f64) -> f64 {
+                self.inner.evaluate(argument)
+            }
+
+            /// Value and first two derivatives at `argument`.
+            fn evaluate_with_derivatives(&self, argument: f64) -> [f64; 3] {
+                self.inner.evaluate_with_derivatives::<3>(argument)
+            }
+
+            /// Real roots as a Python list.
+            fn real_roots<'python>(&self, python: Python<'python>) -> PyResult<Py<PyList>> {
+                let roots = self.inner.real_roots().map_err(errors::polynomial_error)?;
+                Ok(PyList::new(python, roots.as_slice())?.unbind())
+            }
+
+            fn __len__(&self) -> usize {
+                $count
+            }
+
+            fn __repr__(&self) -> String {
+                format!(
+                    "{}({:?})",
+                    stringify!($py_name),
+                    self.inner.coefficients().as_slice()
+                )
+            }
+        }
+    };
+}
+
+bind_polynomial_with_roots!(Polynomial2, 2);
+bind_polynomial_with_roots!(Polynomial3, 3);
+bind_polynomial_with_roots!(Polynomial4, 4);
+bind_polynomial_with_roots!(Polynomial5, 5);
+bind_polynomial!(Polynomial6, 6);
+bind_polynomial!(Polynomial7, 7);
+bind_polynomial!(Polynomial8, 8);
+
+/// Two linear pieces on two spans.
+#[pyclass(name = "PiecewisePolynomial2")]
+pub struct PyPiecewisePolynomial2 {
+    inner: PiecewisePolynomial<2, 2, 1>,
+}
+
+#[pymethods]
+impl PyPiecewisePolynomial2 {
+    /// Two coefficient rows of length 2 and two positive spans.
+    #[new]
+    fn new(coefficient_rows: Vec<Vec<f64>>, spans: Vec<f64>) -> PyResult<Self> {
+        if coefficient_rows.len() != 2 || spans.len() != 2 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "PiecewisePolynomial2 needs 2 pieces and 2 spans",
+            ));
+        }
+        let first = Polynomial::new(polynomial_coefficients::<2>(coefficient_rows[0].clone())?);
+        let second = Polynomial::new(polynomial_coefficients::<2>(coefficient_rows[1].clone())?);
+        let pieces = [[first], [second]];
+        let span_array = [spans[0], spans[1]];
+        Ok(Self {
+            inner: PiecewisePolynomial::try_from_pieces(&pieces, &span_array)
+                .map_err(errors::polynomial_error)?,
+        })
+    }
+
+    /// Value at `parameter` along the concatenated pieces.
+    fn evaluate(&self, parameter: f64) -> PyResult<f64> {
+        let point = self
+            .inner
+            .evaluate(parameter)
+            .map_err(errors::polynomial_error)?;
+        Ok(point.into_array()[0])
+    }
+
+    fn __len__(&self) -> usize {
+        2
+    }
+
+    fn __repr__(&self) -> String {
+        "PiecewisePolynomial2(pieces=2)".to_string()
+    }
+}
+
+/// Two-variable polynomial (up to 4 terms).
+#[pyclass(name = "MultivariatePolynomial2")]
+pub struct PyMultivariatePolynomial2 {
+    inner: MultivariatePolynomial<2, 4>,
+}
+
+#[pymethods]
+impl PyMultivariatePolynomial2 {
+    /// Terms as `(coefficient, [exponent_x, exponent_y])`.
+    #[new]
+    fn new(terms: Vec<(f64, Vec<u32>)>) -> PyResult<Self> {
+        let mut converted = Vec::with_capacity(terms.len());
+        for (coefficient, exponents) in terms {
+            if exponents.len() != 2 {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "each term needs 2 exponents",
+                ));
+            }
+            converted.push(MultivariateTerm::new(
+                coefficient,
+                [exponents[0], exponents[1]],
+            ));
+        }
+        Ok(Self {
+            inner: MultivariatePolynomial::try_from_terms(&converted)
+                .map_err(errors::polynomial_error)?,
+        })
+    }
+
+    /// Value at a 2-vector of variables.
+    fn evaluate(&self, variables: Vec<f64>) -> PyResult<f64> {
+        if variables.len() != 2 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "MultivariatePolynomial2 needs 2 variables",
+            ));
+        }
+        Ok(self.inner.evaluate(&[variables[0], variables[1]]))
+    }
+
+    fn __len__(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("MultivariatePolynomial2(terms={})", self.inner.len())
+    }
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_class::<Polynomial2>()?;
+    module.add_class::<Polynomial3>()?;
+    module.add_class::<Polynomial4>()?;
+    module.add_class::<Polynomial5>()?;
+    module.add_class::<Polynomial6>()?;
+    module.add_class::<Polynomial7>()?;
+    module.add_class::<Polynomial8>()?;
+    module.add_class::<PyPiecewisePolynomial2>()?;
+    module.add_class::<PyMultivariatePolynomial2>()?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/random.rs
+++ b/crates/multicalc-py/src/random.rs
@@ -1,0 +1,31 @@
+use multicalc::random::{Pcg32, RandomSource};
+use pyo3::prelude::*;
+
+/// PCG32 random source (unit interval and standard normal).
+#[pyclass(name = "Pcg32")]
+pub struct PyPcg32 {
+    inner: Pcg32<f64>,
+}
+
+#[pymethods]
+impl PyPcg32 {
+    #[new]
+    fn new(seed: u64) -> Self {
+        Self {
+            inner: Pcg32::new(seed),
+        }
+    }
+
+    fn next_unit(&mut self) -> f64 {
+        self.inner.next_unit()
+    }
+
+    fn standard_normal(&mut self) -> f64 {
+        self.inner.standard_normal()
+    }
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_class::<PyPcg32>()?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/roots.rs
+++ b/crates/multicalc-py/src/roots.rs
@@ -1,0 +1,51 @@
+use multicalc::numerical_derivative::FiniteDifferenceSingle;
+use multicalc::root_finding::{Bisection, Brent, Newton};
+use pyo3::prelude::*;
+
+use crate::callables::PythonScalarFn;
+use crate::errors;
+
+/// Bisection root of a scalar callable on `[lower, upper]`.
+#[pyfunction(name = "bisection")]
+fn bind_bisection(callback: Py<PyAny>, lower: f64, upper: f64) -> PyResult<f64> {
+    let function = PythonScalarFn::new(callback);
+    function.finish(
+        Bisection::default()
+            .solve(&function, lower, upper)
+            .map(|report| report.root)
+            .map_err(errors::solve_error),
+    )
+}
+
+/// Brent root of a scalar callable on `[lower, upper]`.
+#[pyfunction(name = "brent")]
+fn bind_brent(callback: Py<PyAny>, lower: f64, upper: f64) -> PyResult<f64> {
+    let function = PythonScalarFn::new(callback);
+    function.finish(
+        Brent::default()
+            .solve(&function, lower, upper)
+            .map(|report| report.root)
+            .map_err(errors::solve_error),
+    )
+}
+
+/// Newton root from `initial_guess`, derivative by finite difference.
+#[pyfunction(name = "newton")]
+fn bind_newton(callback: Py<PyAny>, initial_guess: f64) -> PyResult<f64> {
+    let function = PythonScalarFn::new(callback);
+    let solver: Newton<FiniteDifferenceSingle> =
+        Newton::from_derivator(FiniteDifferenceSingle::default());
+    function.finish(
+        solver
+            .solve(&function, initial_guess)
+            .map(|report| report.root)
+            .map_err(errors::solve_error),
+    )
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_function(wrap_pyfunction!(bind_bisection, module)?)?;
+    module.add_function(wrap_pyfunction!(bind_brent, module)?)?;
+    module.add_function(wrap_pyfunction!(bind_newton, module)?)?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/signal.rs
+++ b/crates/multicalc-py/src/signal.rs
@@ -1,0 +1,144 @@
+use multicalc::signal_processing::{
+    Biquad, BiquadCoefficients, Deadband, MovingAverage, OnePoleLowPass, RunningMedian,
+    SlewRateLimiter,
+};
+use pyo3::prelude::*;
+
+use crate::errors;
+
+/// First-order IIR low-pass.
+#[pyclass(name = "OnePoleLowPass")]
+pub struct PyOnePoleLowPass {
+    inner: OnePoleLowPass,
+}
+
+#[pymethods]
+impl PyOnePoleLowPass {
+    /// Smoothing factor in `(0, 1]`.
+    #[new]
+    fn new(smoothing: f64) -> PyResult<Self> {
+        Ok(Self {
+            inner: OnePoleLowPass::new(smoothing).map_err(errors::signal_error)?,
+        })
+    }
+
+    fn filter(&mut self, sample: f64) -> f64 {
+        self.inner.filter(sample)
+    }
+}
+
+/// Direct-form II biquad.
+#[pyclass(name = "Biquad")]
+pub struct PyBiquad {
+    inner: Biquad,
+}
+
+#[pymethods]
+impl PyBiquad {
+    /// Low-pass coefficients from cutoff (Hz), `quality_factor`, and sample period.
+    #[staticmethod]
+    fn low_pass(cutoff_hz: f64, quality_factor: f64, timestep: f64) -> PyResult<Self> {
+        let coefficients = BiquadCoefficients::low_pass(cutoff_hz, quality_factor, timestep)
+            .map_err(errors::signal_error)?;
+        Ok(Self {
+            inner: Biquad::new(coefficients),
+        })
+    }
+
+    fn filter(&mut self, sample: f64) -> f64 {
+        self.inner.filter(sample)
+    }
+}
+
+/// Symmetric deadband around zero.
+#[pyclass(name = "Deadband")]
+pub struct PyDeadband {
+    inner: Deadband,
+}
+
+#[pymethods]
+impl PyDeadband {
+    /// Half-width of the zero region.
+    #[staticmethod]
+    fn plain(threshold: f64) -> PyResult<Self> {
+        Ok(Self {
+            inner: Deadband::plain(threshold).map_err(errors::signal_error)?,
+        })
+    }
+
+    fn apply(&self, sample: f64) -> f64 {
+        self.inner.apply(sample)
+    }
+}
+
+/// Rate limiter on a scalar command.
+#[pyclass(name = "SlewRateLimiter")]
+pub struct PySlewRateLimiter {
+    inner: SlewRateLimiter,
+}
+
+#[pymethods]
+impl PySlewRateLimiter {
+    /// Rise/fall rates per second and sample period.
+    #[new]
+    fn new(rise_per_second: f64, fall_per_second: f64, timestep: f64) -> PyResult<Self> {
+        Ok(Self {
+            inner: SlewRateLimiter::new(rise_per_second, fall_per_second, timestep)
+                .map_err(errors::signal_error)?,
+        })
+    }
+
+    fn filter(&mut self, target: f64) -> f64 {
+        self.inner.filter(target)
+    }
+}
+
+/// Moving average of window 4.
+#[pyclass(name = "MovingAverage4")]
+pub struct PyMovingAverage4 {
+    inner: MovingAverage<4>,
+}
+
+#[pymethods]
+impl PyMovingAverage4 {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(Self {
+            inner: MovingAverage::<4>::new().map_err(errors::signal_error)?,
+        })
+    }
+
+    fn filter(&mut self, sample: f64) -> f64 {
+        self.inner.filter(sample)
+    }
+}
+
+/// Running median of window 5.
+#[pyclass(name = "RunningMedian5")]
+pub struct PyRunningMedian5 {
+    inner: RunningMedian<5>,
+}
+
+#[pymethods]
+impl PyRunningMedian5 {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(Self {
+            inner: RunningMedian::new().map_err(errors::signal_error)?,
+        })
+    }
+
+    fn filter(&mut self, sample: f64) -> f64 {
+        self.inner.filter(sample)
+    }
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_class::<PyOnePoleLowPass>()?;
+    module.add_class::<PyBiquad>()?;
+    module.add_class::<PyDeadband>()?;
+    module.add_class::<PySlewRateLimiter>()?;
+    module.add_class::<PyMovingAverage4>()?;
+    module.add_class::<PyRunningMedian5>()?;
+    Ok(())
+}

--- a/crates/multicalc-py/src/spatial.rs
+++ b/crates/multicalc-py/src/spatial.rs
@@ -1,0 +1,286 @@
+use multicalc::linear_algebra::Vector;
+use multicalc::spatial::{
+    FreeJointState, Quaternion, SE2, SE3, SO2, SO3, SpatialInertia, Twist, Wrench,
+};
+use pyo3::prelude::*;
+
+use crate::convert::{vector_from_list, vector_to_list};
+use crate::errors;
+
+/// Unit quaternion `(real_part, vector_i, vector_j, vector_k)` for 3D rotation.
+#[pyclass(name = "Quaternion")]
+pub struct PyQuaternion {
+    inner: Quaternion,
+}
+
+#[pymethods]
+impl PyQuaternion {
+    #[new]
+    fn new(real_part: f64, vector_i: f64, vector_j: f64, vector_k: f64) -> Self {
+        Self {
+            inner: Quaternion::new(real_part, vector_i, vector_j, vector_k),
+        }
+    }
+
+    #[staticmethod]
+    fn identity() -> Self {
+        Self {
+            inner: Quaternion::identity(),
+        }
+    }
+
+    fn as_array(&self) -> [f64; 4] {
+        self.inner.as_array()
+    }
+
+    fn transform_point(&self, point: Vec<f64>) -> PyResult<Vec<f64>> {
+        let point = vector_from_list::<3>(point)?;
+        Ok(vector_to_list(self.inner.transform_point(point)))
+    }
+}
+
+/// 2D rotation (Lie group SO(2)).
+#[pyclass(name = "SO2")]
+pub struct PySO2 {
+    pub(crate) inner: SO2,
+}
+
+#[pymethods]
+impl PySO2 {
+    #[staticmethod]
+    fn identity() -> Self {
+        Self {
+            inner: SO2::identity(),
+        }
+    }
+
+    /// Rotation by `theta` radians.
+    #[staticmethod]
+    fn exp(theta: f64) -> Self {
+        Self {
+            inner: SO2::exp(theta),
+        }
+    }
+
+    fn act(&self, point: Vec<f64>) -> PyResult<Vec<f64>> {
+        let point = vector_from_list::<2>(point)?;
+        Ok(vector_to_list(self.inner.act(point)))
+    }
+}
+
+/// 3D rotation (Lie group SO(3)).
+#[pyclass(name = "SO3")]
+pub struct PySO3 {
+    pub(crate) inner: SO3,
+}
+
+#[pymethods]
+impl PySO3 {
+    #[staticmethod]
+    fn identity() -> Self {
+        Self {
+            inner: SO3::identity(),
+        }
+    }
+
+    /// Rotation from a 3-vector (axis-angle).
+    #[staticmethod]
+    fn exp(rotation_vector: [f64; 3]) -> Self {
+        Self {
+            inner: SO3::exp(Vector::new(rotation_vector)),
+        }
+    }
+
+    fn act(&self, point: [f64; 3]) -> [f64; 3] {
+        self.inner.act(Vector::new(point)).into_array()
+    }
+}
+
+/// 2D rigid transform (Lie group SE(2)).
+#[pyclass(name = "SE2")]
+pub struct PySE2 {
+    pub(crate) inner: SE2,
+}
+
+#[pymethods]
+impl PySE2 {
+    #[staticmethod]
+    fn identity() -> Self {
+        Self {
+            inner: SE2::identity(),
+        }
+    }
+
+    /// Pose from rotation and 2-vector translation.
+    #[staticmethod]
+    fn from_parts(rotation: &PySO2, translation: Vec<f64>) -> PyResult<Self> {
+        Ok(Self {
+            inner: SE2::from_parts(rotation.inner, vector_from_list::<2>(translation)?),
+        })
+    }
+
+    fn act(&self, point: Vec<f64>) -> PyResult<Vec<f64>> {
+        let point = vector_from_list::<2>(point)?;
+        Ok(vector_to_list(self.inner.act(point)))
+    }
+}
+
+/// 3D rigid transform (Lie group SE(3)).
+#[pyclass(name = "SE3")]
+pub struct PySE3 {
+    pub(crate) inner: SE3,
+}
+
+#[pymethods]
+impl PySE3 {
+    #[staticmethod]
+    fn identity() -> Self {
+        Self {
+            inner: SE3::identity(),
+        }
+    }
+
+    /// Pose from rotation and 3-vector translation.
+    #[staticmethod]
+    fn from_parts(rotation: &PySO3, translation: Vec<f64>) -> PyResult<Self> {
+        Ok(Self {
+            inner: SE3::from_parts(rotation.inner, vector_from_list::<3>(translation)?),
+        })
+    }
+
+    fn act(&self, point: Vec<f64>) -> PyResult<Vec<f64>> {
+        let point = vector_from_list::<3>(point)?;
+        Ok(vector_to_list(self.inner.act(point)))
+    }
+}
+
+/// Spatial velocity: linear then angular, six components.
+#[pyclass(name = "Twist")]
+pub struct PyTwist {
+    pub(crate) inner: Twist,
+}
+
+#[pymethods]
+impl PyTwist {
+    #[new]
+    fn new(linear: Vec<f64>, angular: Vec<f64>) -> PyResult<Self> {
+        Ok(Self {
+            inner: Twist::new(
+                vector_from_list::<3>(linear)?,
+                vector_from_list::<3>(angular)?,
+            ),
+        })
+    }
+
+    #[staticmethod]
+    fn zeros() -> Self {
+        Self {
+            inner: Twist::zeros(),
+        }
+    }
+
+    fn as_array(&self) -> [f64; 6] {
+        self.inner.as_array()
+    }
+}
+
+/// Spatial force: force then torque, six components.
+#[pyclass(name = "Wrench")]
+pub struct PyWrench {
+    pub(crate) inner: Wrench,
+}
+
+#[pymethods]
+impl PyWrench {
+    #[new]
+    fn new(force: Vec<f64>, torque: Vec<f64>) -> PyResult<Self> {
+        Ok(Self {
+            inner: Wrench::new(
+                vector_from_list::<3>(force)?,
+                vector_from_list::<3>(torque)?,
+            ),
+        })
+    }
+
+    #[staticmethod]
+    fn zeros() -> Self {
+        Self {
+            inner: Wrench::zeros(),
+        }
+    }
+
+    fn as_array(&self) -> [f64; 6] {
+        self.inner.as_array()
+    }
+}
+
+/// Rigid-body spatial inertia.
+#[pyclass(name = "SpatialInertia")]
+pub struct PySpatialInertia {
+    pub(crate) inner: SpatialInertia,
+}
+
+#[pymethods]
+impl PySpatialInertia {
+    /// Mass, center of mass, and principal inertia diagonals.
+    #[staticmethod]
+    fn from_diagonal_inertia(
+        mass: f64,
+        center_of_mass: Vec<f64>,
+        diagonal: Vec<f64>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            inner: SpatialInertia::from_diagonal_inertia(
+                mass,
+                vector_from_list::<3>(center_of_mass)?,
+                vector_from_list::<3>(diagonal)?,
+            )
+            .map_err(errors::spatial_error)?,
+        })
+    }
+
+    fn mass(&self) -> f64 {
+        self.inner.mass()
+    }
+}
+
+/// Free-flying rigid body pose and twist.
+#[pyclass(name = "FreeJointState")]
+pub struct PyFreeJointState {
+    inner: FreeJointState,
+}
+
+#[pymethods]
+impl PyFreeJointState {
+    #[staticmethod]
+    fn identity() -> Self {
+        Self {
+            inner: FreeJointState::identity(),
+        }
+    }
+
+    fn pose(&self) -> PySE3 {
+        PySE3 {
+            inner: self.inner.pose(),
+        }
+    }
+
+    fn velocity(&self) -> PyTwist {
+        PyTwist {
+            inner: self.inner.velocity(),
+        }
+    }
+}
+
+pub(crate) fn register<'python>(module: &Bound<'python, PyModule>) -> PyResult<()> {
+    module.add_class::<PyQuaternion>()?;
+    module.add_class::<PySO2>()?;
+    module.add_class::<PySO3>()?;
+    module.add_class::<PySE2>()?;
+    module.add_class::<PySE3>()?;
+    module.add_class::<PyTwist>()?;
+    module.add_class::<PyWrench>()?;
+    module.add_class::<PySpatialInertia>()?;
+    module.add_class::<PyFreeJointState>()?;
+    Ok(())
+}

--- a/crates/multicalc-py/tests/test_autodiff.py
+++ b/crates/multicalc-py/tests/test_autodiff.py
@@ -1,0 +1,21 @@
+import pytest
+
+import multicalc_py
+
+def test_dual_square():
+    x = multicalc_py.Dual.variable(3.0)
+    y = x * x
+    assert y.value == pytest.approx(9.0)
+    assert y.deriv == pytest.approx(6.0)
+
+def test_hyperdual_square():
+    x = multicalc_py.HyperDual.variable(3.0)
+    y = x * x
+    assert y.real == pytest.approx(9.0)
+    assert y.eps1eps2 == pytest.approx(2.0)
+
+def test_jet7_square():
+    x = multicalc_py.Jet7.variable(3.0)
+    y = x * x
+    assert y.value() == pytest.approx(9.0)
+    assert y.derivative(order=1) == pytest.approx(6.0)

--- a/crates/multicalc-py/tests/test_calculus.py
+++ b/crates/multicalc-py/tests/test_calculus.py
@@ -1,0 +1,19 @@
+import pytest
+
+import multicalc_py
+
+def test_derivative_of_cube():
+    slope = multicalc_py.derivative(lambda argument: argument**3, 2.0)
+    assert slope == pytest.approx(12.0, rel=1e-6)
+
+def test_second_derivative_of_cube():
+    bend = multicalc_py.second_derivative(lambda argument: argument**3, 2.0)
+    assert bend == pytest.approx(12, rel=1e-4)
+
+def test_partial_of_product():
+    slope = multicalc_py.partial(lambda first, second: first * first * second, 0, [3.0, 4.0])
+    assert slope == pytest.approx(24.0, rel=1e-6)
+
+def test_integral_of_line():
+    area = multicalc_py.integral(lambda argument: 2.0 * argument, 0.0, 2.0)
+    assert area == pytest.approx(4.0, rel=1e-6)

--- a/crates/multicalc-py/tests/test_callback_errors.py
+++ b/crates/multicalc-py/tests/test_callback_errors.py
@@ -1,0 +1,23 @@
+import pytest
+import multicalc_py
+
+def test_derivative_reraises_callback_exception():
+    def bad(x):
+        raise ValueError("domain error")
+
+    with pytest.raises(ValueError, match="domain error"):
+        multicalc_py.derivative(bad, 1.0)
+
+def test_bisection_reraises_callback_exception():
+    def bad(x):
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        multicalc_py.bisection(bad, 0.0, 1.0)
+
+def test_rk4_step_reraises_callback_exception():
+    def bad(t, state):
+        raise ValueError("ode failed")
+
+    with pytest.raises(ValueError, match="ode failed"):
+        multicalc_py.rk4_step(bad, 0.0, [1.0, 0.0], 0.1)

--- a/crates/multicalc-py/tests/test_control.py
+++ b/crates/multicalc-py/tests/test_control.py
@@ -1,0 +1,50 @@
+import pytest
+
+import multicalc_py
+
+def test_lqr_cart():
+    controller = multicalc_py.Lqr2x1(
+        [[1.0, 0.1], [0.0, 1.0]],
+        [[0.005], [0.1]],
+        [[1.0, 0.0], [0.0, 1.0]],
+        [[1.0]],
+    )
+    controller.certify_stability()
+    state = [1.0, 0.0]
+    for _ in range(400):
+        command = controller.control(state)
+        state = [
+            1.0 * state[0] + 0.1 * state[1] + 0.005 * command[0],
+            0.0 * state[0] + 1.0 * state[1] + 0.1 * command[0],
+        ]
+    assert (state[0] ** 2 + state[1] ** 2) ** 0.5 < 1e-6
+
+def test_geometric_attitude_zero_torque():
+    inertia = [[0.02, 0.0, 0.0], [0.0, 0.02, 0.0], [0.0, 0.0, 0.04]]
+    controller = multicalc_py.GeometricAttitudeController(6.0, 1.2, inertia)
+    still = [0.0, 0.0, 0.0]
+    level = multicalc_py.SO3.identity()
+    torque = controller.torque(level, still, level, still, still)
+    assert torque[0] == pytest.approx(0.0, abs=1e-12)
+    assert torque[1] == pytest.approx(0.0, abs=1e-12)
+    assert torque[2] == pytest.approx(0.0, abs=1e-12)
+
+def test_pure_pursuit_straight():
+    curvature = multicalc_py.pure_pursuit_curvature(
+        multicalc_py.SE2.identity(), [2.0, 0.0], 2.0
+    )
+    assert curvature == pytest.approx(0.0, abs=1e-12)
+
+def test_thrust_hover_and_freefall():
+    hover = multicalc_py.thrust_command_from_acceleration([0.0, 0.0, 0.0], 0.0, 9.81)
+    assert hover.thrust_acceleration() == pytest.approx(9.81, abs=1e-12)
+    with pytest.raises(multicalc_py.ControlError):
+        multicalc_py.thrust_command_from_acceleration([0.0, 0.0, -9.81], 0.0, 9.81)
+
+def test_follow_the_gap():
+    follower = multicalc_py.FollowTheGap5.try_new(2.0, 4.0, 0.5, 0.5, 0.4)
+    clear = follower.compute([4.0, 4.0, 4.0, 4.0, 4.0], 0.0)
+    assert not clear.is_blocked()
+    blocked = follower.compute([0.2, 0.2, 0.2, 0.2, 0.2], 0.0)
+    assert blocked.is_blocked()
+    

--- a/crates/multicalc-py/tests/test_discretization.py
+++ b/crates/multicalc-py/tests/test_discretization.py
@@ -1,0 +1,16 @@
+import pytest
+
+import multicalc_py
+
+def test_zoh_double_integrator():
+    discrete_state, discrete_input = multicalc_py.zoh(
+        [[0.0, 1.0], [0.0, 0.0]],
+        [[0.0], [1.0]],
+        0.1,
+    )
+    assert discrete_state[0][1] == pytest.approx(0.1, abs=1e-9)
+    assert discrete_input[0][0] == pytest.approx(0.005, abs=1e-9)
+
+def test_q_discrete_white_noise():
+    covariance = multicalc_py.q_discrete_white_noise(0.1, 2.0)
+    assert covariance[1][1] == pytest.approx(0.02, abs=1e-15)

--- a/crates/multicalc-py/tests/test_dynamics.py
+++ b/crates/multicalc-py/tests/test_dynamics.py
@@ -1,0 +1,16 @@
+import pytest
+
+import multicalc_py
+
+def test_rigid_body_falls():
+    inertia = multicalc_py.SpatialInertia.from_diagonal_inertia(
+        2.0, [0.0, 0.0, 0.0], [1.0, 1.0, 1.0]
+    )
+    body = multicalc_py.RigidBody(inertia, [0.0, 0.0, -9.81])
+    linear, angular = body.accelerations(
+        multicalc_py.SO3.identity(),
+        [0.0, 0.0, 0.0],
+        multicalc_py.Wrench.zeros(),
+    )
+    assert linear[2] == pytest.approx(-9.81)
+    assert angular[0] == pytest.approx(0.0)

--- a/crates/multicalc-py/tests/test_estimation.py
+++ b/crates/multicalc-py/tests/test_estimation.py
@@ -1,0 +1,28 @@
+import pytest
+
+import multicalc_py
+
+def test_kalman_constant_velocity():
+    filt = multicalc_py.KalmanFilter2x1(
+        [0.0, 0.0],
+        [[1.0, 0.0], [0.0, 1.0]],
+        [[1.0, 1.0], [0.0, 1.0]],
+        [[1.0, 0.0]],
+        [[0.01, 0.0], [0.0, 0.01]],
+        [[0.1]],
+    )
+    filt.predict()
+    filt.update([1.0])
+    assert filt.state()[0] > 0.0
+
+def test_madgwick_finds_level():
+    tilt = multicalc_py.SO3.exp([0.1, -0.05, 0.0])
+    filt = multicalc_py.MadgwickFilter(tilt)
+    still = [0.0, 0.0, 0.0]
+    gravity = [0.0, 0.0, 9.81]
+    north = [1.0, 0.0, 0.0]
+    for _ in range(2000):
+        filt.step(still, gravity, north, 0.005)
+    residual = filt.orientation().act([0.0, 0.0, 1.0])
+    assert residual[2] == pytest.approx(1.0, abs=1e-3)
+    

--- a/crates/multicalc-py/tests/test_kinematics.py
+++ b/crates/multicalc-py/tests/test_kinematics.py
@@ -1,0 +1,18 @@
+import pytest
+
+import multicalc_py
+
+def test_deifferential_drive_straight():
+    chassis = multicalc_py.DifferentialDrive(0.05, 0.2)
+    linear, angular = chassis.forward(2.0, 2.0)
+    assert linear == pytest.approx(0.1)
+    assert angular == pytest.approx(0.0)
+
+def test_planar_two_link_stretched():
+    tree = multicalc_py.KinematicTree2.planar_two_link(1.0)
+    assert len(tree) == 2
+    assert repr(tree) == "KinematicTree2(joints=2)"
+    tip = tree.forward_kinematics([0.0, 0.0])
+    assert tip[0] == pytest.approx(1.0)
+    assert tip[1] == pytest.approx(0.0)
+    assert tip[2] == pytest.approx(0.0)

--- a/crates/multicalc-py/tests/test_mapping.py
+++ b/crates/multicalc-py/tests/test_mapping.py
@@ -1,0 +1,16 @@
+import math
+
+import pytest
+
+import multicalc_py
+
+def test_scan_middle_beam_ahead():
+    scan = multicalc_py.ScanGeometry5(math.pi / 2, 4.0)
+    assert scan.beam_angle(2) == pytest.approx(0.0)
+
+def test_dynamic_grid_blocks_a_cell():
+    grid = multicalc_py.DynamicOccupancyGrid(8, 8, 1.0, [0.0, 0.0])
+    grid.occupy_point([3.5, 4.5])
+    assert grid.is_occupied(4, 3) is True
+    hit = grid.cast_ray([0.5, 4.5], 0.0, 10.0)
+    assert hit is not None

--- a/crates/multicalc-py/tests/test_motion.py
+++ b/crates/multicalc-py/tests/test_motion.py
@@ -1,0 +1,11 @@
+import pytest
+
+import multicalc_py
+
+def test_polyline_length_and_lookahead():
+    path = multicalc_py.PolylinePath8x2.try_from_points(
+        [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]
+    )
+    assert path.total_arc_length() == pytest.approx(2.0)
+    point = path.lookahead_point(0.0, 0.5)
+    assert len(point) == 2

--- a/crates/multicalc-py/tests/test_ode.py
+++ b/crates/multicalc-py/tests/test_ode.py
@@ -1,0 +1,31 @@
+import math
+
+import pytest
+
+import multicalc_py
+
+def growth(_time: float, state: list[float]) -> list[float]:
+    return [state[0], 0.0]
+
+def decay(_time: float, state: list[float]) -> list[float]:
+    return [-state[0], 0.0]
+
+def test_rk4_step_exponential():
+    next_state = multicalc_py.rk4_step(growth, 0.0, [1.0, 0.0], 0.1)
+    assert next_state[0] == pytest.approx(math.exp(0.1), rel=1e-5)
+
+def test_rk45_solve_decay():
+    final_state = multicalc_py.rk45_solve(decay, 0.0, [1.0, 0.0], 1.0)
+    assert final_state[0] == pytest.approx(math.exp(-1.0), rel=1e-5)
+
+def test_exponential_map_quarter_turn():
+    timestep = math.pi / 8.0
+    orientation = multicalc_py.SO3.identity()
+    rate = [0.0, 0.0, 2.0]
+    orientation = multicalc_py.exponential_map_attitude_step(orientation, rate, timestep)
+    orientation = multicalc_py.exponential_map_attitude_step(orientation, rate, timestep)
+    point = orientation.act([1.0, 0.0, 0.0])
+    assert point[0] == pytest.approx(0.0, abs=1e-12)
+    assert point[1] == pytest.approx(1.0, abs=1e-12)
+    assert point[2] == pytest.approx(0.0, abs=1e-12)
+    

--- a/crates/multicalc-py/tests/test_optimization.py
+++ b/crates/multicalc-py/tests/test_optimization.py
@@ -1,0 +1,22 @@
+import pytest
+
+import multicalc_py
+
+def rosenbrock(x, y):
+    return [10.0 * (y - x * x), 1.0 - x]
+
+def test_gauss_newton_rosenbrock():
+    solution, objective, _evals = multicalc_py.GaussNewton2x2().minimize(
+        rosenbrock, [-1.2, 1.0]
+    )
+    assert solution[0] == pytest.approx(1.0, abs=1e-4)
+    assert solution[1] == pytest.approx(1.0, abs=1e-4)
+    assert objective == pytest.approx(0.0, abs=1e-8)
+
+def test_levenberg_marquardt_rosenbrock():
+    solution, objective, _evals = multicalc_py.LevenbergMarquardt2x2().minimize(
+        rosenbrock, [-1.2, 1.0]
+    )
+    assert solution[0] == pytest.approx(1.0, abs=1e-4)
+    assert solution[1] == pytest.approx(1.0, abs=1e-4)
+    assert objective == pytest.approx(0.0, abs=1e-8)

--- a/crates/multicalc-py/tests/test_particle.py
+++ b/crates/multicalc-py/tests/test_particle.py
@@ -1,0 +1,22 @@
+import pytest
+
+import multicalc_py
+
+def identity(x, y):
+    return [x, y]
+
+def test_particle_filter_stays_near_measurement():
+    filt = multicalc_py.ParticleFilter2x2(
+        64,
+        [0.0, 0.0],
+        [[1.0, 0.0], [0.0, 1.0]],
+        [[0.01, 0.0], [0.0, 0.01]],
+        [[0.1, 0.0], [0.0, 0.1]],
+        1,
+    )
+    for _ in range(8):
+        filt.predict(identity)
+        filt.update(identity, [1.0, 2.0])
+    mean = filt.mean()
+    assert abs(mean[0] - 1.0) < 0.5
+    assert abs(mean[1] - 2.0) < 0.5

--- a/crates/multicalc-py/tests/test_plant.py
+++ b/crates/multicalc-py/tests/test_plant.py
@@ -1,0 +1,14 @@
+import pytest
+
+import multicalc_py
+
+def test_quadrotor_hover_mix():
+    mixer = multicalc_py.MultirotorMixer4.quadrotor_x(0.2, 0.01, 0.0, 10.0)
+    thrusts, saturated = mixer.rotor_thrusts(4.0, [0.0, 0.0, 0.0])
+    assert len(thrusts) == 4
+    assert saturated is False
+
+def test_rotor_lag_steps_toward_command():
+    rotors = multicalc_py.RotorLag4(0.02, 0.001)
+    out = rotors.stepped([2.0, 2.0, 2.0, 2.0])
+    assert 0.0 < out[0] < 2.0

--- a/crates/multicalc-py/tests/test_polynomial_extra.py
+++ b/crates/multicalc-py/tests/test_polynomial_extra.py
@@ -1,0 +1,18 @@
+import pytest
+
+import multicalc_py
+
+def test_piecewise_handover():
+    curve = multicalc_py.PiecewisePolynomial2([[0.0, 1.0], [1.0, 2.0]], [2.0, 1.0])
+    assert curve.evaluate(2.0) == pytest.approx(1.0, abs=1e-12)
+    assert curve.evaluate(9.0) == pytest.approx(3.0, abs=1e-12)
+
+def test_multivariate_point():
+    polynomial = multicalc_py.MultivariatePolynomial2(
+        [(3.0, [2, 1]), (2.0, [1, 1]), (-1.0, [0, 0])]
+    )
+    assert polynomial.evaluate([2.0, 3.0]) == pytest.approx(47.0, abs=1e-12)
+
+def test_linear_root():
+    roots = multicalc_py.Polynomial2([-6.0, 2.0]).real_roots()
+    assert roots[0] == pytest.approx(3.0, abs=1e-12)

--- a/crates/multicalc-py/tests/test_random.py
+++ b/crates/multicalc-py/tests/test_random.py
@@ -1,0 +1,8 @@
+import multicalc_py
+
+def test_pcg32_repeatable():
+    first = [multicalc_py.Pcg32(1).next_unit() for _ in range(3)]
+    second = [multicalc_py.Pcg32(1).next_unit() for _ in range(3)]
+    assert first == second
+    assert 0.0 <= first[0] < 1.0
+    

--- a/crates/multicalc-py/tests/test_roots.py
+++ b/crates/multicalc-py/tests/test_roots.py
@@ -1,0 +1,20 @@
+import math
+
+import pytest
+
+import multicalc_py
+
+def residual(argument: float) -> float:
+    return argument * argument - 2.0
+
+def test_bisection_sqrt_two():
+    root = multicalc_py.bisection(residual, 0.0, 2.0)
+    assert root == pytest.approx(math.sqrt(2.0), abs=1e-9)
+
+def test_brent_sqrt_two():
+    root = multicalc_py.brent(residual, 0.0, 2.0)
+    assert root == pytest.approx(math.sqrt(2.0), abs=1e-9)
+
+def test_newton_sqrt_two():
+    root = multicalc_py.newton(residual, 2.0)
+    assert root == pytest.approx(math.sqrt(2.0), abs=1e-8)

--- a/crates/multicalc-py/tests/test_signal.py
+++ b/crates/multicalc-py/tests/test_signal.py
@@ -1,0 +1,18 @@
+import pytest
+
+import multicalc_py
+
+def test_one_pole_passthrough():
+    filt = multicalc_py.OnePoleLowPass(1.0)
+    assert filt.filter(3.0) == 3.0
+    assert filt.filter(-2.0) == -2.0
+
+def test_deadband_plain():
+    band = multicalc_py.Deadband.plain(0.1)
+    assert abs(band.apply(0.05)) < 1e-12
+    assert band.apply(0.5) == pytest.approx(0.5)
+
+def test_moving_average_four():
+    filt = multicalc_py.MovingAverage4()
+    assert filt.filter(1.0) == 1.0
+    assert filt.filter(5.0) == 2.0

--- a/crates/multicalc-py/tests/test_smoke.py
+++ b/crates/multicalc-py/tests/test_smoke.py
@@ -1,0 +1,103 @@
+import math
+import struct
+
+import pytest
+
+import multicalc_py
+
+def hex_f64(value: str) -> float:
+    return struct.unpack("d", struct.pack("Q", int(value, 16)))[0]
+
+def close(got: float, want: float, abs_tol: float, rel_tol: float) -> bool:
+    return abs(got - want) <= abs_tol + rel_tol * max(abs(got), abs(want))
+
+def test_version():
+    from importlib.metadata import version
+    assert multicalc_py.version() == version("multicalc_py")
+    assert multicalc_py.__version__ == version("multicalc_py")
+
+def test_vector_dot():
+    ascending = multicalc_py.Vector4([1.0, 2.0, 3.0, 4.0])
+    descending = multicalc_py.Vector4([4.0, 3.0, 2.0, 1.0])
+    assert ascending.dot(descending) == pytest.approx(20.0)
+
+def test_vector_to_list():
+    vector = multicalc_py.Vector4([1.0, 2.0, 3.0, 4.0])
+    assert vector.to_list() == [1.0, 2.0, 3.0, 4.0]
+    assert len(vector) == 4
+    assert repr(vector) == "Vector4([1.0, 2.0, 3.0, 4.0])"
+
+def test_svd_golden():
+    # Bit-exact input from tools/qa/fixtures/linalg/svd_3x3.json
+    rows = [
+        "0x3fe2763f5d1ce592",
+        "0xbfd8d914ad03f36c",
+        "0x3fb25b646e3094b0",
+        "0x3fe622dfc7a9f89e",
+        "0x3fd9e223541c2004",
+        "0xbfe62d633c4f7204",
+        "0xbfef15212fa242ca",
+        "0x3f86822382d5fe80",
+        "0xbfe18282767f4e98",
+    ]
+    matrix = [
+        [hex_f64(rows[0]), hex_f64(rows[1]), hex_f64(rows[2])],
+        [hex_f64(rows[3]), hex_f64(rows[4]), hex_f64(rows[5])],
+        [hex_f64(rows[6]), hex_f64(rows[7]), hex_f64(rows[8])],
+    ]
+    expected = [
+        hex_f64("0x3ff5400d80d4d692"),
+        hex_f64("0x3feefaabc5b78ecf"),
+        hex_f64("0x3fd907ffa3d1e959"),
+    ]
+    _left, values, _right = multicalc_py.Matrix3(matrix).svd()
+    assert len(values) == 3
+    for value, want in zip(values, expected):
+        assert close(value, want, 1e-11, 1e-10)
+
+def test_lu_singular():
+    with pytest.raises(multicalc_py.LinalgError, match="Singular"):
+        multicalc_py.Matrix3.zeros().lu_decompose()
+
+def test_cholesky_not_positive_definite():
+    matrix = multicalc_py.Matrix2([[1.0, 2.0], [2.0, 1.0]])
+    with pytest.raises(multicalc_py.LinalgError, match="NotPositiveDefinite"):
+        matrix.cholesky()
+
+def test_pid_step():
+    dt = 0.01
+    setpoint = 1.0
+    pid = multicalc_py.Pid(2.0, 1.0, 0.0, dt)
+    first = pid.update(setpoint, 0.0)
+    assert first == pytest.approx(2.01, abs=1e-12)
+
+    measurement = dt * first
+    for _ in range(100):
+        previous = measurement
+        output = pid.update(setpoint, measurement)
+        measurement += dt * output
+        assert measurement > previous
+    assert measurement == pytest.approx(setpoint, abs=0.01)
+
+def test_polynomial_evaluate():
+    coeffs = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+    poly = multicalc_py.Polynomial8(coeffs)
+    value, slope, bend = poly.evaluate_with_derivatives(0.5)
+    assert value == pytest.approx(3.921875, abs=1e-12)
+    assert slope == pytest.approx(14.5625, abs=1e-12)
+    assert bend == pytest.approx(71.625, abs=1e-12)
+
+def test_polynomial_quadratic_roots():
+    poly = multicalc_py.Polynomial3([2.0, -3.0, 1.0])
+    roots = poly.real_roots()
+    assert len(roots) == 2
+    assert roots[0] == pytest.approx(1.0, abs=1e-12)
+    assert roots[1] == pytest.approx(2.0, abs=1e-12)
+
+def test_so3_rotation():
+    half_pi = math.pi / 2.0
+    rot = multicalc_py.SO3.exp([0.0, 0.0, half_pi])
+    point = rot.act([1.0, 0.0, 0.0])
+    assert point[0] == pytest.approx(0.0, abs=1e-12)
+    assert point[1] == pytest.approx(1.0, abs=1e-12)
+    assert point[2] == pytest.approx(0.0, abs=1e-12)

--- a/crates/multicalc-py/tests/test_spatial.py
+++ b/crates/multicalc-py/tests/test_spatial.py
@@ -1,0 +1,32 @@
+import math
+
+import pytest
+
+import multicalc_py
+
+def test_so2_act():
+    point = multicalc_py.SO2.exp(math.pi / 2.0).act([1.0, 0.0])
+    assert point[0] == pytest.approx(0.0, abs=1e-12)
+    assert point[1] == pytest.approx(1.0, abs=1e-12)
+
+def test_se2_identity():
+    assert multicalc_py.SE2.identity().act([1.0, 2.0]) == pytest.approx([1.0, 2.0])
+
+def test_quaternion_identity():
+    point = multicalc_py.Quaternion.identity().transform_point([1.0, 0.0, 0.0])
+    assert point == pytest.approx([1.0, 0.0, 0.0])
+
+def test_spatial_inertia_and_error():
+    body = multicalc_py.SpatialInertia.from_diagonal_inertia(
+        2.0, [0.0, 0.0, 0.0], [1.0, 2.0, 3.0]
+    )
+    assert body.mass() == 2.0
+    with pytest.raises(multicalc_py.SpatialError):
+        multicalc_py.SpatialInertia.from_diagonal_inertia(
+            0.0, [0.0, 0.0, 0.0], [1.0, 2.0, 3.0]
+        )
+
+def test_free_joint_identity():
+    state = multicalc_py.FreeJointState.identity()
+    assert state.velocity().as_array() == pytest.approx([0.0] * 6)
+    

--- a/deny.toml
+++ b/deny.toml
@@ -1,9 +1,9 @@
 # Supply-chain checks for cargo-deny.
 
 [graph]
-# multicalc-demos is a host-only, unpublished visualization satellite; its heavy Rerun tree is not
-# part of the shipped or bare-metal graph, so it is excluded from the supply-chain audit.
-exclude = ["multicalc-demos"]
+# Host-only unpublished satellites excluded from the supply-chain audit:
+# multicalc-demos (heavy Rerun tree) and multicalc-py (PyO3 host bindings).
+exclude = ["multicalc-demos", "multicalc-py"]
 
 [advisories]
 # Fail on known security advisories and yanked crates.


### PR DESCRIPTION
Closes #48 

Expose a slice of crate-root multicalc over PyO3/maturin as import multicalc_py. Host f64 only; const-generic sizes are fixed in the type name. Workspace-internal (publish = false), with pytest coverage and crate/type docs.

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [x] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
