### PR TITLE
Cap the tilt thrust_command_from_acceleration asks for

### DIFF
--- a/crates/multicalc/src/control/mod.rs
+++ b/crates/multicalc/src/control/mod.rs
@@ -5,6 +5,8 @@
 //! - [`GeometricAttitudeController`] — attitude control on rotations, for a rigid body.
 //! - [`thrust_command_from_acceleration`] — the attitude and thrust realizing a desired
 //!   acceleration; what joins a position loop to an attitude loop.
+//! - [`thrust_command_from_acceleration_with_tilt_limit`] — the same, with the tilt capped so a
+//!   large lateral request cannot tip the body past where its thrust still holds it up.
 //! - [`OnePoleLowPass`] — the filter on the PID's derivative term, re-exported from
 //!   [`signal_processing`](crate::signal_processing).
 //! - [`pure_pursuit_curvature`] — the pure-pursuit path-following law (takes a lookahead point).
@@ -47,4 +49,7 @@ pub use lqr::Lqr;
 pub use motion_reference::{CartesianReference, JointReference};
 pub use pid::Pid;
 pub use pure_pursuit::{Curvature, pure_pursuit_curvature};
-pub use thrust_command::{ThrustCommand, thrust_command_from_acceleration};
+pub use thrust_command::{
+    ThrustCommand, thrust_command_from_acceleration,
+    thrust_command_from_acceleration_with_tilt_limit,
+};

