### PR TITLE
I fixed line_integral_partial_* panicking on an out-of-range index.

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -3,4 +3,4 @@ allow-unwrap-in-tests = true
 allow-expect-in-tests = true
 allow-panic-in-tests = true
 min-ident-chars-threshold = 2
-allowed-idents-below-min-chars = ["i", "j", "k", "n", "x", "y", "z", "w", "h", "f", "a", "b", "dx"]
+allowed-idents-below-min-chars = ["i", "j", "k", "n", "t", "x", "y", "z", "w", "h", "f", "a", "b", "dx"]

--- a/crates/multicalc/src/vector_field/line_integral.rs
+++ b/crates/multicalc/src/vector_field/line_integral.rs
@@ -26,6 +26,8 @@ fn get_partial<T: Numeric, const N: usize>(
 ) -> Result<T, IntegrateError> {
     if total_iterations == 0 {
         return Err(IntegrateError::IterationsZero);
+    } else if idx >= N {
+        return Err(IntegrateError::IndexOutOfRange);
     }
     // rejects NaN, equal, and reversed limits (partial_cmp is None for NaN)
     if !matches!(
@@ -136,6 +138,7 @@ pub fn line_integral_2d_custom<T: Numeric>(
 /// [`IntegrateError::IterationsZero`] if `total_iterations` is zero, or
 /// [`IntegrateError::LimitsIllDefined`] if the lower limit is not strictly less than the
 /// upper limit.
+/// [`IntegrateError::IndexOutOfRange`] if `idx` is greater than or equal to 2.
 pub fn line_integral_partial_2d<T: Numeric>(
     vector_field: &[&dyn Fn(&[T; 2]) -> T; 2],
     transformations: &[&dyn Fn(T) -> T; 2],
@@ -211,6 +214,7 @@ pub fn line_integral_3d_custom<T: Numeric>(
 /// [`IntegrateError::IterationsZero`] if `total_iterations` is zero, or
 /// [`IntegrateError::LimitsIllDefined`] if the lower limit is not strictly less than the
 /// upper limit.
+/// [`IntegrateError::IndexOutOfRange`] if `idx` is greater than or equal to 3.
 pub fn line_integral_partial_3d<T: Numeric>(
     vector_field: &[&dyn Fn(&[T; 3]) -> T; 3],
     transformations: &[&dyn Fn(T) -> T; 3],

--- a/crates/multicalc/tests/suite/vector_field.rs
+++ b/crates/multicalc/tests/suite/vector_field.rs
@@ -7,6 +7,7 @@ use multicalc::scalar_fn_vec;
 use multicalc::vector_field::{
     curl_2d, curl_3d, divergence_2d, divergence_3d, flux_integral_2d_custom,
     flux_integral_3d_custom, line_integral_2d_custom, line_integral_3d_custom,
+    line_integral_partial_2d, line_integral_partial_3d,
 };
 
 use multicalc::error::IntegrateError;
@@ -267,6 +268,134 @@ fn line_integral_accepts_a_negative_lower_limit() {
 
     let expected = -3.0;
     assert!(f64::abs(circulation - expected) < 1e-9);
+}
+
+#[test]
+fn line_integral_partial_2d_rejects_invalid_index() {
+    use std::f64::consts::TAU;
+
+    //vector field is (y, -x).
+    let field_x = |point: &[f64; 2]| point[1]; // P(x, y) = y
+    let field_y = |point: &[f64; 2]| -point[0]; // Q(x, y) = -x
+
+    let vector_field: [&dyn Fn(&[f64; 2]) -> f64; 2] = [&field_x, &field_y];
+
+    // r(t) = (cos(t), sin(t))
+    let x_of_t = |t: f64| t.cos(); // x(t) = cos(t)
+    let y_of_t = |t: f64| t.sin(); // y(t) = sin(t)
+
+    let transformations: [&dyn Fn(f64) -> f64; 2] = [&x_of_t, &y_of_t];
+
+    let integration_limit = [0.0, TAU];
+    let total_iterations = 10_000;
+    let idx = 2;
+
+    let result = line_integral_partial_2d(
+        &vector_field,
+        &transformations,
+        &integration_limit,
+        total_iterations,
+        idx,
+    );
+    assert!(result.unwrap_err() == IntegrateError::IndexOutOfRange);
+}
+
+#[test]
+fn line_integral_partial_2d_accepts_valid_index() {
+    use std::f64::consts::{PI, TAU};
+
+    //vector field is (y, -x).
+    let field_x = |point: &[f64; 2]| point[1]; // P(x, y) = y
+    let field_y = |point: &[f64; 2]| -point[0]; // Q(x, y) = -x
+
+    let vector_field: [&dyn Fn(&[f64; 2]) -> f64; 2] = [&field_x, &field_y];
+
+    // r(t) = (cos(t), sin(t))
+    let x_of_t = |t: f64| t.cos(); // x(t) = cos(t)
+    let y_of_t = |t: f64| t.sin(); // y(t) = sin(t)
+
+    let transformations: [&dyn Fn(f64) -> f64; 2] = [&x_of_t, &y_of_t];
+
+    let integration_limit = [0.0, TAU];
+    let total_iterations = 10_000;
+    let idx = 1;
+
+    let result = line_integral_partial_2d(
+        &vector_field,
+        &transformations,
+        &integration_limit,
+        total_iterations,
+        idx,
+    );
+
+    let expected = -PI;
+    assert!(f64::abs(result.unwrap() - expected) < 1e-6); // -PI - (-PI) == -PI + PI == 0
+}
+
+#[test]
+fn line_integral_partial_3d_accepts_valid_index() {
+    use std::f64::consts::TAU;
+
+    //vector field is (y, -x, 2z).
+    let field_x = |point: &[f64; 3]| point[1]; // P(x, y) = y
+    let field_y = |point: &[f64; 3]| -point[0]; // Q(x, y) = -x
+    let field_z = |point: &[f64; 3]| 2.0 * point[0]; // R(x, y) = 2z
+
+    let vector_field: [&dyn Fn(&[f64; 3]) -> f64; 3] = [&field_x, &field_y, &field_z];
+
+    // r(t) = (cos(t), sin(t), 0.0)
+    let x_of_t = |t: f64| t.cos(); // x(t) = cos(t)
+    let y_of_t = |t: f64| t.sin(); // y(t) = sin(t)
+    let z_of_t = |_: f64| 0.0; // z(t) = 0.0
+
+    let transformations: [&dyn Fn(f64) -> f64; 3] = [&x_of_t, &y_of_t, &z_of_t];
+
+    let integration_limit = [0.0, TAU];
+    let total_iterations = 10_000;
+    let idx = 2;
+
+    let result = line_integral_partial_3d(
+        &vector_field,
+        &transformations,
+        &integration_limit,
+        total_iterations,
+        idx,
+    );
+
+    let expected = 0.0;
+    assert!(f64::abs(result.unwrap() - expected) < 1e-9);
+}
+
+#[test]
+fn line_integral_partial_3d_rejects_invalid_index() {
+    use std::f64::consts::TAU;
+
+    //vector field is (y, -x, 2z).
+    let field_x = |point: &[f64; 3]| point[1]; // P(x, y) = y
+    let field_y = |point: &[f64; 3]| -point[0]; // Q(x, y) = -x
+    let field_z = |point: &[f64; 3]| 2.0 * point[0]; // R(x, y) = 2z
+
+    let vector_field: [&dyn Fn(&[f64; 3]) -> f64; 3] = [&field_x, &field_y, &field_z];
+
+    // r(t) = (cos(t), sin(t), 0.0)
+    let x_of_t = |t: f64| t.cos(); // x(t) = cos(t)
+    let y_of_t = |t: f64| t.sin(); // y(t) = sin(t)
+    let z_of_t = |_: f64| 0.0; // z(t) = 0.0
+
+    let transformations: [&dyn Fn(f64) -> f64; 3] = [&x_of_t, &y_of_t, &z_of_t];
+
+    let integration_limit = [0.0, TAU];
+    let total_iterations = 10_000;
+    let idx = 3;
+
+    let result = line_integral_partial_3d(
+        &vector_field,
+        &transformations,
+        &integration_limit,
+        total_iterations,
+        idx,
+    );
+    assert!(result.unwrap_err() == IntegrateError::IndexOutOfRange);
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes issue [309](https://github.com/kmolan/multicalc-rust/issues/309).

`get_partial()` indexed vector_field/transformations with `idx` before bounds-checking it. Incorrect indices previously led to panics. It now returns `IntegrateError::IndexOutOfRange` when `idx >= N`.

I also added an allowed short identifier (`t`) to clippy.toml and added four tests for the line_integral test suite.

This is my first PR to an external project, so please let me know if I need to fix anything! Also, as an disclaimer, I used Claude to verify whether my fixes were correct and if I correctly followed `CONTRIBUTING.md`.