### PR TITLE
Write down the conventions the #333 review turned up

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,12 +35,18 @@ locally anyway, the setup lives in [ci/README.md](ci/README.md) (optional).
 
 - **No panics on library paths** — fallible ops return typed per-module errors (`LinalgError`,
   `DiffError`, `IntegrateError`, `SolveError`), never `unwrap`. Clippy enforces this.
+- **Fallible functions take a `try_` prefix** — `try_row`, `try_from_slice` — `Option` or
+  `Result` alike.
+- **A `Mut` type mirrors its read-only twin**, plus what writing adds; document any gap.
 - **Stay generic over the scalar** — inside generic code, never call an `f64`-only
   function (it silently drops the autodiff payload). Use the `Numeric` trait surface.
+- **Descriptive names** — variables and other names need to be as clear as possible: `matrix`,
+  not `m`.
 - **Tests**: f64 assertions may use golden values; f32 correctness is asserted via
   mathematical identities (e.g. reconstruction, round-trips), not goldens.
-- **Docs**: public APIs get a doc example; behavior notes (NaN policy, iteration
-  budgets) live on the item.
+- **Docs**: public APIs get a doc example — one or two sentences, then the example. Don't name a
+  method that doesn't exist. Behavior notes (NaN policy, iteration budgets) live on the item, and
+  new API earns a line on its [tutorial page](crates/multicalc/tutorials/), compiled as a doctest.
 
 ## Where does a check go?
 


### PR DESCRIPTION
Requested by @kmolan in #333. That review surfaced rules a contributor can currently only learn by being reviewed, so they go in the list that already holds this kind of thing.

Three added -- the `try_` prefix for fallible functions, keeping a `Mut` type in step with its read-only twin, and descriptive names -- and the docs bullet picks up how long an example's prose should be, that it must not name methods that do not exist, and that new API earns a line on its tutorial page.

Docs only, so no CHANGELOG entry.

## What & why

<!-- one paragraph; link the issue -->

## Checklist
- [ ] `cargo test` + `cargo clippy --all-targets` clean locally
- [ ] New public APIs have a doc example
- [ ] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)