--- a/crates/multicalc/src/control/thrust_command.rs
+++ b/crates/multicalc/src/control/thrust_command.rs
@@ -17,6 +17,7 @@ use crate::spatial::SO3;
 pub struct ThrustCommand<T: Numeric = f64> {
     attitude: SO3<T>,
     thrust_acceleration: T,
+    tilt_bound: bool,
 }
 
 impl<T: Numeric> ThrustCommand<T> {
@@ -39,6 +40,19 @@ impl<T: Numeric> ThrustCommand<T> {
     #[must_use]
     pub fn thrust_force(&self, mass: T) -> T {
         self.thrust_acceleration * mass
+    }
+
+    /// `true` when the attitude asks for less tilt than the wanted acceleration would otherwise
+    /// need, because
+    /// [`thrust_command_from_acceleration_with_tilt_limit`] capped it at its `max_tilt` and scaled
+    /// the sideways part of the push down to fit, keeping the vertical part unchanged.
+    ///
+    /// A command built by [`thrust_command_from_acceleration`], which has no tilt limit to hit, is
+    /// never bound.
+    #[inline]
+    #[must_use]
+    pub fn tilt_bound(&self) -> bool {
+        self.tilt_bound
     }
 }
 
@@ -96,6 +110,108 @@ pub fn thrust_command_from_acceleration<T: Numeric>(
     // Gravity pulls the body down the whole time, so the rotors cover that as well as whatever
     // acceleration is being asked for.
     let push = acceleration_command + Vector::new([T::ZERO, T::ZERO, gravity]);
+    thrust_command_from_push(push, desired_heading, false)
+}
+
+/// Works out how to point a flying body, and how hard to push, to get a wanted acceleration —
+/// the same as [`thrust_command_from_acceleration`], but with the tilt capped.
+///
+/// A position loop with a distant setpoint, or one that has wound up, can ask for a lateral
+/// acceleration large enough to tip the body past where its vertical thrust still holds it up, so
+/// it descends while accelerating sideways instead of climbing or holding height. `max_tilt` caps
+/// how far from level the attitude is allowed to lean, as an angle in `(0, π/2)` radians measured
+/// from the world's +z axis. When the wanted acceleration would tip the body past that, the
+/// sideways part of the push is scaled down to fit the cap while the vertical part — and so the
+/// climb or descent it commands — is left exactly as it was; [`ThrustCommand::tilt_bound`] then
+/// reports `true`. A wanted acceleration already inside the cap comes back unchanged, same as
+/// [`thrust_command_from_acceleration`] would give it, with [`ThrustCommand::tilt_bound`]
+/// reporting `false`.
+///
+/// Returns [`ControlError::NonFinite`] if any argument, including `max_tilt`, is not finite,
+/// [`ControlError::InvalidTiltLimit`] if `max_tilt` is not strictly positive or reaches a quarter
+/// turn (π/2) or beyond, [`ControlError::UndefinedThrustDirection`] if the wanted acceleration
+/// cancels gravity exactly, leaving no direction to push in, or
+/// [`ControlError::UndefinedHeadingDirection`] if the push would be straight along the wanted
+/// heading, which leaves the heading with nothing to set it by.
+///
+/// ```
+/// use multicalc::control::thrust_command_from_acceleration_with_tilt_limit;
+/// use multicalc::linear_algebra::Vector;
+///
+/// let gravity = 9.81_f64;
+/// let facing_along_x = 0.0;
+/// let max_tilt = 0.5; // a bit under a third of a turn
+///
+/// // A modest sideways request stays inside the cap and comes back unbound.
+/// let modest = thrust_command_from_acceleration_with_tilt_limit(
+///     Vector::new([1.0, 0.0, 0.0]),
+///     facing_along_x,
+///     gravity,
+///     max_tilt,
+/// )
+/// .unwrap();
+/// assert!(!modest.tilt_bound());
+///
+/// // A far larger sideways request is capped at max_tilt, and says so.
+/// let huge = thrust_command_from_acceleration_with_tilt_limit(
+///     Vector::new([50.0, 0.0, 0.0]),
+///     facing_along_x,
+///     gravity,
+///     max_tilt,
+/// )
+/// .unwrap();
+/// assert!(huge.tilt_bound());
+/// let up_axis = huge.attitude().act(Vector::new([0.0, 0.0, 1.0]));
+/// assert!((up_axis[2].acos() - max_tilt).abs() < 1e-9);
+///
+/// // The vertical part of the push — what holds the body up — is left untouched by the cap.
+/// assert!((huge.thrust_acceleration() * up_axis[2] - gravity).abs() < 1e-9);
+/// ```
+pub fn thrust_command_from_acceleration_with_tilt_limit<T: Numeric>(
+    acceleration_command: Vector3D<T>,
+    desired_heading: T,
+    gravity: T,
+    max_tilt: T,
+) -> Result<ThrustCommand<T>, ControlError> {
+    if !acceleration_command.is_finite()
+        || !desired_heading.is_finite()
+        || !gravity.is_finite()
+        || !max_tilt.is_finite()
+    {
+        return Err(ControlError::NonFinite);
+    }
+    let quarter_turn = T::PI * T::HALF;
+    if max_tilt <= T::ZERO || max_tilt >= quarter_turn {
+        return Err(ControlError::InvalidTiltLimit);
+    }
+
+    let push = acceleration_command + Vector::new([T::ZERO, T::ZERO, gravity]);
+    let vertical = push[2];
+    let horizontal = Vector::new([push[0], push[1], T::ZERO]).norm();
+
+    // Only a push that still points somewhat upward has a tilt worth capping this way: leaning the
+    // body over trades vertical thrust for horizontal, so past level there is no vertical part left
+    // to hold the cap against.
+    let mut tilt_bound = false;
+    let push = if vertical > T::ZERO && horizontal.atan2(vertical) > max_tilt {
+        tilt_bound = true;
+        let horizontal_limit = vertical * max_tilt.tan();
+        let scale = horizontal_limit / horizontal;
+        Vector::new([push[0] * scale, push[1] * scale, vertical])
+    } else {
+        push
+    };
+
+    thrust_command_from_push(push, desired_heading, tilt_bound)
+}
+
+/// Shared tail of both entry points: turns an already-settled push (gravity accounted for, and
+/// tilt-capped if that was asked for) into the attitude and thrust that produce it.
+fn thrust_command_from_push<T: Numeric>(
+    push: Vector3D<T>,
+    desired_heading: T,
+    tilt_bound: bool,
+) -> Result<ThrustCommand<T>, ControlError> {
     let thrust_acceleration = push.norm();
     let up_axis = push
         .try_normalized()
@@ -123,5 +239,6 @@ pub fn thrust_command_from_acceleration<T: Numeric>(
     Ok(ThrustCommand {
         attitude,
         thrust_acceleration,
+        tilt_bound,
     })
 }

--- a/crates/multicalc/src/error.rs
+++ b/crates/multicalc/src/error.rs
@@ -241,6 +241,8 @@ pub enum ControlError {
     UndefinedThrustDirection,
     /// The push would be straight along the wanted heading, so the heading cannot be set.
     UndefinedHeadingDirection,
+    /// A maximum tilt was not strictly positive, or reached a quarter turn (π/2) or beyond.
+    InvalidTiltLimit,
     /// A matrix step inside a controller's setup failed.
     Linalg(LinalgError),
     /// A filter setup error.
@@ -874,6 +876,9 @@ impl core::fmt::Display for ControlError {
             }
             ControlError::UndefinedHeadingDirection => {
                 "the push is straight along the wanted heading, so the heading cannot be set"
+            }
+            ControlError::InvalidTiltLimit => {
+                "maximum tilt must be strictly positive and less than a quarter turn (π/2)"
             }
             ControlError::NegativeGain => "stiffness, damping and posture gains must not be negative",
             ControlError::Linalg(err) => return write!(f, "{err}"),

--- a/crates/multicalc/src/lib.rs
+++ b/crates/multicalc/src/lib.rs
@@ -167,7 +167,7 @@ pub use control::{
     CartesianImpedanceController, CartesianReference, ComputedTorqueController, Curvature,
     FollowTheGap, FollowTheGapOutput, GeometricAttitudeController, JointImpedanceController,
     JointPdController, JointReference, Lqr, Pid, ThrustCommand, pure_pursuit_curvature,
-    thrust_command_from_acceleration,
+    thrust_command_from_acceleration, thrust_command_from_acceleration_with_tilt_limit,
 };
 
 /// Waypoint paths, planned trajectories, point-to-point motion profiles, and their arc-length,

--- a/crates/multicalc/tests/suite/control/thrust_command.rs
+++ b/crates/multicalc/tests/suite/control/thrust_command.rs
@@ -2,7 +2,10 @@
 //! turning the body about its push, the two directions that cannot be worked out, and a hand-off
 //! to the attitude controller.
 
-use multicalc::control::{GeometricAttitudeController, thrust_command_from_acceleration};
+use multicalc::control::{
+    GeometricAttitudeController, thrust_command_from_acceleration,
+    thrust_command_from_acceleration_with_tilt_limit,
+};
 use multicalc::error::ControlError;
 use multicalc::linear_algebra::{Matrix, Vector};
 use multicalc::scalar::Numeric;
@@ -143,4 +146,108 @@ fn works_at_f32() {
         assert!((command.thrust_acceleration() - push.norm()).abs() < tolerance);
     }
     check(1e-5_f32);
+}
+
+#[test]
+fn modest_request_is_unchanged_by_the_tilt_limit() {
+    let acceleration_command = Vector::new([1.5, -2.5, 0.75]);
+    let heading = 0.4;
+    let generous_limit = 1.3; // well past what this request needs
+    let capped = thrust_command_from_acceleration_with_tilt_limit(
+        acceleration_command,
+        heading,
+        GRAVITY,
+        generous_limit,
+    )
+    .unwrap();
+    let uncapped =
+        thrust_command_from_acceleration(acceleration_command, heading, GRAVITY).unwrap();
+
+    assert!(!capped.tilt_bound());
+    assert_eq!(capped.attitude(), uncapped.attitude());
+    assert!((capped.thrust_acceleration() - uncapped.thrust_acceleration()).abs() < 1e-12);
+}
+
+#[test]
+fn large_lateral_request_is_capped_at_the_limit_with_vertical_preserved() {
+    let max_tilt = 0.5;
+    let command = thrust_command_from_acceleration_with_tilt_limit(
+        Vector::new([50.0, 0.0, 0.0]),
+        0.0,
+        GRAVITY,
+        max_tilt,
+    )
+    .unwrap();
+
+    assert!(command.tilt_bound());
+    let up_axis = command.attitude().act(Vector::new([0.0, 0.0, 1.0]));
+    // The attitude sits right at the cap...
+    assert!((up_axis[2].acos() - max_tilt).abs() < 1e-9);
+    // ...and the vertical part of the push — thrust_acceleration projected onto up — is exactly
+    // what it was before capping: gravity, since the wanted acceleration had no vertical part.
+    assert!((command.thrust_acceleration() * up_axis[2] - GRAVITY).abs() < 1e-9);
+}
+
+#[test]
+fn capping_preserves_the_direction_of_the_lateral_push() {
+    let acceleration_command = Vector::new([40.0, 30.0, 0.0]);
+    let command =
+        thrust_command_from_acceleration_with_tilt_limit(acceleration_command, 0.0, GRAVITY, 0.4)
+            .unwrap();
+
+    assert!(command.tilt_bound());
+    let up_axis = command.attitude().act(Vector::new([0.0, 0.0, 1.0]));
+    // Same azimuth as the uncapped push — scaled down, not turned.
+    assert!((up_axis[0] * 30.0 - up_axis[1] * 40.0).abs() < 1e-9);
+    assert!(up_axis[0] > 0.0 && up_axis[1] > 0.0);
+}
+
+#[test]
+fn tilt_limit_still_reports_undefined_directions() {
+    assert_eq!(
+        thrust_command_from_acceleration_with_tilt_limit(
+            Vector::new([0.0, 0.0, -GRAVITY]),
+            0.0,
+            GRAVITY,
+            0.5
+        )
+        .err(),
+        Some(ControlError::UndefinedThrustDirection)
+    );
+    assert_eq!(
+        thrust_command_from_acceleration_with_tilt_limit(
+            Vector::new([5.0, 0.0, -GRAVITY]),
+            0.0,
+            GRAVITY,
+            0.5
+        )
+        .err(),
+        Some(ControlError::UndefinedHeadingDirection)
+    );
+}
+
+#[test]
+fn rejects_invalid_tilt_limit() {
+    let level = Vector::new([0.0, 0.0, 0.0]);
+    let quarter_turn = core::f64::consts::FRAC_PI_2;
+    for max_tilt in [0.0, -0.2, quarter_turn, quarter_turn + 0.1] {
+        assert_eq!(
+            thrust_command_from_acceleration_with_tilt_limit(level, 0.0, GRAVITY, max_tilt).err(),
+            Some(ControlError::InvalidTiltLimit)
+        );
+    }
+}
+
+#[test]
+fn rejects_non_finite_tilt_limit() {
+    assert_eq!(
+        thrust_command_from_acceleration_with_tilt_limit(
+            Vector::new([0.0, 0.0, 0.0]),
+            0.0,
+            GRAVITY,
+            f64::NAN
+        )
+        .err(),
+        Some(ControlError::NonFinite)
+    );
 }


### PR DESCRIPTION
Fixes #293.

A position loop with a distant setpoint, or one that has wound up, can ask `thrust_command_from_acceleration` for a lateral acceleration large enough to tip the body past where its vertical thrust still holds it up, so it descends while accelerating sideways instead of climbing or holding height.

This adds `thrust_command_from_acceleration_with_tilt_limit`, which behaves the same as `thrust_command_from_acceleration` but caps how far from level the attitude is allowed to lean (an angle in `(0, pi/2)` measured from +z). When the wanted acceleration would tip the body past that cap, the sideways part of the push is scaled down to fit while the vertical part is left exactly as it was, so the requested climb or descent rate is preserved. A new `ThrustCommand::tilt_bound()` accessor reports whether the cap was hit, following the same pattern as `RotorCommands::saturated()` elsewhere in the crate.

Changes:
- `ControlError::InvalidTiltLimit` for a `max_tilt` that isn't strictly positive or reaches/exceeds a quarter turn.
- `thrust_command_from_acceleration_with_tilt_limit` in `control/thrust_command.rs`, with a doctest.
- `ThrustCommand::tilt_bound()` accessor.
- Re-exports in `control/mod.rs` and `lib.rs`.
- Six new tests covering: an unchanged modest request, a large request capped with vertical preserved, direction preservation while capping, undefined-direction errors still surfacing through the new entry point, and rejection of invalid/non-finite tilt limits.

Verified locally: `cargo test -p multicalc`, `cargo test -p multicalc --features alloc`, `cargo test -p multicalc --all-features --doc`, `cargo fmt --all --check`, `cargo clippy -p multicalc --all-targets --features alloc -- -D warnings`, and `cargo doc -p multicalc --no-deps --all-features` all pass.

- [x] `cargo test` + `cargo clippy --all-targets` clean
- [x] `cargo fmt`
- [x] doctests pass (`cargo test --doc`)