### PR TITLE
Normalize root-counting chain entries to survive f32 at high degree

### DIFF
--- a/crates/multicalc/src/polynomial/roots.rs
+++ b/crates/multicalc/src/polynomial/roots.rs
@@ -452,12 +452,26 @@ impl<const COEFFICIENT_COUNT: usize, T: Numeric> Polynomial<COEFFICIENT_COUNT, T
             // turned around.
             let previous = chain.get(length - 2).copied().unwrap_or_default();
             let current = chain.get(length - 1).copied().unwrap_or_default();
-            let Some(next) = remainder(&previous, &current) else {
+            let Some(mut next) = remainder(&previous, &current) else {
                 break;
             };
             // Nothing left over means the chain is finished.
             if next.is_zero() {
                 break;
+            }
+            // With no rescaling the coefficients grow or shrink geometrically down the chain,
+            // overflowing to infinity in f32 (and underflowing to zero in both precisions) by
+            // around degree ten. Only the signs are ever read back out of the chain, so
+            // renormalizing each entry to unit max-norm as it is built removes the failure without
+            // changing a single sign.
+            let max_norm = next
+                .coefficients()
+                .iter()
+                .fold(T::ZERO, |largest, coefficient| {
+                    largest.max(coefficient.abs())
+                });
+            if max_norm.is_finite() && max_norm != T::ZERO {
+                next = next / max_norm;
             }
             if let Some(slot) = chain.get_mut(length) {
                 *slot = -next;

--- a/crates/multicalc/tests/suite/polynomial/roots.rs
+++ b/crates/multicalc/tests/suite/polynomial/roots.rs
@@ -341,7 +341,7 @@ fn real_roots_in_rejects_bad_arguments() {
             .unwrap()
             .len(),
         4
-);
+        );
 }
 
 fn assert_counts_a_degree_twelve_polynomial<T: Numeric>() {

--- a/crates/multicalc/tests/suite/polynomial/roots.rs
+++ b/crates/multicalc/tests/suite/polynomial/roots.rs
@@ -341,7 +341,7 @@ fn real_roots_in_rejects_bad_arguments() {
             .unwrap()
             .len(),
         4
-        );
+            );
 }
 
 fn assert_counts_a_degree_twelve_polynomial<T: Numeric>() {

--- a/crates/multicalc/tests/suite/polynomial/roots.rs
+++ b/crates/multicalc/tests/suite/polynomial/roots.rs
@@ -3,13 +3,34 @@
 
 use multicalc::error::PolynomialError;
 use multicalc::polynomial::Polynomial;
-use multicalc::scalar::Dual;
+use multicalc::scalar::{Dual, Numeric};
 
 /// x(x - 1)(x - 2)(x - 4), whose roots are 0, 1, 2 and 4.
 const QUARTIC_FOUR_ROOTS: [f64; 5] = [0.0, -8.0, 14.0, -7.0, 1.0];
 
 /// (x - 2)²(x + 1), which has a doubled root at 2 and a single one at -1.
 const CUBIC_REPEATED: [f64; 4] = [4.0, 0.0, -3.0, 1.0];
+/// A degree-12 polynomial with twelve distinct real roots: -50, -30, -30.0001, -20, -10,
+/// -10.0001, 10, 10.0001, 20, 30, 30.0001 and 50. Four of them sit in close pairs 0.0001 apart, so
+/// the root-counting chain built from this polynomial needs several divisions between nearly
+/// proportional polynomials, which is exactly where an unnormalized chain's coefficients drift
+/// hardest. In `f32` that drift used to run entries out of range partway through the chain,
+/// silently miscounting the roots.
+const DEGREE_TWELVE_CLOSE_PAIRS: [f64; 13] = [
+    8_099_999_999_100_000.0,
+    17_999_999_999.64,
+    -203_489_999_981_990.0,
+    -288_199_999.994_956,
+    1_710_099_999_884.44,
+    1_302_399.999_984_04,
+    -5_601_999_999.721_6,
+    -2_375.999_999_984_4,
+    7_979_999.999_756,
+    1.759_999_999_996,
+    -4_899.999_999_94,
+    -0.0004,
+    1.0,
+];
 
 fn assert_close(found: &[f64], expected: &[f64], tolerance: f64) {
     assert_eq!(found.len(), expected.len());
@@ -320,5 +341,27 @@ fn real_roots_in_rejects_bad_arguments() {
             .unwrap()
             .len(),
         4
+);
+}
+
+fn assert_counts_a_degree_twelve_polynomial<T: Numeric>() {
+    let coefficients = DEGREE_TWELVE_CLOSE_PAIRS.map(T::from_f64);
+    let poly: Polynomial<13, T> = Polynomial::new(coefficients);
+    let bound = T::from_f64(60.0);
+
+    assert_eq!(
+        poly.count_real_roots(-bound, bound).unwrap(),
+        12,
+        "the root-counting chain should not lose roots to overflow or underflow by this degree"
     );
+}
+
+#[test]
+fn count_real_roots_survives_high_degree_f32() {
+    assert_counts_a_degree_twelve_polynomial::<f32>();
+}
+
+#[test]
+fn count_real_roots_survives_high_degree_f64() {
+    assert_counts_a_degree_twelve_polynomial::<f64>();
 }

--- a/crates/multicalc/tests/suite/polynomial/roots.rs
+++ b/crates/multicalc/tests/suite/polynomial/roots.rs
@@ -341,7 +341,7 @@ fn real_roots_in_rejects_bad_arguments() {
             .unwrap()
             .len(),
         4
-            );
+    );
 }
 
 fn assert_counts_a_degree_twelve_polynomial<T: Numeric>() {


### PR DESCRIPTION
## What & why

Fixes #295. `root_counting_chain` built up each new Sturm-sequence entry from raw pseudo-division remainders with no rescaling, so the coefficient magnitudes could drift geometrically down the chain. For a degree-12 polynomial with two close pairs of roots (0.0001 apart), that drift ran an `f32` chain entry to exact zero partway through, and `count_real_roots` returned 8 instead of 12 -- the same failure mode described in the issue.

The fix renormalizes each new chain entry to unit max-norm (divide every coefficient by the largest absolute coefficient) right after it is built. `sign_changes` is the only thing that reads the chain back out, and dividing by a positive scalar never changes a sign, so this is a no-op for correctness on every case that already worked -- it only prevents the coefficients from running out of range.

Added `count_real_roots_survives_high_degree_f32`/`_f64`, which build the degree-12 polynomial described above and assert the count is 12 at both `f32` and `f64`. The `f32` variant fails on `main` (finds 8) and passes with this change; the `f64` variant passes either way, since `f64` has enough range that this particular case doesn't run out of it

## Checklist
- [x] `cargo test` + `cargo clippy --all-targets` clean locally
- [ ] New public APIs have a doc example
- [x] No `unwrap`/`expect`/`panic` on library paths (typed errors instead)