### PR TITLE
Fix gaps in large occupy_circle rims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Large-circle occupancy rims.** `occupy_circle` now derives its sample count from a maximum
+  arc length relative to grid resolution, replacing its fixed minimum angular step so large rims
+  remain closed to ray casts. Non-finite radii now leave the map unchanged. (#296)
+
 - **Finite-difference step scaling and validation.** Default steps now follow the scalar type's
   machine epsilon and the chosen stencil, improving `f32` accuracy. Negative and non-finite steps
   are rejected instead of reversing the stencil or returning NaN.

--- a/crates/multicalc/src/mapping/occupancy_grid.rs
+++ b/crates/multicalc/src/mapping/occupancy_grid.rs
@@ -343,7 +343,8 @@ pub trait MutableOccupancyMap<T: Numeric + Primal = f64>: OccupancyMap<T> {
     ///
     /// The rim is walked in steps small enough that consecutive points land in the same cell or the
     /// next one, so it closes on itself with no gap. A radius smaller than a cell marks one cell or
-    /// a handful.
+    /// a handful. A non-finite radius leaves the map unchanged. Sampling work grows in proportion
+    /// to the circumference measured in cells.
     ///
     /// ```
     /// # use multicalc::mapping::{MutableOccupancyMap, OccupancyMap};
@@ -386,14 +387,22 @@ pub trait MutableOccupancyMap<T: Numeric + Primal = f64>: OccupancyMap<T> {
     /// }
     /// ```
     fn occupy_circle(&mut self, center: [T; 2], radius: T) {
-        let step = (T::from_f64(0.4) * self.resolution() / radius).max(T::from_f64(1e-3));
-        let mut angle = T::ZERO;
-        while angle < T::TWO_PI {
+        if !radius.is_finite() {
+            return;
+        }
+        let radius_in_cells = radius.abs() / self.resolution();
+        // Keep a zero-radius circle drawable and the angular step well-defined.
+        let samples = (T::TWO_PI * radius_in_cells / T::from_f64(0.4))
+            .ceil()
+            .max(T::ONE)
+            .to_f64() as usize;
+        let angular_step = T::TWO_PI / T::from_usize(samples);
+        for sample in 0..samples {
+            let angle = T::from_usize(sample) * angular_step;
             self.occupy_point([
                 center[0] + radius * angle.cos(),
                 center[1] + radius * angle.sin(),
             ]);
-            angle += step;
         }
     }
 }

--- a/crates/multicalc/tests/suite/mapping/occupancy_map.rs
+++ b/crates/multicalc/tests/suite/mapping/occupancy_map.rs
@@ -232,6 +232,44 @@ fn a_circle_marks_its_rim_and_not_its_middle() {
 }
 
 #[test]
+fn a_large_circle_blocks_beams_through_its_east_rim() {
+    let resolution = 1.0;
+    let radius = 2_000.0;
+    let centre = [0.5, 0.5];
+    // Keep the test map small by placing a window near the circle's eastern rim in world
+    // coordinates. Rasterization and ray casting still exercise the large-circle geometry
+    // without allocating a map large enough to contain the whole circle.
+    let mut map: TestMap<10, 32> = TestMap::new(resolution, [1_996.0, -2.0]);
+
+    map.occupy_circle(centre, radius);
+
+    const BEARING_DIVISIONS: usize = 8_192;
+    for beam in 0..16 {
+        // Offset from angle zero, which is also the circle rasterizer's first sample, so these
+        // rays probe the gaps between sampled rim points rather than that convenient sample.
+        let bearing = core::f64::consts::TAU * (beam as f64 + 0.5) / BEARING_DIVISIONS as f64;
+        let distance = map.cast_ray(centre, bearing, radius + 2.0);
+        assert!(
+            distance.is_some_and(|met| (met - radius).abs() <= 2.0 * map.resolution()),
+            "beam {beam} read {distance:?} instead of about {radius}"
+        );
+    }
+}
+
+#[test]
+fn a_non_finite_circle_radius_leaves_the_map_unchanged() {
+    let mut map: TestMap<40, 40> = TestMap::new(0.1, [0.0, 0.0]);
+    for radius in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        map.occupy_circle([2.0, 2.0], radius);
+    }
+    for row in 0..40 {
+        for column in 0..40 {
+            assert!(!map.is_occupied(row, column));
+        }
+    }
+}
+
+#[test]
 fn clearing_frees_every_cell() {
     let mut map: TestMap<40, 40> = TestMap::new(0.1, [0.0, 0.0]);
     map.occupy_circle([2.0, 2.0], 1.0);


### PR DESCRIPTION
## What & why

Fixes #296. `occupy_circle` previously imposed a minimum angular step of `1e-3` radians, causing samples on circles larger than roughly 400 cells in radius to land more than one cell apart and leave gaps that ray casts could pass through. This change derives an evenly spaced sample count from the circumference in cells, keeping the arc between samples at most 0.4 cell widths regardless of radius. Non-finite radii now leave the map unchanged. The regression test casts offset rays through a compact window over a rim with a 2,000-cell radius, avoiding the stack cost of storing a full circle sized map. `occupy_circle` still samples the full circumference, while the map stores and checks only the rim segment under test. A second test verifies the non-finite-radius behavior.


## Checklist

- [x] `cargo test` and `cargo clippy --all-targets` pass locally
- [x] No new public APIs; the existing `occupy_circle` documentation describes the behavior
- [x] No `unwrap`, `expect`, or `panic` added on library paths